### PR TITLE
Add JULIA_VULKAN_LIBNAME for setting a custom libname

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,8 @@
+@static if get(ENV, "JULIA_GITHUB_ACTIONS_CI", "OFF") == "ON" && Sys.isapple()
+	import Libdl: DL_LOAD_PATH
+	push!(DL_LOAD_PATH, ENV["JULIA_VULKAN_SDK_SEARCH_PATH"])
+end
+
 using VulkanCore
 using VulkanCore.LibVulkan
 using Test


### PR DESCRIPTION
This is a small part of what I did in #34, related to how the libname is picked. Rather than just hardcoding a value for each platform, it allows one to set a custom libname. I also put a more explicit error message, and removed the use of JULIA_VULKAN_SDK_*. So basically, a libname is chosen at compile time, and checked/dlopened at runtime via `__init__`. Hopefully some of the work of #34 on dynamic library loading will be applicable to 1.6, because it's a pain to change the libname once VulkanCore is compiled (if there are multiple Vulkan implementations you want to test for example, or if you had a bad libname before compiling). I kept a working version of #34 that allows a dynamic loading behavior on >= 1.6 and falls back to what we do now for earlier versions, we can give it a look once 1.6 is out.