### PR TITLE
Add another lib alias "vulkan-1" and fix depwarns in test

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -8,7 +8,7 @@ using .CEnum
 const version = v"1.0" # Latest branch  see generator.jl for other versions
 
 paths = String[]
-const libvulkan = Libdl.find_library(["libvulkan", "vulkan", "libvulkan.so.1"], paths)
+const libvulkan = Libdl.find_library(["libvulkan", "vulkan", "vulkan-1", "libvulkan.so.1"], paths)
 @assert libvulkan != ""
 
 #### External definitions

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ count = Ref{Cuint}(0)
 # Scan layers
 err = api.vkEnumerateInstanceLayerProperties(count, C_NULL)
 assert(err == api.VK_SUCCESS)
-global_layer_properties = Array(api.VkLayerProperties, count[])
+global_layer_properties = Array{api.VkLayerProperties}(count[])
 err = api.vkEnumerateInstanceLayerProperties(count, global_layer_properties)
 assert(err == api.VK_SUCCESS)
 
@@ -62,7 +62,7 @@ println(instance)
 gpu_count = Ref{Cuint}(0)
 err = api.vkEnumeratePhysicalDevices(instance[], gpu_count, C_NULL)
 println(err)
-devices = Array(api.VkPhysicalDevice, gpu_count[])
+devices = Array{api.VkPhysicalDevice}(gpu_count[])
 
 err = api.vkEnumeratePhysicalDevices(instance[], gpu_count, devices)
 
@@ -110,7 +110,7 @@ println(deviceprops[])
 queue_count = Ref{Cuint}(0)
 
 api.vkGetPhysicalDeviceQueueFamilyProperties(devices[], queue_count, C_NULL)
-queueprops = Array(api.VkQueueFamilyProperties, queue_count[])
+queueprops = Array{api.VkQueueFamilyProperties}(queue_count[])
 println(queue_count[])
 api.vkGetPhysicalDeviceQueueFamilyProperties(devices[], queue_count, queueprops)
 println(queueprops)


### PR DESCRIPTION
This PR fixes the following error:
```
julia> versioninfo()
Julia Version 0.6.1
Commit 0d7248e2ff* (2017-10-24 22:15 UTC)
Platform Info:
  OS: Windows (x86_64-w64-mingw32)
  CPU: Intel(R) Xeon(R) CPU E3-1231 v3 @ 3.40GHz
  WORD_SIZE: 64
  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Haswell)
  LAPACK: libopenblas64_
  LIBM: libopenlibm
  LLVM: libLLVM-3.9.1 (ORCJIT, haswell)

julia> Pkg.test("VulkanCore")    # master
INFO: Testing VulkanCore

WARNING: deprecated syntax "Base.(:|)".
Use "Base.:|" instead.

WARNING: deprecated syntax "Base.(:&)".
Use "Base.:&" instead.
ERROR: LoadError: LoadError: AssertionError: libvulkan != ""
Stacktrace:
 [1] include_from_node1(::String) at .\loading.jl:576
 [2] include(::String) at .\sysimg.jl:14
 [3] include_from_node1(::String) at .\loading.jl:576
 [4] include(::String) at .\sysimg.jl:14
 [5] anonymous at .\<missing>:2
while loading C:\Users\Gnimuc\.julia\v0.6\VulkanCore\src\api.jl, in expression starting on line 12
while loading C:\Users\Gnimuc\.julia\v0.6\VulkanCore\src\VulkanCore.jl, in expression starting on line 5
ERROR: LoadError: Failed to precompile VulkanCore to C:\Users\Gnimuc\.julia\lib\v0.6\VulkanCore.ji.
Stacktrace:
 [1] compilecache(::String) at .\loading.jl:710
 [2] _require(::Symbol) at .\loading.jl:463
 [3] require(::Symbol) at .\loading.jl:405
 [4] include_from_node1(::String) at .\loading.jl:576
 [5] include(::String) at .\sysimg.jl:14
 [6] process_options(::Base.JLOptions) at .\client.jl:305
 [7] _start() at .\client.jl:371
while loading C:\Users\Gnimuc\.julia\v0.6\VulkanCore\test\runtests.jl, in expression starting on line 1
=================================================[ ERROR: VulkanCore ]==================================================

failed process: Process(`'C:\Users\Gnimuc\AppData\Local\Julia-0.6.1\bin\julia.exe' -Cx86-64 '-JC:\Users\Gnimuc\AppData\Local\Julia-0.6.1\lib\julia\sys.dll' --compile=yes --depwarn=yes --check-bounds=yes --code-coverage=none --color=yes --compilecache=yes 'C:\Users\Gnimuc\.julia\v0.6\VulkanCore\test\runtests.jl'`, ProcessExited(1)) [1]

========================================================================================================================
ERROR: VulkanCore had test errors
```
It seems that the lib name has been changed to "Vulkan-1" on Windows.(My Vulkan driver version is 2.0.1 with api version 1.0.65)
