### PR TITLE
Better support for bit masking

### DIFF
--- a/src/CEnum.jl
+++ b/src/CEnum.jl
@@ -1,8 +1,8 @@
 module CEnum
 
 abstract type Cenum{T} end
-Base.:|(a::T, b::T) where {T<:Cenum} = T(Int(a) | Int(b))
-Base.:&(a::T, b::T) where {T<:Cenum} = T(Int(a) & Int(b))
+Base.:|(a::T, b::T) where {T<:Cenum} = UInt32(a) | UInt32(b)
+Base.:&(a::T, b::T) where {T<:Cenum} = UInt32(a) & UInt32(b)
 # typemin and typemax won't change for an enum, so we might as well inline them per type
 function Base.typemax{T<:Cenum}(::Type{T})
     last(enum_values(T))

--- a/src/CEnum.jl
+++ b/src/CEnum.jl
@@ -88,7 +88,7 @@ macro cenum(name, args...)
     expr = quote
         primitive type $typename <: CEnum.Cenum{UInt32} 32 end
         function Base.convert(::Type{$typename}, x::Integer)
-            is_member($typename, x) || Base.enum_argument_error($(Expr(:quote, name)), x)
+            is_member($typename, x) || Base.Enums.enum_argument_error($(Expr(:quote, name)), x)
             Base.bitcast($typename, convert(Int32, x))
         end
         CEnum.enum_names(::Type{$typename}) = tuple($(map(x-> Expr(:quote, first(x)), name_values)...))


### PR DESCRIPTION
Currently, VulkanCore's `|` and `&` aggressively convert their return type to the same type of their input enums, this will make life struggle because a lot of Vulkan enums are used for bit masking(see https://github.com/JuliaGPU/VulkanCore.jl/issues/15#issuecomment-361954931). This PR uses hard-coded `UInt32` as return type which is more general. If the return type constraints is intended for other inevitable situation, this feature could be added in some other upstream packages like Vulkan.jl. 