### PR TITLE
use version number instead of release in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
release will change over time, but your REQUIRE file says this package supports julia 0.4 so it should continue to be tested