### PR TITLE
Regenerate wrapper

### DIFF
--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -65,6 +65,7 @@ for target in JLLEnvs.JLL_ENV_TRIPLES
         ]
     general["add_fptr_methods"] = true
     codegen["add_record_constructors"] = true
+    codegen["union_single_constructor"] = true
     codegen["opaque_as_mutable_struct"] = false
 
     # add compiler flags

--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -63,6 +63,7 @@ for target in JLLEnvs.JLL_ENV_TRIPLES
         "VKAPI_PTR",
         "VKAPI_CALL",
         ]
+    general["add_fptr_methods"] = true
     codegen["opaque_as_mutable_struct"] = false
 
     # add compiler flags

--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -64,6 +64,7 @@ for target in JLLEnvs.JLL_ENV_TRIPLES
         "VKAPI_CALL",
         ]
     general["add_fptr_methods"] = true
+    codegen["add_record_constructors"] = true
     codegen["opaque_as_mutable_struct"] = false
 
     # add compiler flags

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -3184,24 +3184,16 @@ end
 
 const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
 
-function VkClearColorValue(float32::NTuple{4, Cfloat})
+function VkClearColorValue(val::__U_VkClearColorValue)
     ref = Ref{VkClearColorValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkClearColorValue(int32::NTuple{4, Int32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkClearColorValue(uint32::NTuple{4, UInt32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.uint32 = uint32
+    if val isa NTuple{4, Cfloat}
+        ptr.float32 = val
+    elseif val isa NTuple{4, Int32}
+        ptr.int32 = val
+    elseif val isa NTuple{4, UInt32}
+        ptr.uint32 = val
+    end
     ref[]
 end
 
@@ -3233,17 +3225,14 @@ end
 
 const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
 
-function VkClearValue(color::VkClearColorValue)
+function VkClearValue(val::__U_VkClearValue)
     ref = Ref{VkClearValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.color = color
-    ref[]
-end
-
-function VkClearValue(depthStencil::VkClearDepthStencilValue)
-    ref = Ref{VkClearValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.depthStencil = depthStencil
+    if val isa VkClearColorValue
+        ptr.color = val
+    elseif val isa VkClearDepthStencilValue
+        ptr.depthStencil = val
+    end
     ref[]
 end
 
@@ -7802,45 +7791,22 @@ end
 
 const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
 
-function VkPerformanceCounterResultKHR(int32::Int32)
+function VkPerformanceCounterResultKHR(val::__U_VkPerformanceCounterResultKHR)
     ref = Ref{VkPerformanceCounterResultKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(int64::Int64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int64 = int64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint32::UInt32)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint32 = uint32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint64::UInt64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint64 = uint64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float32::Cfloat)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float64::Cdouble)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float64 = float64
+    if val isa Int32
+        ptr.int32 = val
+    elseif val isa Int64
+        ptr.int64 = val
+    elseif val isa UInt32
+        ptr.uint32 = val
+    elseif val isa UInt64
+        ptr.uint64 = val
+    elseif val isa Cfloat
+        ptr.float32 = val
+    elseif val isa Cdouble
+        ptr.float64 = val
+    end
     ref[]
 end
 
@@ -8537,31 +8503,18 @@ end
 
 const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
 
-function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+function VkPipelineExecutableStatisticValueKHR(val::__U_VkPipelineExecutableStatisticValueKHR)
     ref = Ref{VkPipelineExecutableStatisticValueKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.b32 = b32
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(i64::Int64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.i64 = i64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.u64 = u64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.f64 = f64
+    if val isa VkBool32
+        ptr.b32 = val
+    elseif val isa Int64
+        ptr.i64 = val
+    elseif val isa UInt64
+        ptr.u64 = val
+    elseif val isa Cdouble
+        ptr.f64 = val
+    end
     ref[]
 end
 
@@ -11395,38 +11348,20 @@ end
 
 const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
 
-function VkPerformanceValueDataINTEL(value32::UInt32)
+function VkPerformanceValueDataINTEL(val::__U_VkPerformanceValueDataINTEL)
     ref = Ref{VkPerformanceValueDataINTEL}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value32 = value32
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(value64::UInt64)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value64 = value64
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueFloat = valueFloat
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueBool::VkBool32)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueBool = valueBool
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueString = valueString
+    if val isa UInt32
+        ptr.value32 = val
+    elseif val isa UInt64
+        ptr.value64 = val
+    elseif val isa Cfloat
+        ptr.valueFloat = val
+    elseif val isa VkBool32
+        ptr.valueBool = val
+    elseif val isa Ptr{Cchar}
+        ptr.valueString = val
+    end
     ref[]
 end
 
@@ -12925,17 +12860,14 @@ end
 
 const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressKHR(val::__U_VkDeviceOrHostAddressKHR)
     ref = Ref{VkDeviceOrHostAddressKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -12962,17 +12894,14 @@ end
 
 const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressConstKHR(val::__U_VkDeviceOrHostAddressConstKHR)
     ref = Ref{VkDeviceOrHostAddressConstKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressConstKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -13033,24 +12962,16 @@ end
 
 const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
 
-function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+function VkAccelerationStructureGeometryDataKHR(val::__U_VkAccelerationStructureGeometryDataKHR)
     ref = Ref{VkAccelerationStructureGeometryDataKHR}()
     ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.triangles = triangles
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.aabbs = aabbs
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.instances = instances
+    if val isa VkAccelerationStructureGeometryTrianglesDataKHR
+        ptr.triangles = val
+    elseif val isa VkAccelerationStructureGeometryAabbsDataKHR
+        ptr.aabbs = val
+    elseif val isa VkAccelerationStructureGeometryInstancesDataKHR
+        ptr.instances = val
+    end
     ref[]
 end
 

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -3182,6 +3182,29 @@ function Base.setproperty!(x::Ptr{VkClearColorValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
+
+function VkClearColorValue(float32::NTuple{4, Cfloat})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkClearColorValue(int32::NTuple{4, Int32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkClearColorValue(uint32::NTuple{4, UInt32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
 struct VkClearDepthStencilValue
     depth::Cfloat
     stencil::UInt32
@@ -3206,6 +3229,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkClearValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
+
+function VkClearValue(color::VkClearColorValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.color = color
+    ref[]
+end
+
+function VkClearValue(depthStencil::VkClearDepthStencilValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.depthStencil = depthStencil
+    ref[]
 end
 
 struct VkClearAttachment
@@ -7761,6 +7800,50 @@ function Base.setproperty!(x::Ptr{VkPerformanceCounterResultKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
+
+function VkPerformanceCounterResultKHR(int32::Int32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(int64::Int64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int64 = int64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint32::UInt32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint64::UInt64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint64 = uint64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float32::Cfloat)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float64::Cdouble)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float64 = float64
+    ref[]
+end
+
 struct VkAcquireProfilingLockInfoKHR
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8450,6 +8533,36 @@ end
 
 function Base.setproperty!(x::Ptr{VkPipelineExecutableStatisticValueKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
+
+function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.b32 = b32
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(i64::Int64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.i64 = i64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.u64 = u64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.f64 = f64
+    ref[]
 end
 
 struct VkPipelineExecutableStatisticKHR
@@ -10710,6 +10823,18 @@ function Base.setproperty!(x::Ptr{VkAccelerationStructureInstanceKHR}, f::Symbol
     unsafe_store!(getproperty(x, f), v)
 end
 
+function VkAccelerationStructureInstanceKHR(transform::VkTransformMatrixKHR, instanceCustomIndex::UInt32, mask::UInt32, instanceShaderBindingTableRecordOffset::UInt32, flags::VkGeometryInstanceFlagsKHR, accelerationStructureReference::UInt64)
+    ref = Ref{VkAccelerationStructureInstanceKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureInstanceKHR}, ref)
+    ptr.transform = transform
+    ptr.instanceCustomIndex = instanceCustomIndex
+    ptr.mask = mask
+    ptr.instanceShaderBindingTableRecordOffset = instanceShaderBindingTableRecordOffset
+    ptr.flags = flags
+    ptr.accelerationStructureReference = accelerationStructureReference
+    ref[]
+end
+
 const VkAccelerationStructureInstanceNV = VkAccelerationStructureInstanceKHR
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkCreateAccelerationStructureNV ) ( VkDevice device , const VkAccelerationStructureCreateInfoNV * pCreateInfo , const VkAllocationCallbacks * pAllocator , VkAccelerationStructureNV * pAccelerationStructure )
@@ -11266,6 +11391,43 @@ end
 
 function Base.setproperty!(x::Ptr{VkPerformanceValueDataINTEL}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
+
+function VkPerformanceValueDataINTEL(value32::UInt32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value32 = value32
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(value64::UInt64)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value64 = value64
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueFloat = valueFloat
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueBool::VkBool32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueBool = valueBool
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueString = valueString
+    ref[]
 end
 
 struct VkPerformanceValueINTEL
@@ -12761,6 +12923,22 @@ function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
+end
+
 struct VkDeviceOrHostAddressConstKHR
     data::NTuple{8, UInt8}
 end
@@ -12780,6 +12958,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressConstKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
 end
 
 struct VkAccelerationStructureBuildRangeInfoKHR
@@ -12835,6 +13029,29 @@ end
 
 function Base.setproperty!(x::Ptr{VkAccelerationStructureGeometryDataKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
+
+function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.triangles = triangles
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.aabbs = aabbs
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.instances = instances
+    ref[]
 end
 
 struct VkAccelerationStructureGeometryKHR

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -3668,548 +3668,1096 @@ function vkCreateInstance(pCreateInfo, pAllocator, pInstance)
     ccall((:vkCreateInstance, libvulkan), VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
 end
 
+function vkCreateInstance(pCreateInfo, pAllocator, pInstance, fptr)
+    ccall(fptr, VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
+end
+
 function vkDestroyInstance(instance, pAllocator)
     ccall((:vkDestroyInstance, libvulkan), Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
+end
+
+function vkDestroyInstance(instance, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
 end
 
 function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices)
     ccall((:vkEnumeratePhysicalDevices, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
 end
 
+function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
+end
+
 function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
+end
+
+function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
 end
 
 function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceProperties(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
 end
 
+function vkGetPhysicalDeviceProperties(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
+end
+
 function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
+function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
 function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetInstanceProcAddr(instance, pName)
     ccall((:vkGetInstanceProcAddr, libvulkan), PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
+end
+
+function vkGetInstanceProcAddr(instance, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
 end
 
 function vkGetDeviceProcAddr(device, pName)
     ccall((:vkGetDeviceProcAddr, libvulkan), PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
 end
 
+function vkGetDeviceProcAddr(device, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
+end
+
 function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice)
     ccall((:vkCreateDevice, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
+end
+
+function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
 end
 
 function vkDestroyDevice(device, pAllocator)
     ccall((:vkDestroyDevice, libvulkan), Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
 end
 
+function vkDestroyDevice(device, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
+end
+
 function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceExtensionProperties, libvulkan), VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceExtensionProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
+end
+
 function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceLayerProperties, libvulkan), VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceLayerProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue)
     ccall((:vkGetDeviceQueue, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
+end
+
+function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
 end
 
 function vkQueueSubmit(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
+function vkQueueSubmit(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
 function vkQueueWaitIdle(queue)
     ccall((:vkQueueWaitIdle, libvulkan), VkResult, (VkQueue,), queue)
+end
+
+function vkQueueWaitIdle(queue, fptr)
+    ccall(fptr, VkResult, (VkQueue,), queue)
 end
 
 function vkDeviceWaitIdle(device)
     ccall((:vkDeviceWaitIdle, libvulkan), VkResult, (VkDevice,), device)
 end
 
+function vkDeviceWaitIdle(device, fptr)
+    ccall(fptr, VkResult, (VkDevice,), device)
+end
+
 function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory)
     ccall((:vkAllocateMemory, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
+end
+
+function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
 end
 
 function vkFreeMemory(device, memory, pAllocator)
     ccall((:vkFreeMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
 end
 
+function vkFreeMemory(device, memory, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
+end
+
 function vkMapMemory(device, memory, offset, size, flags, ppData)
     ccall((:vkMapMemory, libvulkan), VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
+end
+
+function vkMapMemory(device, memory, offset, size, flags, ppData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
 end
 
 function vkUnmapMemory(device, memory)
     ccall((:vkUnmapMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory), device, memory)
 end
 
+function vkUnmapMemory(device, memory, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory), device, memory)
+end
+
 function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkFlushMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
+function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
 function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkInvalidateMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
+function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
 function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes)
     ccall((:vkGetDeviceMemoryCommitment, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
+end
+
+function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
 end
 
 function vkBindBufferMemory(device, buffer, memory, memoryOffset)
     ccall((:vkBindBufferMemory, libvulkan), VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
 end
 
+function vkBindBufferMemory(device, buffer, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
+end
+
 function vkBindImageMemory(device, image, memory, memoryOffset)
     ccall((:vkBindImageMemory, libvulkan), VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
+end
+
+function vkBindImageMemory(device, image, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
 end
 
 function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
+end
+
 function vkGetImageMemoryRequirements(device, image, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements(device, image, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
 end
 
 function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
+function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
 end
 
 function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence)
     ccall((:vkQueueBindSparse, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
 end
 
+function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
+end
+
 function vkCreateFence(device, pCreateInfo, pAllocator, pFence)
     ccall((:vkCreateFence, libvulkan), VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
+end
+
+function vkCreateFence(device, pCreateInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
 end
 
 function vkDestroyFence(device, fence, pAllocator)
     ccall((:vkDestroyFence, libvulkan), Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
 end
 
+function vkDestroyFence(device, fence, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
+end
+
 function vkResetFences(device, fenceCount, pFences)
     ccall((:vkResetFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
+end
+
+function vkResetFences(device, fenceCount, pFences, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
 end
 
 function vkGetFenceStatus(device, fence)
     ccall((:vkGetFenceStatus, libvulkan), VkResult, (VkDevice, VkFence), device, fence)
 end
 
+function vkGetFenceStatus(device, fence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkFence), device, fence)
+end
+
 function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout)
     ccall((:vkWaitForFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
+end
+
+function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
 end
 
 function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore)
     ccall((:vkCreateSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
 end
 
+function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
+end
+
 function vkDestroySemaphore(device, semaphore, pAllocator)
     ccall((:vkDestroySemaphore, libvulkan), Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
+end
+
+function vkDestroySemaphore(device, semaphore, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
 end
 
 function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent)
     ccall((:vkCreateEvent, libvulkan), VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
 end
 
+function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
+end
+
 function vkDestroyEvent(device, event, pAllocator)
     ccall((:vkDestroyEvent, libvulkan), Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
+end
+
+function vkDestroyEvent(device, event, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
 end
 
 function vkGetEventStatus(device, event)
     ccall((:vkGetEventStatus, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkGetEventStatus(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkSetEvent(device, event)
     ccall((:vkSetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
+end
+
+function vkSetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
 end
 
 function vkResetEvent(device, event)
     ccall((:vkResetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkResetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool)
     ccall((:vkCreateQueryPool, libvulkan), VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
+end
+
+function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
 end
 
 function vkDestroyQueryPool(device, queryPool, pAllocator)
     ccall((:vkDestroyQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
 end
 
+function vkDestroyQueryPool(device, queryPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
+end
+
 function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
     ccall((:vkGetQueryPoolResults, libvulkan), VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
+end
+
+function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
 end
 
 function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer)
     ccall((:vkCreateBuffer, libvulkan), VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
 end
 
+function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
+end
+
 function vkDestroyBuffer(device, buffer, pAllocator)
     ccall((:vkDestroyBuffer, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
+end
+
+function vkDestroyBuffer(device, buffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
 end
 
 function vkCreateBufferView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateBufferView, libvulkan), VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
 end
 
+function vkCreateBufferView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
+end
+
 function vkDestroyBufferView(device, bufferView, pAllocator)
     ccall((:vkDestroyBufferView, libvulkan), Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
+end
+
+function vkDestroyBufferView(device, bufferView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
 end
 
 function vkCreateImage(device, pCreateInfo, pAllocator, pImage)
     ccall((:vkCreateImage, libvulkan), VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
 end
 
+function vkCreateImage(device, pCreateInfo, pAllocator, pImage, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
+end
+
 function vkDestroyImage(device, image, pAllocator)
     ccall((:vkDestroyImage, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
+end
+
+function vkDestroyImage(device, image, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
 end
 
 function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout)
     ccall((:vkGetImageSubresourceLayout, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
 end
 
+function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
+end
+
 function vkCreateImageView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateImageView, libvulkan), VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
+end
+
+function vkCreateImageView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
 end
 
 function vkDestroyImageView(device, imageView, pAllocator)
     ccall((:vkDestroyImageView, libvulkan), Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
 end
 
+function vkDestroyImageView(device, imageView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
+end
+
 function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule)
     ccall((:vkCreateShaderModule, libvulkan), VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
+end
+
+function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
 end
 
 function vkDestroyShaderModule(device, shaderModule, pAllocator)
     ccall((:vkDestroyShaderModule, libvulkan), Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
 end
 
+function vkDestroyShaderModule(device, shaderModule, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
+end
+
 function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache)
     ccall((:vkCreatePipelineCache, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
+end
+
+function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
 end
 
 function vkDestroyPipelineCache(device, pipelineCache, pAllocator)
     ccall((:vkDestroyPipelineCache, libvulkan), Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
 end
 
+function vkDestroyPipelineCache(device, pipelineCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
+end
+
 function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData)
     ccall((:vkGetPipelineCacheData, libvulkan), VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
+end
+
+function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
 end
 
 function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergePipelineCaches, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateGraphicsPipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateComputePipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
+function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
 function vkDestroyPipeline(device, pipeline, pAllocator)
     ccall((:vkDestroyPipeline, libvulkan), Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
+end
+
+function vkDestroyPipeline(device, pipeline, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
 end
 
 function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout)
     ccall((:vkCreatePipelineLayout, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
 end
 
+function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
+end
+
 function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator)
     ccall((:vkDestroyPipelineLayout, libvulkan), Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
+end
+
+function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
 end
 
 function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler)
     ccall((:vkCreateSampler, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
 end
 
+function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
+end
+
 function vkDestroySampler(device, sampler, pAllocator)
     ccall((:vkDestroySampler, libvulkan), Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
+end
+
+function vkDestroySampler(device, sampler, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
 end
 
 function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout)
     ccall((:vkCreateDescriptorSetLayout, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
 end
 
+function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
+end
+
 function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator)
     ccall((:vkDestroyDescriptorSetLayout, libvulkan), Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
+end
+
+function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
 end
 
 function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool)
     ccall((:vkCreateDescriptorPool, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
 end
 
+function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
+end
+
 function vkDestroyDescriptorPool(device, descriptorPool, pAllocator)
     ccall((:vkDestroyDescriptorPool, libvulkan), Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
+end
+
+function vkDestroyDescriptorPool(device, descriptorPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
 end
 
 function vkResetDescriptorPool(device, descriptorPool, flags)
     ccall((:vkResetDescriptorPool, libvulkan), VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
 end
 
+function vkResetDescriptorPool(device, descriptorPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
+end
+
 function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets)
     ccall((:vkAllocateDescriptorSets, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
+end
+
+function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
 end
 
 function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets)
     ccall((:vkFreeDescriptorSets, libvulkan), VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
 end
 
+function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
+end
+
 function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
     ccall((:vkUpdateDescriptorSets, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
+end
+
+function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
 end
 
 function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer)
     ccall((:vkCreateFramebuffer, libvulkan), VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
 end
 
+function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
+end
+
 function vkDestroyFramebuffer(device, framebuffer, pAllocator)
     ccall((:vkDestroyFramebuffer, libvulkan), Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
+end
+
+function vkDestroyFramebuffer(device, framebuffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
 end
 
 function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkDestroyRenderPass(device, renderPass, pAllocator)
     ccall((:vkDestroyRenderPass, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
+end
+
+function vkDestroyRenderPass(device, renderPass, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
 end
 
 function vkGetRenderAreaGranularity(device, renderPass, pGranularity)
     ccall((:vkGetRenderAreaGranularity, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
 end
 
+function vkGetRenderAreaGranularity(device, renderPass, pGranularity, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
+end
+
 function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool)
     ccall((:vkCreateCommandPool, libvulkan), VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
+end
+
+function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
 end
 
 function vkDestroyCommandPool(device, commandPool, pAllocator)
     ccall((:vkDestroyCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
 end
 
+function vkDestroyCommandPool(device, commandPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
+end
+
 function vkResetCommandPool(device, commandPool, flags)
     ccall((:vkResetCommandPool, libvulkan), VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
+end
+
+function vkResetCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
 end
 
 function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers)
     ccall((:vkAllocateCommandBuffers, libvulkan), VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
 end
 
+function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
+end
+
 function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers)
     ccall((:vkFreeCommandBuffers, libvulkan), Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
+end
+
+function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
 end
 
 function vkBeginCommandBuffer(commandBuffer, pBeginInfo)
     ccall((:vkBeginCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
 end
 
+function vkBeginCommandBuffer(commandBuffer, pBeginInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
+end
+
 function vkEndCommandBuffer(commandBuffer)
     ccall((:vkEndCommandBuffer, libvulkan), VkResult, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkEndCommandBuffer(commandBuffer, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer,), commandBuffer)
 end
 
 function vkResetCommandBuffer(commandBuffer, flags)
     ccall((:vkResetCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
 end
 
+function vkResetCommandBuffer(commandBuffer, flags, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
+end
+
 function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline)
     ccall((:vkCmdBindPipeline, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
+end
+
+function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
 end
 
 function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports)
     ccall((:vkCmdSetViewport, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
 end
 
+function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
+end
+
 function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors)
     ccall((:vkCmdSetScissor, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
+end
+
+function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
 end
 
 function vkCmdSetLineWidth(commandBuffer, lineWidth)
     ccall((:vkCmdSetLineWidth, libvulkan), Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
 end
 
+function vkCmdSetLineWidth(commandBuffer, lineWidth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
+end
+
 function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
     ccall((:vkCmdSetDepthBias, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
+end
+
+function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
 end
 
 function vkCmdSetBlendConstants(commandBuffer, blendConstants)
     ccall((:vkCmdSetBlendConstants, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
 end
 
+function vkCmdSetBlendConstants(commandBuffer, blendConstants, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
+end
+
 function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds)
     ccall((:vkCmdSetDepthBounds, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
+end
+
+function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
 end
 
 function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask)
     ccall((:vkCmdSetStencilCompareMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
 end
 
+function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
+end
+
 function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask)
     ccall((:vkCmdSetStencilWriteMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
+end
+
+function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
 end
 
 function vkCmdSetStencilReference(commandBuffer, faceMask, reference)
     ccall((:vkCmdSetStencilReference, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
 end
 
+function vkCmdSetStencilReference(commandBuffer, faceMask, reference, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
+end
+
 function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
     ccall((:vkCmdBindDescriptorSets, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
+end
+
+function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
 end
 
 function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType)
     ccall((:vkCmdBindIndexBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
 end
 
+function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
+end
+
 function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
     ccall((:vkCmdBindVertexBuffers, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
+end
+
+function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
 end
 
 function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
     ccall((:vkCmdDraw, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
 end
 
+function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
+end
+
 function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
     ccall((:vkCmdDrawIndexed, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
+end
+
+function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
 end
 
 function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndexedIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
 function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatch, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
 end
 
+function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
+end
+
 function vkCmdDispatchIndirect(commandBuffer, buffer, offset)
     ccall((:vkCmdDispatchIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
+end
+
+function vkCmdDispatchIndirect(commandBuffer, buffer, offset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
 end
 
 function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
     ccall((:vkCmdBlitImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
 end
 
+function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
+end
+
 function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyBufferToImage, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyImageToBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData)
     ccall((:vkCmdUpdateBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
+end
+
+function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
 end
 
 function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data)
     ccall((:vkCmdFillBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
 end
 
+function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
+end
+
 function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
     ccall((:vkCmdClearColorImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
+end
+
+function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
 end
 
 function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
     ccall((:vkCmdClearDepthStencilImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
 end
 
+function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
+end
+
 function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
     ccall((:vkCmdClearAttachments, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
+end
+
+function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
 end
 
 function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdResolveImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
+function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
 function vkCmdSetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdSetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
+function vkCmdSetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
 function vkCmdResetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
+function vkCmdResetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
 function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdWaitEvents, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
+function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
 function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdPipelineBarrier, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
+function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
 function vkCmdBeginQuery(commandBuffer, queryPool, query, flags)
     ccall((:vkCmdBeginQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
+end
+
+function vkCmdBeginQuery(commandBuffer, queryPool, query, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
 end
 
 function vkCmdEndQuery(commandBuffer, queryPool, query)
     ccall((:vkCmdEndQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
 end
 
+function vkCmdEndQuery(commandBuffer, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
+end
+
 function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount)
     ccall((:vkCmdResetQueryPool, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
+end
+
+function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
 end
 
 function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query)
     ccall((:vkCmdWriteTimestamp, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
+end
+
 function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
     ccall((:vkCmdCopyQueryPoolResults, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
+end
+
+function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
 end
 
 function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues)
     ccall((:vkCmdPushConstants, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
 end
 
+function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
+end
+
 function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents)
     ccall((:vkCmdBeginRenderPass, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
+end
+
+function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
 end
 
 function vkCmdNextSubpass(commandBuffer, contents)
     ccall((:vkCmdNextSubpass, libvulkan), Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
 end
 
+function vkCmdNextSubpass(commandBuffer, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
+end
+
 function vkCmdEndRenderPass(commandBuffer)
     ccall((:vkCmdEndRenderPass, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndRenderPass(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers)
     ccall((:vkCmdExecuteCommands, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
+end
+
+function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
 end
 
 const VkSamplerYcbcrConversion_T = Cvoid
@@ -4999,112 +5547,224 @@ function vkEnumerateInstanceVersion(pApiVersion)
     ccall((:vkEnumerateInstanceVersion, libvulkan), VkResult, (Ptr{UInt32},), pApiVersion)
 end
 
+function vkEnumerateInstanceVersion(pApiVersion, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32},), pApiVersion)
+end
+
 function vkBindBufferMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindBufferMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 function vkBindImageMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindImageMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
     ccall((:vkGetDeviceGroupPeerMemoryFeatures, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
+function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
 function vkCmdSetDeviceMask(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMask, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMask(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBase, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroups, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
+function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
 function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
 function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
+function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
 function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
 function vkTrimCommandPool(device, commandPool, flags)
     ccall((:vkTrimCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
+function vkTrimCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
 function vkGetDeviceQueue2(device, pQueueInfo, pQueue)
     ccall((:vkGetDeviceQueue2, libvulkan), Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
 end
 
+function vkGetDeviceQueue2(device, pQueueInfo, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
+end
+
 function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion)
     ccall((:vkCreateSamplerYcbcrConversion, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
+function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
 function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversion, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
+function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
 function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
     ccall((:vkCreateDescriptorUpdateTemplate, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
+function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
 function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
+function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
 function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFenceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphoreProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
+function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
 function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupport, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
+function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
 @cenum VkDriverId::UInt32 begin
@@ -5804,52 +6464,104 @@ function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, coun
     ccall((:vkCmdDrawIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 function vkResetQueryPool(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
+function vkResetQueryPool(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
 function vkGetSemaphoreCounterValue(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValue, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
+function vkGetSemaphoreCounterValue(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
 function vkWaitSemaphores(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphores, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphores(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphore(device, pSignalInfo)
     ccall((:vkSignalSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphore(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 function vkGetBufferDeviceAddress(device, pInfo)
     ccall((:vkGetBufferDeviceAddress, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddress(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkSurfaceKHR_T = Cvoid
@@ -5950,20 +6662,40 @@ function vkDestroySurfaceKHR(instance, surface, pAllocator)
     ccall((:vkDestroySurfaceKHR, libvulkan), Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
 end
 
+function vkDestroySurfaceKHR(instance, surface, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
+end
+
 function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported)
     ccall((:vkGetPhysicalDeviceSurfaceSupportKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
+end
+
+function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
 end
 
 function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormatsKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
 end
 
+function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
+end
+
 function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes)
     ccall((:vkGetPhysicalDeviceSurfacePresentModesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
+end
+
+function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
 end
 
 const VkSwapchainKHR_T = Cvoid
@@ -6096,36 +6828,72 @@ function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain)
     ccall((:vkCreateSwapchainKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
 end
 
+function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
+end
+
 function vkDestroySwapchainKHR(device, swapchain, pAllocator)
     ccall((:vkDestroySwapchainKHR, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
+end
+
+function vkDestroySwapchainKHR(device, swapchain, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
 end
 
 function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages)
     ccall((:vkGetSwapchainImagesKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
 end
 
+function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
+end
+
 function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex)
     ccall((:vkAcquireNextImageKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
+end
+
+function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
 end
 
 function vkQueuePresentKHR(queue, pPresentInfo)
     ccall((:vkQueuePresentKHR, libvulkan), VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
 end
 
+function vkQueuePresentKHR(queue, pPresentInfo, fptr)
+    ccall(fptr, VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
+end
+
 function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities)
     ccall((:vkGetDeviceGroupPresentCapabilitiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
+end
+
+function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
 end
 
 function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes)
     ccall((:vkGetDeviceGroupSurfacePresentModesKHR, libvulkan), VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
 end
 
+function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
+end
+
 function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects)
     ccall((:vkGetPhysicalDevicePresentRectanglesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
 end
 
+function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
+end
+
 function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex)
     ccall((:vkAcquireNextImage2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
+end
+
+function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
 end
 
 const VkDisplayKHR_T = Cvoid
@@ -6232,28 +7000,56 @@ function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount,
     ccall((:vkGetPhysicalDeviceDisplayPropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlanePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays)
     ccall((:vkGetDisplayPlaneSupportedDisplaysKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
 end
 
+function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
+end
+
 function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
+function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
 function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode)
     ccall((:vkCreateDisplayModeKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
 end
 
+function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
+end
+
 function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
 end
 
+function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
+end
+
 function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateDisplayPlaneSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
+function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
 struct VkDisplayPresentInfoKHR
@@ -6269,6 +7065,10 @@ const PFN_vkCreateSharedSwapchainsKHR = Ptr{Cvoid}
 
 function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
     ccall((:vkCreateSharedSwapchainsKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
+end
+
+function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
 end
 
 const VkRenderPassMultiviewCreateInfoKHR = VkRenderPassMultiviewCreateInfo
@@ -6320,28 +7120,56 @@ function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
 const VkPeerMemoryFeatureFlagsKHR = VkPeerMemoryFeatureFlags
@@ -6379,12 +7207,24 @@ function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceInd
     ccall((:vkGetDeviceGroupPeerMemoryFeaturesKHR, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
+function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
 function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMaskKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBaseKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 const VkCommandPoolTrimFlagsKHR = VkCommandPoolTrimFlags
@@ -6396,6 +7236,10 @@ function vkTrimCommandPoolKHR(device, commandPool, flags)
     ccall((:vkTrimCommandPoolKHR, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
+function vkTrimCommandPoolKHR(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
 const VkPhysicalDeviceGroupPropertiesKHR = VkPhysicalDeviceGroupProperties
 
 const VkDeviceGroupDeviceCreateInfoKHR = VkDeviceGroupDeviceCreateInfo
@@ -6405,6 +7249,10 @@ const PFN_vkEnumeratePhysicalDeviceGroupsKHR = Ptr{Cvoid}
 
 function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroupsKHR, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
+function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
 const VkExternalMemoryHandleTypeFlagsKHR = VkExternalMemoryHandleTypeFlags
@@ -6432,6 +7280,10 @@ const PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferPropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
+function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
 const VkExternalMemoryImageCreateInfoKHR = VkExternalMemoryImageCreateInfo
@@ -6470,8 +7322,16 @@ function vkGetMemoryFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetMemoryFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
+function vkGetMemoryFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
 function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties)
     ccall((:vkGetMemoryFdPropertiesKHR, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
+end
+
+function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
 end
 
 const VkExternalSemaphoreHandleTypeFlagsKHR = VkExternalSemaphoreHandleTypeFlags
@@ -6491,6 +7351,10 @@ const PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphorePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
+function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
 const VkSemaphoreImportFlagsKHR = VkSemaphoreImportFlags
@@ -6525,8 +7389,16 @@ function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo)
     ccall((:vkImportSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
 end
 
+function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
+end
+
 function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 struct VkPhysicalDevicePushDescriptorPropertiesKHR
@@ -6545,8 +7417,16 @@ function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set
     ccall((:vkCmdPushDescriptorSetKHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
 end
 
+function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
+end
+
 function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData)
     ccall((:vkCmdPushDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
+end
+
+function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
 end
 
 const VkPhysicalDeviceShaderFloat16Int8FeaturesKHR = VkPhysicalDeviceShaderFloat16Int8Features
@@ -6596,12 +7476,24 @@ function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pD
     ccall((:vkCreateDescriptorUpdateTemplateKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
+function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
 function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 const VkPhysicalDeviceImagelessFramebufferFeaturesKHR = VkPhysicalDeviceImagelessFramebufferFeatures
@@ -6642,16 +7534,32 @@ function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 struct VkSharedPresentSurfaceCapabilitiesKHR
@@ -6665,6 +7573,10 @@ const PFN_vkGetSwapchainStatusKHR = Ptr{Cvoid}
 
 function vkGetSwapchainStatusKHR(device, swapchain)
     ccall((:vkGetSwapchainStatusKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
+end
+
+function vkGetSwapchainStatusKHR(device, swapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
 end
 
 const VkExternalFenceHandleTypeFlagsKHR = VkExternalFenceHandleTypeFlags
@@ -6684,6 +7596,10 @@ const PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFencePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 const VkFenceImportFlagsKHR = VkFenceImportFlags
@@ -6718,8 +7634,16 @@ function vkImportFenceFdKHR(device, pImportFenceFdInfo)
     ccall((:vkImportFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
 end
 
+function vkImportFenceFdKHR(device, pImportFenceFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
+end
+
 function vkGetFenceFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetFenceFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 @cenum VkPerformanceCounterUnitKHR::UInt32 begin
@@ -6866,16 +7790,32 @@ function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physica
     ccall((:vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
 end
 
+function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
+end
+
 function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
     ccall((:vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
+end
+
+function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
 end
 
 function vkAcquireProfilingLockKHR(device, pInfo)
     ccall((:vkAcquireProfilingLockKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
 end
 
+function vkAcquireProfilingLockKHR(device, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
+end
+
 function vkReleaseProfilingLockKHR(device)
     ccall((:vkReleaseProfilingLockKHR, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkReleaseProfilingLockKHR(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 const VkPointClippingBehaviorKHR = VkPointClippingBehavior
@@ -6920,8 +7860,16 @@ function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormats2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
+end
+
+function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
 end
 
 const VkPhysicalDeviceVariablePointerFeaturesKHR = VkPhysicalDeviceVariablePointersFeatures
@@ -6975,16 +7923,32 @@ function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount
     ccall((:vkGetPhysicalDeviceDisplayProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlaneProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModeProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
+function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
 function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
+end
+
+function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
 end
 
 const VkMemoryDedicatedRequirementsKHR = VkMemoryDedicatedRequirements
@@ -7014,12 +7978,24 @@ function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 const VkImageFormatListCreateInfoKHR = VkImageFormatListCreateInfo
@@ -7054,8 +8030,16 @@ function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcb
     ccall((:vkCreateSamplerYcbcrConversionKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
+function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
 function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversionKHR, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
+function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
 const VkBindBufferMemoryInfoKHR = VkBindBufferMemoryInfo
@@ -7072,8 +8056,16 @@ function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 const VkPhysicalDeviceMaintenance3PropertiesKHR = VkPhysicalDeviceMaintenance3Properties
@@ -7087,6 +8079,10 @@ function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupportKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
+function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountKHR ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
 const PFN_vkCmdDrawIndirectCountKHR = Ptr{Cvoid}
 
@@ -7097,8 +8093,16 @@ function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 const VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR = VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures
@@ -7163,12 +8167,24 @@ function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValueKHR, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
+function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
 function vkWaitSemaphoresKHR(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphoresKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphoresKHR(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphoreKHR(device, pSignalInfo)
     ccall((:vkSignalSemaphoreKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphoreKHR(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR = VkPhysicalDeviceVulkanMemoryModelFeatures
@@ -7249,8 +8265,16 @@ function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentSha
     ccall((:vkGetPhysicalDeviceFragmentShadingRatesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
 end
 
+function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
+end
+
 function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps)
     ccall((:vkCmdSetFragmentShadingRateKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
+end
+
+function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
 end
 
 struct VkSurfaceProtectedCapabilitiesKHR
@@ -7290,12 +8314,24 @@ function vkGetBufferDeviceAddressKHR(device, pInfo)
     ccall((:vkGetBufferDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkDeferredOperationKHR_T = Cvoid
@@ -7321,20 +8357,40 @@ function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation)
     ccall((:vkCreateDeferredOperationKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
 end
 
+function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
+end
+
 function vkDestroyDeferredOperationKHR(device, operation, pAllocator)
     ccall((:vkDestroyDeferredOperationKHR, libvulkan), Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
+end
+
+function vkDestroyDeferredOperationKHR(device, operation, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
 end
 
 function vkGetDeferredOperationMaxConcurrencyKHR(device, operation)
     ccall((:vkGetDeferredOperationMaxConcurrencyKHR, libvulkan), UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationMaxConcurrencyKHR(device, operation, fptr)
+    ccall(fptr, UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkGetDeferredOperationResultKHR(device, operation)
     ccall((:vkGetDeferredOperationResultKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationResultKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkDeferredOperationJoinKHR(device, operation)
     ccall((:vkDeferredOperationJoinKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
+function vkDeferredOperationJoinKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
 @cenum VkPipelineExecutableStatisticFormatKHR::UInt32 begin
@@ -7428,12 +8484,24 @@ function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutable
     ccall((:vkGetPipelineExecutablePropertiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
 end
 
+function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutableCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
+end
+
 function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics)
     ccall((:vkGetPipelineExecutableStatisticsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
 end
 
+function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
+end
+
 function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
     ccall((:vkGetPipelineExecutableInternalRepresentationsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
+end
+
+function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
 end
 
 struct VkPipelineLibraryCreateInfoKHR
@@ -7585,32 +8653,64 @@ function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo)
     ccall((:vkCmdSetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
 end
 
+function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
+end
+
 function vkCmdResetEvent2KHR(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
+end
+
+function vkCmdResetEvent2KHR(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
 end
 
 function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos)
     ccall((:vkCmdWaitEvents2KHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
 end
 
+function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
+end
+
 function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo)
     ccall((:vkCmdPipelineBarrier2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
+end
+
+function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
 end
 
 function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query)
     ccall((:vkCmdWriteTimestamp2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
+end
+
 function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit2KHR, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
+function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
 function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarker2AMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
 end
 
+function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
+end
+
 function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointData2NV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR
@@ -7761,24 +8861,48 @@ function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo)
     ccall((:vkCmdCopyBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
 end
 
+function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
+end
+
 function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo)
     ccall((:vkCmdCopyImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
+end
+
+function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
 end
 
 function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo)
     ccall((:vkCmdCopyBufferToImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
 end
 
+function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
+end
+
 function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo)
     ccall((:vkCmdCopyImageToBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
+end
+
+function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
 end
 
 function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo)
     ccall((:vkCmdBlitImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
 end
 
+function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
+end
+
 function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo)
     ccall((:vkCmdResolveImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
+end
+
+function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
 end
 
 const VkDebugReportCallbackEXT_T = Cvoid
@@ -7864,12 +8988,24 @@ function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCall
     ccall((:vkCreateDebugReportCallbackEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
 end
 
+function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
+end
+
 function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator)
     ccall((:vkDestroyDebugReportCallbackEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
 end
 
+function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
+end
+
 function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
     ccall((:vkDebugReportMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
+end
+
+function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
 end
 
 @cenum VkRasterizationOrderAMD::UInt32 begin
@@ -7928,20 +9064,40 @@ function vkDebugMarkerSetObjectTagEXT(device, pTagInfo)
     ccall((:vkDebugMarkerSetObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
 end
 
+function vkDebugMarkerSetObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
+end
+
 function vkDebugMarkerSetObjectNameEXT(device, pNameInfo)
     ccall((:vkDebugMarkerSetObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
+end
+
+function vkDebugMarkerSetObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
 end
 
 function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerBeginEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdDebugMarkerEndEXT(commandBuffer)
     ccall((:vkCmdDebugMarkerEndEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdDebugMarkerEndEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerInsertEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
 struct VkDedicatedAllocationImageCreateInfoNV
@@ -8016,24 +9172,48 @@ function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindi
     ccall((:vkCmdBindTransformFeedbackBuffersEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
 end
 
+function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
+end
+
 function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdBeginTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
+function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
 function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdEndTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
+function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
 function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index)
     ccall((:vkCmdBeginQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
+end
+
+function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
 end
 
 function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index)
     ccall((:vkCmdEndQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
 end
 
+function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
+end
+
 function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
     ccall((:vkCmdDrawIndirectByteCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
+end
+
+function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
 end
 
 struct VkImageViewHandleInfoNVX
@@ -8061,8 +9241,16 @@ function vkGetImageViewHandleNVX(device, pInfo)
     ccall((:vkGetImageViewHandleNVX, libvulkan), UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
 end
 
+function vkGetImageViewHandleNVX(device, pInfo, fptr)
+    ccall(fptr, UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
+end
+
 function vkGetImageViewAddressNVX(device, imageView, pProperties)
     ccall((:vkGetImageViewAddressNVX, libvulkan), VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
+end
+
+function vkGetImageViewAddressNVX(device, imageView, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
 end
 
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountAMD ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
@@ -8075,8 +9263,16 @@ function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkTextureLODGatherFormatPropertiesAMD
@@ -8117,6 +9313,10 @@ function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, 
     ccall((:vkGetShaderInfoAMD, libvulkan), VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
 end
 
+function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
+end
+
 struct VkPhysicalDeviceCornerSampledImageFeaturesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8154,6 +9354,10 @@ const PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
     ccall((:vkGetPhysicalDeviceExternalImageFormatPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
 end
 
 struct VkExternalMemoryImageCreateInfoNV
@@ -8237,8 +9441,16 @@ function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingB
     ccall((:vkCmdBeginConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
 end
 
+function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
+end
+
 function vkCmdEndConditionalRenderingEXT(commandBuffer)
     ccall((:vkCmdEndConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkCmdEndConditionalRenderingEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
 struct VkViewportWScalingNV
@@ -8261,11 +9473,19 @@ function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount,
     ccall((:vkCmdSetViewportWScalingNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
 end
 
+function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
+end
+
 # typedef VkResult ( VKAPI_PTR * PFN_vkReleaseDisplayEXT ) ( VkPhysicalDevice physicalDevice , VkDisplayKHR display )
 const PFN_vkReleaseDisplayEXT = Ptr{Cvoid}
 
 function vkReleaseDisplayEXT(physicalDevice, display)
     ccall((:vkReleaseDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
+function vkReleaseDisplayEXT(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
 @cenum VkSurfaceCounterFlagBitsEXT::UInt32 begin
@@ -8297,6 +9517,10 @@ const PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2EXT, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
+function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
 @cenum VkDisplayPowerStateEXT::UInt32 begin
@@ -8356,16 +9580,32 @@ function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo)
     ccall((:vkDisplayPowerControlEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
 end
 
+function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
+end
+
 function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDeviceEventEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
+end
+
+function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
 end
 
 function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDisplayEventEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
 end
 
+function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
+end
+
 function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue)
     ccall((:vkGetSwapchainCounterEXT, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
+end
+
+function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
 end
 
 struct VkRefreshCycleDurationGOOGLE
@@ -8402,8 +9642,16 @@ function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProper
     ccall((:vkGetRefreshCycleDurationGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
 end
 
+function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
+end
+
 function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings)
     ccall((:vkGetPastPresentationTimingGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
+end
+
+function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
 end
 
 struct VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX
@@ -8469,6 +9717,10 @@ const PFN_vkCmdSetDiscardRectangleEXT = Ptr{Cvoid}
 
 function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
     ccall((:vkCmdSetDiscardRectangleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
+end
+
+function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
 end
 
 @cenum VkConservativeRasterizationModeEXT::UInt32 begin
@@ -8540,6 +9792,10 @@ const PFN_vkSetHdrMetadataEXT = Ptr{Cvoid}
 
 function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata)
     ccall((:vkSetHdrMetadataEXT, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
+end
+
+function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
 end
 
 const VkDebugUtilsMessengerEXT_T = Cvoid
@@ -8659,44 +9915,88 @@ function vkSetDebugUtilsObjectNameEXT(device, pNameInfo)
     ccall((:vkSetDebugUtilsObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
 end
 
+function vkSetDebugUtilsObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
+end
+
 function vkSetDebugUtilsObjectTagEXT(device, pTagInfo)
     ccall((:vkSetDebugUtilsObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
+end
+
+function vkSetDebugUtilsObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
 end
 
 function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkQueueEndDebugUtilsLabelEXT(queue)
     ccall((:vkQueueEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue,), queue)
+end
+
+function vkQueueEndDebugUtilsLabelEXT(queue, fptr)
+    ccall(fptr, Cvoid, (VkQueue,), queue)
 end
 
 function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCmdEndDebugUtilsLabelEXT(commandBuffer)
     ccall((:vkCmdEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndDebugUtilsLabelEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger)
     ccall((:vkCreateDebugUtilsMessengerEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
 end
 
+function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
+end
+
 function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator)
     ccall((:vkDestroyDebugUtilsMessengerEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
 end
 
+function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
+end
+
 function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData)
     ccall((:vkSubmitDebugUtilsMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
+end
+
+function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
 end
 
 const VkSamplerReductionModeEXT = VkSamplerReductionMode
@@ -8801,8 +10101,16 @@ function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo)
     ccall((:vkCmdSetSampleLocationsEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
 end
 
+function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
+end
+
 function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties)
     ccall((:vkGetPhysicalDeviceMultisamplePropertiesEXT, libvulkan), Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
+end
+
+function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
 end
 
 @cenum VkBlendOverlapEXT::UInt32 begin
@@ -8930,6 +10238,10 @@ function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties)
     ccall((:vkGetImageDrmFormatModifierPropertiesEXT, libvulkan), VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
 end
 
+function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
+end
+
 const VkValidationCacheEXT_T = Cvoid
 
 const VkValidationCacheEXT = Ptr{VkValidationCacheEXT_T}
@@ -8971,16 +10283,32 @@ function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidation
     ccall((:vkCreateValidationCacheEXT, libvulkan), VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
 end
 
+function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
+end
+
 function vkDestroyValidationCacheEXT(device, validationCache, pAllocator)
     ccall((:vkDestroyValidationCacheEXT, libvulkan), Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
+end
+
+function vkDestroyValidationCacheEXT(device, validationCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
 end
 
 function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergeValidationCachesEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData)
     ccall((:vkGetValidationCacheDataEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
+end
+
+function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
 end
 
 const VkDescriptorBindingFlagBitsEXT = VkDescriptorBindingFlagBits
@@ -9083,12 +10411,24 @@ function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout)
     ccall((:vkCmdBindShadingRateImageNV, libvulkan), Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
 end
 
+function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
+end
+
 function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
     ccall((:vkCmdSetViewportShadingRatePaletteNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
 end
 
+function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
+end
+
 function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
     ccall((:vkCmdSetCoarseSampleOrderNV, libvulkan), Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
+end
+
+function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
 end
 
 const VkAccelerationStructureNV_T = Cvoid
@@ -9415,52 +10755,104 @@ function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccel
     ccall((:vkCreateAccelerationStructureNV, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureNV, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements)
     ccall((:vkGetAccelerationStructureMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
+end
+
 function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos)
     ccall((:vkBindAccelerationStructureMemoryNV, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
 end
 
 function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
     ccall((:vkCmdBuildAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
 end
 
+function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
+end
+
 function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode)
     ccall((:vkCmdCopyAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
+end
+
+function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
 end
 
 function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
     ccall((:vkCmdTraceRaysNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
 end
 
+function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesNV, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
+function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
 function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData)
     ccall((:vkGetAccelerationStructureHandleNV, libvulkan), VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
 end
 
+function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
+function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
 function vkCompileDeferredNV(device, pipeline, shader)
     ccall((:vkCompileDeferredNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
+end
+
+function vkCompileDeferredNV(device, pipeline, shader, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
 end
 
 struct VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV
@@ -9528,11 +10920,19 @@ function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, p
     ccall((:vkGetMemoryHostPointerPropertiesEXT, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
 end
 
+function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, pMemoryHostPointerProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdWriteBufferMarkerAMD ) ( VkCommandBuffer commandBuffer , VkPipelineStageFlagBits pipelineStage , VkBuffer dstBuffer , VkDeviceSize dstOffset , uint32_t marker )
 const PFN_vkCmdWriteBufferMarkerAMD = Ptr{Cvoid}
 
 function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarkerAMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
+end
+
+function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
 end
 
 @cenum VkPipelineCompilerControlFlagBitsAMD::UInt32 begin
@@ -9571,8 +10971,16 @@ function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDom
     ccall((:vkGetPhysicalDeviceCalibrateableTimeDomainsEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
 end
 
+function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDomainCount, pTimeDomains, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
+end
+
 function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
     ccall((:vkGetCalibratedTimestampsEXT, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
+end
+
+function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
 end
 
 struct VkPhysicalDeviceShaderCorePropertiesAMD
@@ -9704,12 +11112,24 @@ function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask)
     ccall((:vkCmdDrawMeshTasksNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
 end
 
+function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
+end
+
 function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectCountNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV
@@ -9744,6 +11164,10 @@ function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclus
     ccall((:vkCmdSetExclusiveScissorNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
 end
 
+function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
+end
+
 struct VkQueueFamilyCheckpointPropertiesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -9767,8 +11191,16 @@ function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker)
     ccall((:vkCmdSetCheckpointNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
 end
 
+function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
+end
+
 function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointDataNV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL
@@ -9912,36 +11344,72 @@ function vkInitializePerformanceApiINTEL(device, pInitializeInfo)
     ccall((:vkInitializePerformanceApiINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
 end
 
+function vkInitializePerformanceApiINTEL(device, pInitializeInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
+end
+
 function vkUninitializePerformanceApiINTEL(device)
     ccall((:vkUninitializePerformanceApiINTEL, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkUninitializePerformanceApiINTEL(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceStreamMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
 function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo)
     ccall((:vkCmdSetPerformanceOverrideINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
 end
 
+function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
+end
+
 function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration)
     ccall((:vkAcquirePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
+end
+
+function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
 end
 
 function vkReleasePerformanceConfigurationINTEL(device, configuration)
     ccall((:vkReleasePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
 end
 
+function vkReleasePerformanceConfigurationINTEL(device, configuration, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
+end
+
 function vkQueueSetPerformanceConfigurationINTEL(queue, configuration)
     ccall((:vkQueueSetPerformanceConfigurationINTEL, libvulkan), VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
 end
 
+function vkQueueSetPerformanceConfigurationINTEL(queue, configuration, fptr)
+    ccall(fptr, VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
+end
+
 function vkGetPerformanceParameterINTEL(device, parameter, pValue)
     ccall((:vkGetPerformanceParameterINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
+end
+
+function vkGetPerformanceParameterINTEL(device, parameter, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
 end
 
 struct VkPhysicalDevicePCIBusInfoPropertiesEXT
@@ -9970,6 +11438,10 @@ const PFN_vkSetLocalDimmingAMD = Ptr{Cvoid}
 
 function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable)
     ccall((:vkSetLocalDimmingAMD, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
+end
+
+function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
 end
 
 struct VkPhysicalDeviceFragmentDensityMapFeaturesEXT
@@ -10094,6 +11566,10 @@ function vkGetBufferDeviceAddressEXT(device, pInfo)
     ccall((:vkGetBufferDeviceAddressEXT, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressEXT(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 @cenum VkToolPurposeFlagBitsEXT::UInt32 begin
     VK_TOOL_PURPOSE_VALIDATION_BIT_EXT = 1
     VK_TOOL_PURPOSE_PROFILING_BIT_EXT = 2
@@ -10122,6 +11598,10 @@ const PFN_vkGetPhysicalDeviceToolPropertiesEXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties)
     ccall((:vkGetPhysicalDeviceToolPropertiesEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
+end
+
+function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
 end
 
 const VkImageStencilUsageCreateInfoEXT = VkImageStencilUsageCreateInfo
@@ -10211,6 +11691,10 @@ function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPrope
     ccall((:vkGetPhysicalDeviceCooperativeMatrixPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
+end
+
 @cenum VkCoverageReductionModeNV::UInt32 begin
     VK_COVERAGE_REDUCTION_MODE_MERGE_NV = 0
     VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV = 1
@@ -10246,6 +11730,10 @@ const PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV = Pt
 
 function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations)
     ccall((:vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
+end
+
+function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
 end
 
 struct VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT
@@ -10303,6 +11791,10 @@ function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateHeadlessSurfaceEXT, libvulkan), VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 @cenum VkLineRasterizationModeEXT::UInt32 begin
     VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT = 0
     VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT = 1
@@ -10344,6 +11836,10 @@ function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePat
     ccall((:vkCmdSetLineStippleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
 end
 
+function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
+end
+
 struct VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10368,6 +11864,10 @@ const PFN_vkResetQueryPoolEXT = Ptr{Cvoid}
 
 function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPoolEXT, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
+function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
 struct VkPhysicalDeviceIndexTypeUint8FeaturesEXT
@@ -10422,48 +11922,96 @@ function vkCmdSetCullModeEXT(commandBuffer, cullMode)
     ccall((:vkCmdSetCullModeEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
 end
 
+function vkCmdSetCullModeEXT(commandBuffer, cullMode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
+end
+
 function vkCmdSetFrontFaceEXT(commandBuffer, frontFace)
     ccall((:vkCmdSetFrontFaceEXT, libvulkan), Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
+end
+
+function vkCmdSetFrontFaceEXT(commandBuffer, frontFace, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
 end
 
 function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology)
     ccall((:vkCmdSetPrimitiveTopologyEXT, libvulkan), Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
 end
 
+function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
+end
+
 function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports)
     ccall((:vkCmdSetViewportWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
+end
+
+function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
 end
 
 function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors)
     ccall((:vkCmdSetScissorWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
 end
 
+function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
+end
+
 function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
     ccall((:vkCmdBindVertexBuffers2EXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
+end
+
+function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
 end
 
 function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable)
     ccall((:vkCmdSetDepthTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
 end
 
+function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
+end
+
 function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable)
     ccall((:vkCmdSetDepthWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
+end
+
+function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
 end
 
 function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp)
     ccall((:vkCmdSetDepthCompareOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
 end
 
+function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
+end
+
 function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable)
     ccall((:vkCmdSetDepthBoundsTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
+end
+
+function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
 end
 
 function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable)
     ccall((:vkCmdSetStencilTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
 end
 
+function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
+end
+
 function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
     ccall((:vkCmdSetStencilOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
+end
+
+function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
 end
 
 struct VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT
@@ -10645,24 +12193,48 @@ function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequir
     ccall((:vkGetGeneratedCommandsMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo)
     ccall((:vkCmdPreprocessGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
+end
+
+function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
 end
 
 function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
     ccall((:vkCmdExecuteGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
 end
 
+function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
+end
+
 function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex)
     ccall((:vkCmdBindPipelineShaderGroupNV, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
+end
+
+function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
 end
 
 function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
     ccall((:vkCreateIndirectCommandsLayoutNV, libvulkan), VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
 end
 
+function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
+end
+
 function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator)
     ccall((:vkDestroyIndirectCommandsLayoutNV, libvulkan), Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
+end
+
+function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
 end
 
 struct VkPhysicalDeviceInheritedViewportScissorFeaturesNV
@@ -10826,16 +12398,32 @@ function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDat
     ccall((:vkCreatePrivateDataSlotEXT, libvulkan), VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
 end
 
+function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDataSlot, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
+end
+
 function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator)
     ccall((:vkDestroyPrivateDataSlotEXT, libvulkan), Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
+end
+
+function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
 end
 
 function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data)
     ccall((:vkSetPrivateDataEXT, libvulkan), VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
 end
 
+function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
+end
+
 function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData)
     ccall((:vkGetPrivateDataEXT, libvulkan), Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
+end
+
+function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
 end
 
 struct VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT
@@ -10916,6 +12504,10 @@ function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerO
     ccall((:vkCmdSetFragmentShadingRateEnumNV, libvulkan), Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
 end
 
+function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
+end
+
 struct VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10966,8 +12558,16 @@ function vkAcquireWinrtDisplayNV(physicalDevice, display)
     ccall((:vkAcquireWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
+function vkAcquireWinrtDisplayNV(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
 function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay)
     ccall((:vkGetWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
+end
+
+function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
 end
 
 struct VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE
@@ -11019,6 +12619,10 @@ function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pV
     ccall((:vkCmdSetVertexInputEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
 end
 
+function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
+end
+
 struct VkPhysicalDeviceExtendedDynamicState2FeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -11046,20 +12650,40 @@ function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints)
     ccall((:vkCmdSetPatchControlPointsEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
 end
 
+function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
+end
+
 function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable)
     ccall((:vkCmdSetRasterizerDiscardEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
+end
+
+function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
 end
 
 function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable)
     ccall((:vkCmdSetDepthBiasEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
 end
 
+function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
+end
+
 function vkCmdSetLogicOpEXT(commandBuffer, logicOp)
     ccall((:vkCmdSetLogicOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
 end
 
+function vkCmdSetLogicOpEXT(commandBuffer, logicOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
+end
+
 function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable)
     ccall((:vkCmdSetPrimitiveRestartEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
+end
+
+function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
 end
 
 struct VkPhysicalDeviceColorWriteEnableFeaturesEXT
@@ -11080,6 +12704,10 @@ const PFN_vkCmdSetColorWriteEnableEXT = Ptr{Cvoid}
 
 function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables)
     ccall((:vkCmdSetColorWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
+end
+
+function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
 end
 
 const VkAccelerationStructureKHR_T = Cvoid
@@ -11368,64 +12996,128 @@ function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAcce
     ccall((:vkCreateAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkCmdBuildAccelerationStructuresKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
     ccall((:vkCmdBuildAccelerationStructuresIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
+end
+
+function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
 end
 
 function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkBuildAccelerationStructuresKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureToMemoryKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
 end
 
+function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
+end
+
 function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyMemoryToAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
     ccall((:vkWriteAccelerationStructuresPropertiesKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
 end
 
+function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
+end
+
 function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureToMemoryKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
 end
 
+function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
+end
+
 function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyMemoryToAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo)
     ccall((:vkGetAccelerationStructureDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
 end
 
+function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
+function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
 function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility)
     ccall((:vkGetDeviceAccelerationStructureCompatibilityKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
 end
 
+function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
+end
+
 function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
     ccall((:vkGetAccelerationStructureBuildSizesKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
+end
+
+function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
 end
 
 @cenum VkShaderGroupShaderKHR::UInt32 begin
@@ -11528,24 +13220,48 @@ function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShader
     ccall((:vkCmdTraceRaysKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
 end
 
+function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingCaptureReplayShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
     ccall((:vkCmdTraceRaysIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
+end
+
+function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
 end
 
 function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader)
     ccall((:vkGetRayTracingShaderGroupStackSizeKHR, libvulkan), VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
 end
 
+function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader, fptr)
+    ccall(fptr, VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
+end
+
 function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize)
     ccall((:vkCmdSetRayTracingPipelineStackSizeKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
+end
+
+function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
 end
 
 struct VkPhysicalDeviceRayQueryFeaturesKHR
@@ -11570,6 +13286,10 @@ function vkCreateMacOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateMacOSSurfaceMVK, libvulkan), VkResult, (VkInstance, Ptr{VkMacOSSurfaceCreateInfoMVK}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateMacOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkMacOSSurfaceCreateInfoMVK}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 const CAMetalLayer = Cvoid
 
 const VkMetalSurfaceCreateFlagsEXT = VkFlags
@@ -11586,6 +13306,10 @@ const PFN_vkCreateMetalSurfaceEXT = Ptr{Cvoid}
 
 function vkCreateMetalSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateMetalSurfaceEXT, libvulkan), VkResult, (VkInstance, Ptr{VkMetalSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
+function vkCreateMetalSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkMetalSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
 const VULKAN_H_ = 1

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -3686,548 +3686,1096 @@ function vkCreateInstance(pCreateInfo, pAllocator, pInstance)
     ccall((:vkCreateInstance, libvulkan), VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
 end
 
+function vkCreateInstance(pCreateInfo, pAllocator, pInstance, fptr)
+    ccall(fptr, VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
+end
+
 function vkDestroyInstance(instance, pAllocator)
     ccall((:vkDestroyInstance, libvulkan), Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
+end
+
+function vkDestroyInstance(instance, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
 end
 
 function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices)
     ccall((:vkEnumeratePhysicalDevices, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
 end
 
+function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
+end
+
 function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
+end
+
+function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
 end
 
 function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceProperties(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
 end
 
+function vkGetPhysicalDeviceProperties(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
+end
+
 function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
+function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
 function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetInstanceProcAddr(instance, pName)
     ccall((:vkGetInstanceProcAddr, libvulkan), PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
+end
+
+function vkGetInstanceProcAddr(instance, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
 end
 
 function vkGetDeviceProcAddr(device, pName)
     ccall((:vkGetDeviceProcAddr, libvulkan), PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
 end
 
+function vkGetDeviceProcAddr(device, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
+end
+
 function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice)
     ccall((:vkCreateDevice, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
+end
+
+function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
 end
 
 function vkDestroyDevice(device, pAllocator)
     ccall((:vkDestroyDevice, libvulkan), Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
 end
 
+function vkDestroyDevice(device, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
+end
+
 function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceExtensionProperties, libvulkan), VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceExtensionProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
+end
+
 function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceLayerProperties, libvulkan), VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceLayerProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue)
     ccall((:vkGetDeviceQueue, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
+end
+
+function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
 end
 
 function vkQueueSubmit(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
+function vkQueueSubmit(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
 function vkQueueWaitIdle(queue)
     ccall((:vkQueueWaitIdle, libvulkan), VkResult, (VkQueue,), queue)
+end
+
+function vkQueueWaitIdle(queue, fptr)
+    ccall(fptr, VkResult, (VkQueue,), queue)
 end
 
 function vkDeviceWaitIdle(device)
     ccall((:vkDeviceWaitIdle, libvulkan), VkResult, (VkDevice,), device)
 end
 
+function vkDeviceWaitIdle(device, fptr)
+    ccall(fptr, VkResult, (VkDevice,), device)
+end
+
 function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory)
     ccall((:vkAllocateMemory, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
+end
+
+function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
 end
 
 function vkFreeMemory(device, memory, pAllocator)
     ccall((:vkFreeMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
 end
 
+function vkFreeMemory(device, memory, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
+end
+
 function vkMapMemory(device, memory, offset, size, flags, ppData)
     ccall((:vkMapMemory, libvulkan), VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
+end
+
+function vkMapMemory(device, memory, offset, size, flags, ppData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
 end
 
 function vkUnmapMemory(device, memory)
     ccall((:vkUnmapMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory), device, memory)
 end
 
+function vkUnmapMemory(device, memory, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory), device, memory)
+end
+
 function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkFlushMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
+function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
 function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkInvalidateMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
+function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
 function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes)
     ccall((:vkGetDeviceMemoryCommitment, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
+end
+
+function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
 end
 
 function vkBindBufferMemory(device, buffer, memory, memoryOffset)
     ccall((:vkBindBufferMemory, libvulkan), VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
 end
 
+function vkBindBufferMemory(device, buffer, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
+end
+
 function vkBindImageMemory(device, image, memory, memoryOffset)
     ccall((:vkBindImageMemory, libvulkan), VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
+end
+
+function vkBindImageMemory(device, image, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
 end
 
 function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
+end
+
 function vkGetImageMemoryRequirements(device, image, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements(device, image, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
 end
 
 function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
+function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
 end
 
 function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence)
     ccall((:vkQueueBindSparse, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
 end
 
+function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
+end
+
 function vkCreateFence(device, pCreateInfo, pAllocator, pFence)
     ccall((:vkCreateFence, libvulkan), VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
+end
+
+function vkCreateFence(device, pCreateInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
 end
 
 function vkDestroyFence(device, fence, pAllocator)
     ccall((:vkDestroyFence, libvulkan), Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
 end
 
+function vkDestroyFence(device, fence, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
+end
+
 function vkResetFences(device, fenceCount, pFences)
     ccall((:vkResetFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
+end
+
+function vkResetFences(device, fenceCount, pFences, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
 end
 
 function vkGetFenceStatus(device, fence)
     ccall((:vkGetFenceStatus, libvulkan), VkResult, (VkDevice, VkFence), device, fence)
 end
 
+function vkGetFenceStatus(device, fence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkFence), device, fence)
+end
+
 function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout)
     ccall((:vkWaitForFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
+end
+
+function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
 end
 
 function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore)
     ccall((:vkCreateSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
 end
 
+function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
+end
+
 function vkDestroySemaphore(device, semaphore, pAllocator)
     ccall((:vkDestroySemaphore, libvulkan), Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
+end
+
+function vkDestroySemaphore(device, semaphore, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
 end
 
 function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent)
     ccall((:vkCreateEvent, libvulkan), VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
 end
 
+function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
+end
+
 function vkDestroyEvent(device, event, pAllocator)
     ccall((:vkDestroyEvent, libvulkan), Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
+end
+
+function vkDestroyEvent(device, event, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
 end
 
 function vkGetEventStatus(device, event)
     ccall((:vkGetEventStatus, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkGetEventStatus(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkSetEvent(device, event)
     ccall((:vkSetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
+end
+
+function vkSetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
 end
 
 function vkResetEvent(device, event)
     ccall((:vkResetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkResetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool)
     ccall((:vkCreateQueryPool, libvulkan), VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
+end
+
+function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
 end
 
 function vkDestroyQueryPool(device, queryPool, pAllocator)
     ccall((:vkDestroyQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
 end
 
+function vkDestroyQueryPool(device, queryPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
+end
+
 function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
     ccall((:vkGetQueryPoolResults, libvulkan), VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
+end
+
+function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
 end
 
 function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer)
     ccall((:vkCreateBuffer, libvulkan), VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
 end
 
+function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
+end
+
 function vkDestroyBuffer(device, buffer, pAllocator)
     ccall((:vkDestroyBuffer, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
+end
+
+function vkDestroyBuffer(device, buffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
 end
 
 function vkCreateBufferView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateBufferView, libvulkan), VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
 end
 
+function vkCreateBufferView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
+end
+
 function vkDestroyBufferView(device, bufferView, pAllocator)
     ccall((:vkDestroyBufferView, libvulkan), Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
+end
+
+function vkDestroyBufferView(device, bufferView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
 end
 
 function vkCreateImage(device, pCreateInfo, pAllocator, pImage)
     ccall((:vkCreateImage, libvulkan), VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
 end
 
+function vkCreateImage(device, pCreateInfo, pAllocator, pImage, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
+end
+
 function vkDestroyImage(device, image, pAllocator)
     ccall((:vkDestroyImage, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
+end
+
+function vkDestroyImage(device, image, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
 end
 
 function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout)
     ccall((:vkGetImageSubresourceLayout, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
 end
 
+function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
+end
+
 function vkCreateImageView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateImageView, libvulkan), VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
+end
+
+function vkCreateImageView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
 end
 
 function vkDestroyImageView(device, imageView, pAllocator)
     ccall((:vkDestroyImageView, libvulkan), Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
 end
 
+function vkDestroyImageView(device, imageView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
+end
+
 function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule)
     ccall((:vkCreateShaderModule, libvulkan), VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
+end
+
+function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
 end
 
 function vkDestroyShaderModule(device, shaderModule, pAllocator)
     ccall((:vkDestroyShaderModule, libvulkan), Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
 end
 
+function vkDestroyShaderModule(device, shaderModule, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
+end
+
 function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache)
     ccall((:vkCreatePipelineCache, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
+end
+
+function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
 end
 
 function vkDestroyPipelineCache(device, pipelineCache, pAllocator)
     ccall((:vkDestroyPipelineCache, libvulkan), Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
 end
 
+function vkDestroyPipelineCache(device, pipelineCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
+end
+
 function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData)
     ccall((:vkGetPipelineCacheData, libvulkan), VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
+end
+
+function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
 end
 
 function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergePipelineCaches, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateGraphicsPipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateComputePipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
+function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
 function vkDestroyPipeline(device, pipeline, pAllocator)
     ccall((:vkDestroyPipeline, libvulkan), Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
+end
+
+function vkDestroyPipeline(device, pipeline, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
 end
 
 function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout)
     ccall((:vkCreatePipelineLayout, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
 end
 
+function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
+end
+
 function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator)
     ccall((:vkDestroyPipelineLayout, libvulkan), Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
+end
+
+function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
 end
 
 function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler)
     ccall((:vkCreateSampler, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
 end
 
+function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
+end
+
 function vkDestroySampler(device, sampler, pAllocator)
     ccall((:vkDestroySampler, libvulkan), Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
+end
+
+function vkDestroySampler(device, sampler, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
 end
 
 function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout)
     ccall((:vkCreateDescriptorSetLayout, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
 end
 
+function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
+end
+
 function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator)
     ccall((:vkDestroyDescriptorSetLayout, libvulkan), Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
+end
+
+function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
 end
 
 function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool)
     ccall((:vkCreateDescriptorPool, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
 end
 
+function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
+end
+
 function vkDestroyDescriptorPool(device, descriptorPool, pAllocator)
     ccall((:vkDestroyDescriptorPool, libvulkan), Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
+end
+
+function vkDestroyDescriptorPool(device, descriptorPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
 end
 
 function vkResetDescriptorPool(device, descriptorPool, flags)
     ccall((:vkResetDescriptorPool, libvulkan), VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
 end
 
+function vkResetDescriptorPool(device, descriptorPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
+end
+
 function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets)
     ccall((:vkAllocateDescriptorSets, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
+end
+
+function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
 end
 
 function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets)
     ccall((:vkFreeDescriptorSets, libvulkan), VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
 end
 
+function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
+end
+
 function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
     ccall((:vkUpdateDescriptorSets, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
+end
+
+function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
 end
 
 function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer)
     ccall((:vkCreateFramebuffer, libvulkan), VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
 end
 
+function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
+end
+
 function vkDestroyFramebuffer(device, framebuffer, pAllocator)
     ccall((:vkDestroyFramebuffer, libvulkan), Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
+end
+
+function vkDestroyFramebuffer(device, framebuffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
 end
 
 function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkDestroyRenderPass(device, renderPass, pAllocator)
     ccall((:vkDestroyRenderPass, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
+end
+
+function vkDestroyRenderPass(device, renderPass, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
 end
 
 function vkGetRenderAreaGranularity(device, renderPass, pGranularity)
     ccall((:vkGetRenderAreaGranularity, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
 end
 
+function vkGetRenderAreaGranularity(device, renderPass, pGranularity, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
+end
+
 function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool)
     ccall((:vkCreateCommandPool, libvulkan), VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
+end
+
+function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
 end
 
 function vkDestroyCommandPool(device, commandPool, pAllocator)
     ccall((:vkDestroyCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
 end
 
+function vkDestroyCommandPool(device, commandPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
+end
+
 function vkResetCommandPool(device, commandPool, flags)
     ccall((:vkResetCommandPool, libvulkan), VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
+end
+
+function vkResetCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
 end
 
 function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers)
     ccall((:vkAllocateCommandBuffers, libvulkan), VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
 end
 
+function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
+end
+
 function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers)
     ccall((:vkFreeCommandBuffers, libvulkan), Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
+end
+
+function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
 end
 
 function vkBeginCommandBuffer(commandBuffer, pBeginInfo)
     ccall((:vkBeginCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
 end
 
+function vkBeginCommandBuffer(commandBuffer, pBeginInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
+end
+
 function vkEndCommandBuffer(commandBuffer)
     ccall((:vkEndCommandBuffer, libvulkan), VkResult, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkEndCommandBuffer(commandBuffer, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer,), commandBuffer)
 end
 
 function vkResetCommandBuffer(commandBuffer, flags)
     ccall((:vkResetCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
 end
 
+function vkResetCommandBuffer(commandBuffer, flags, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
+end
+
 function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline)
     ccall((:vkCmdBindPipeline, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
+end
+
+function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
 end
 
 function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports)
     ccall((:vkCmdSetViewport, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
 end
 
+function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
+end
+
 function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors)
     ccall((:vkCmdSetScissor, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
+end
+
+function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
 end
 
 function vkCmdSetLineWidth(commandBuffer, lineWidth)
     ccall((:vkCmdSetLineWidth, libvulkan), Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
 end
 
+function vkCmdSetLineWidth(commandBuffer, lineWidth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
+end
+
 function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
     ccall((:vkCmdSetDepthBias, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
+end
+
+function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
 end
 
 function vkCmdSetBlendConstants(commandBuffer, blendConstants)
     ccall((:vkCmdSetBlendConstants, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
 end
 
+function vkCmdSetBlendConstants(commandBuffer, blendConstants, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
+end
+
 function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds)
     ccall((:vkCmdSetDepthBounds, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
+end
+
+function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
 end
 
 function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask)
     ccall((:vkCmdSetStencilCompareMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
 end
 
+function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
+end
+
 function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask)
     ccall((:vkCmdSetStencilWriteMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
+end
+
+function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
 end
 
 function vkCmdSetStencilReference(commandBuffer, faceMask, reference)
     ccall((:vkCmdSetStencilReference, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
 end
 
+function vkCmdSetStencilReference(commandBuffer, faceMask, reference, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
+end
+
 function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
     ccall((:vkCmdBindDescriptorSets, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
+end
+
+function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
 end
 
 function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType)
     ccall((:vkCmdBindIndexBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
 end
 
+function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
+end
+
 function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
     ccall((:vkCmdBindVertexBuffers, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
+end
+
+function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
 end
 
 function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
     ccall((:vkCmdDraw, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
 end
 
+function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
+end
+
 function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
     ccall((:vkCmdDrawIndexed, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
+end
+
+function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
 end
 
 function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndexedIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
 function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatch, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
 end
 
+function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
+end
+
 function vkCmdDispatchIndirect(commandBuffer, buffer, offset)
     ccall((:vkCmdDispatchIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
+end
+
+function vkCmdDispatchIndirect(commandBuffer, buffer, offset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
 end
 
 function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
     ccall((:vkCmdBlitImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
 end
 
+function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
+end
+
 function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyBufferToImage, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyImageToBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData)
     ccall((:vkCmdUpdateBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
+end
+
+function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
 end
 
 function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data)
     ccall((:vkCmdFillBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
 end
 
+function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
+end
+
 function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
     ccall((:vkCmdClearColorImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
+end
+
+function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
 end
 
 function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
     ccall((:vkCmdClearDepthStencilImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
 end
 
+function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
+end
+
 function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
     ccall((:vkCmdClearAttachments, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
+end
+
+function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
 end
 
 function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdResolveImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
+function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
 function vkCmdSetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdSetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
+function vkCmdSetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
 function vkCmdResetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
+function vkCmdResetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
 function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdWaitEvents, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
+function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
 function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdPipelineBarrier, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
+function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
 function vkCmdBeginQuery(commandBuffer, queryPool, query, flags)
     ccall((:vkCmdBeginQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
+end
+
+function vkCmdBeginQuery(commandBuffer, queryPool, query, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
 end
 
 function vkCmdEndQuery(commandBuffer, queryPool, query)
     ccall((:vkCmdEndQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
 end
 
+function vkCmdEndQuery(commandBuffer, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
+end
+
 function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount)
     ccall((:vkCmdResetQueryPool, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
+end
+
+function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
 end
 
 function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query)
     ccall((:vkCmdWriteTimestamp, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
+end
+
 function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
     ccall((:vkCmdCopyQueryPoolResults, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
+end
+
+function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
 end
 
 function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues)
     ccall((:vkCmdPushConstants, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
 end
 
+function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
+end
+
 function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents)
     ccall((:vkCmdBeginRenderPass, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
+end
+
+function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
 end
 
 function vkCmdNextSubpass(commandBuffer, contents)
     ccall((:vkCmdNextSubpass, libvulkan), Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
 end
 
+function vkCmdNextSubpass(commandBuffer, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
+end
+
 function vkCmdEndRenderPass(commandBuffer)
     ccall((:vkCmdEndRenderPass, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndRenderPass(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers)
     ccall((:vkCmdExecuteCommands, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
+end
+
+function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
 end
 
 const VkSamplerYcbcrConversion_T = Cvoid
@@ -5017,112 +5565,224 @@ function vkEnumerateInstanceVersion(pApiVersion)
     ccall((:vkEnumerateInstanceVersion, libvulkan), VkResult, (Ptr{UInt32},), pApiVersion)
 end
 
+function vkEnumerateInstanceVersion(pApiVersion, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32},), pApiVersion)
+end
+
 function vkBindBufferMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindBufferMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 function vkBindImageMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindImageMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
     ccall((:vkGetDeviceGroupPeerMemoryFeatures, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
+function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
 function vkCmdSetDeviceMask(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMask, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMask(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBase, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroups, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
+function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
 function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
 function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
+function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
 function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
 function vkTrimCommandPool(device, commandPool, flags)
     ccall((:vkTrimCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
+function vkTrimCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
 function vkGetDeviceQueue2(device, pQueueInfo, pQueue)
     ccall((:vkGetDeviceQueue2, libvulkan), Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
 end
 
+function vkGetDeviceQueue2(device, pQueueInfo, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
+end
+
 function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion)
     ccall((:vkCreateSamplerYcbcrConversion, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
+function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
 function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversion, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
+function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
 function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
     ccall((:vkCreateDescriptorUpdateTemplate, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
+function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
 function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
+function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
 function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFenceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphoreProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
+function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
 function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupport, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
+function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
 @cenum VkDriverId::UInt32 begin
@@ -5822,52 +6482,104 @@ function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, coun
     ccall((:vkCmdDrawIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 function vkResetQueryPool(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
+function vkResetQueryPool(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
 function vkGetSemaphoreCounterValue(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValue, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
+function vkGetSemaphoreCounterValue(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
 function vkWaitSemaphores(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphores, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphores(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphore(device, pSignalInfo)
     ccall((:vkSignalSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphore(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 function vkGetBufferDeviceAddress(device, pInfo)
     ccall((:vkGetBufferDeviceAddress, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddress(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkSurfaceKHR_T = Cvoid
@@ -5968,20 +6680,40 @@ function vkDestroySurfaceKHR(instance, surface, pAllocator)
     ccall((:vkDestroySurfaceKHR, libvulkan), Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
 end
 
+function vkDestroySurfaceKHR(instance, surface, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
+end
+
 function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported)
     ccall((:vkGetPhysicalDeviceSurfaceSupportKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
+end
+
+function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
 end
 
 function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormatsKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
 end
 
+function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
+end
+
 function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes)
     ccall((:vkGetPhysicalDeviceSurfacePresentModesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
+end
+
+function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
 end
 
 const VkSwapchainKHR_T = Cvoid
@@ -6114,36 +6846,72 @@ function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain)
     ccall((:vkCreateSwapchainKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
 end
 
+function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
+end
+
 function vkDestroySwapchainKHR(device, swapchain, pAllocator)
     ccall((:vkDestroySwapchainKHR, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
+end
+
+function vkDestroySwapchainKHR(device, swapchain, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
 end
 
 function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages)
     ccall((:vkGetSwapchainImagesKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
 end
 
+function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
+end
+
 function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex)
     ccall((:vkAcquireNextImageKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
+end
+
+function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
 end
 
 function vkQueuePresentKHR(queue, pPresentInfo)
     ccall((:vkQueuePresentKHR, libvulkan), VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
 end
 
+function vkQueuePresentKHR(queue, pPresentInfo, fptr)
+    ccall(fptr, VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
+end
+
 function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities)
     ccall((:vkGetDeviceGroupPresentCapabilitiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
+end
+
+function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
 end
 
 function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes)
     ccall((:vkGetDeviceGroupSurfacePresentModesKHR, libvulkan), VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
 end
 
+function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
+end
+
 function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects)
     ccall((:vkGetPhysicalDevicePresentRectanglesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
 end
 
+function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
+end
+
 function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex)
     ccall((:vkAcquireNextImage2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
+end
+
+function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
 end
 
 const VkDisplayKHR_T = Cvoid
@@ -6250,28 +7018,56 @@ function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount,
     ccall((:vkGetPhysicalDeviceDisplayPropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlanePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays)
     ccall((:vkGetDisplayPlaneSupportedDisplaysKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
 end
 
+function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
+end
+
 function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
+function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
 function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode)
     ccall((:vkCreateDisplayModeKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
 end
 
+function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
+end
+
 function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
 end
 
+function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
+end
+
 function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateDisplayPlaneSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
+function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
 struct VkDisplayPresentInfoKHR
@@ -6287,6 +7083,10 @@ const PFN_vkCreateSharedSwapchainsKHR = Ptr{Cvoid}
 
 function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
     ccall((:vkCreateSharedSwapchainsKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
+end
+
+function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
 end
 
 const VkRenderPassMultiviewCreateInfoKHR = VkRenderPassMultiviewCreateInfo
@@ -6338,28 +7138,56 @@ function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
 const VkPeerMemoryFeatureFlagsKHR = VkPeerMemoryFeatureFlags
@@ -6397,12 +7225,24 @@ function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceInd
     ccall((:vkGetDeviceGroupPeerMemoryFeaturesKHR, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
+function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
 function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMaskKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBaseKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 const VkCommandPoolTrimFlagsKHR = VkCommandPoolTrimFlags
@@ -6414,6 +7254,10 @@ function vkTrimCommandPoolKHR(device, commandPool, flags)
     ccall((:vkTrimCommandPoolKHR, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
+function vkTrimCommandPoolKHR(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
 const VkPhysicalDeviceGroupPropertiesKHR = VkPhysicalDeviceGroupProperties
 
 const VkDeviceGroupDeviceCreateInfoKHR = VkDeviceGroupDeviceCreateInfo
@@ -6423,6 +7267,10 @@ const PFN_vkEnumeratePhysicalDeviceGroupsKHR = Ptr{Cvoid}
 
 function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroupsKHR, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
+function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
 const VkExternalMemoryHandleTypeFlagsKHR = VkExternalMemoryHandleTypeFlags
@@ -6450,6 +7298,10 @@ const PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferPropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
+function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
 const VkExternalMemoryImageCreateInfoKHR = VkExternalMemoryImageCreateInfo
@@ -6488,8 +7340,16 @@ function vkGetMemoryFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetMemoryFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
+function vkGetMemoryFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
 function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties)
     ccall((:vkGetMemoryFdPropertiesKHR, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
+end
+
+function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
 end
 
 const VkExternalSemaphoreHandleTypeFlagsKHR = VkExternalSemaphoreHandleTypeFlags
@@ -6509,6 +7369,10 @@ const PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphorePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
+function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
 const VkSemaphoreImportFlagsKHR = VkSemaphoreImportFlags
@@ -6543,8 +7407,16 @@ function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo)
     ccall((:vkImportSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
 end
 
+function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
+end
+
 function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 struct VkPhysicalDevicePushDescriptorPropertiesKHR
@@ -6563,8 +7435,16 @@ function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set
     ccall((:vkCmdPushDescriptorSetKHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
 end
 
+function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
+end
+
 function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData)
     ccall((:vkCmdPushDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
+end
+
+function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
 end
 
 const VkPhysicalDeviceShaderFloat16Int8FeaturesKHR = VkPhysicalDeviceShaderFloat16Int8Features
@@ -6614,12 +7494,24 @@ function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pD
     ccall((:vkCreateDescriptorUpdateTemplateKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
+function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
 function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 const VkPhysicalDeviceImagelessFramebufferFeaturesKHR = VkPhysicalDeviceImagelessFramebufferFeatures
@@ -6660,16 +7552,32 @@ function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 struct VkSharedPresentSurfaceCapabilitiesKHR
@@ -6683,6 +7591,10 @@ const PFN_vkGetSwapchainStatusKHR = Ptr{Cvoid}
 
 function vkGetSwapchainStatusKHR(device, swapchain)
     ccall((:vkGetSwapchainStatusKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
+end
+
+function vkGetSwapchainStatusKHR(device, swapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
 end
 
 const VkExternalFenceHandleTypeFlagsKHR = VkExternalFenceHandleTypeFlags
@@ -6702,6 +7614,10 @@ const PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFencePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 const VkFenceImportFlagsKHR = VkFenceImportFlags
@@ -6736,8 +7652,16 @@ function vkImportFenceFdKHR(device, pImportFenceFdInfo)
     ccall((:vkImportFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
 end
 
+function vkImportFenceFdKHR(device, pImportFenceFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
+end
+
 function vkGetFenceFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetFenceFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 @cenum VkPerformanceCounterUnitKHR::UInt32 begin
@@ -6884,16 +7808,32 @@ function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physica
     ccall((:vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
 end
 
+function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
+end
+
 function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
     ccall((:vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
+end
+
+function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
 end
 
 function vkAcquireProfilingLockKHR(device, pInfo)
     ccall((:vkAcquireProfilingLockKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
 end
 
+function vkAcquireProfilingLockKHR(device, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
+end
+
 function vkReleaseProfilingLockKHR(device)
     ccall((:vkReleaseProfilingLockKHR, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkReleaseProfilingLockKHR(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 const VkPointClippingBehaviorKHR = VkPointClippingBehavior
@@ -6938,8 +7878,16 @@ function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormats2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
+end
+
+function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
 end
 
 const VkPhysicalDeviceVariablePointerFeaturesKHR = VkPhysicalDeviceVariablePointersFeatures
@@ -6993,16 +7941,32 @@ function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount
     ccall((:vkGetPhysicalDeviceDisplayProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlaneProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModeProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
+function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
 function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
+end
+
+function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
 end
 
 const VkMemoryDedicatedRequirementsKHR = VkMemoryDedicatedRequirements
@@ -7032,12 +7996,24 @@ function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 const VkImageFormatListCreateInfoKHR = VkImageFormatListCreateInfo
@@ -7072,8 +8048,16 @@ function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcb
     ccall((:vkCreateSamplerYcbcrConversionKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
+function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
 function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversionKHR, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
+function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
 const VkBindBufferMemoryInfoKHR = VkBindBufferMemoryInfo
@@ -7090,8 +8074,16 @@ function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 const VkPhysicalDeviceMaintenance3PropertiesKHR = VkPhysicalDeviceMaintenance3Properties
@@ -7105,6 +8097,10 @@ function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupportKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
+function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountKHR ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
 const PFN_vkCmdDrawIndirectCountKHR = Ptr{Cvoid}
 
@@ -7115,8 +8111,16 @@ function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 const VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR = VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures
@@ -7181,12 +8185,24 @@ function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValueKHR, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
+function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
 function vkWaitSemaphoresKHR(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphoresKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphoresKHR(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphoreKHR(device, pSignalInfo)
     ccall((:vkSignalSemaphoreKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphoreKHR(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR = VkPhysicalDeviceVulkanMemoryModelFeatures
@@ -7267,8 +8283,16 @@ function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentSha
     ccall((:vkGetPhysicalDeviceFragmentShadingRatesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
 end
 
+function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
+end
+
 function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps)
     ccall((:vkCmdSetFragmentShadingRateKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
+end
+
+function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
 end
 
 struct VkSurfaceProtectedCapabilitiesKHR
@@ -7308,12 +8332,24 @@ function vkGetBufferDeviceAddressKHR(device, pInfo)
     ccall((:vkGetBufferDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkDeferredOperationKHR_T = Cvoid
@@ -7339,20 +8375,40 @@ function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation)
     ccall((:vkCreateDeferredOperationKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
 end
 
+function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
+end
+
 function vkDestroyDeferredOperationKHR(device, operation, pAllocator)
     ccall((:vkDestroyDeferredOperationKHR, libvulkan), Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
+end
+
+function vkDestroyDeferredOperationKHR(device, operation, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
 end
 
 function vkGetDeferredOperationMaxConcurrencyKHR(device, operation)
     ccall((:vkGetDeferredOperationMaxConcurrencyKHR, libvulkan), UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationMaxConcurrencyKHR(device, operation, fptr)
+    ccall(fptr, UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkGetDeferredOperationResultKHR(device, operation)
     ccall((:vkGetDeferredOperationResultKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationResultKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkDeferredOperationJoinKHR(device, operation)
     ccall((:vkDeferredOperationJoinKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
+function vkDeferredOperationJoinKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
 @cenum VkPipelineExecutableStatisticFormatKHR::UInt32 begin
@@ -7446,12 +8502,24 @@ function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutable
     ccall((:vkGetPipelineExecutablePropertiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
 end
 
+function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutableCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
+end
+
 function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics)
     ccall((:vkGetPipelineExecutableStatisticsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
 end
 
+function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
+end
+
 function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
     ccall((:vkGetPipelineExecutableInternalRepresentationsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
+end
+
+function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
 end
 
 struct VkPipelineLibraryCreateInfoKHR
@@ -7603,32 +8671,64 @@ function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo)
     ccall((:vkCmdSetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
 end
 
+function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
+end
+
 function vkCmdResetEvent2KHR(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
+end
+
+function vkCmdResetEvent2KHR(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
 end
 
 function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos)
     ccall((:vkCmdWaitEvents2KHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
 end
 
+function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
+end
+
 function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo)
     ccall((:vkCmdPipelineBarrier2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
+end
+
+function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
 end
 
 function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query)
     ccall((:vkCmdWriteTimestamp2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
+end
+
 function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit2KHR, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
+function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
 function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarker2AMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
 end
 
+function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
+end
+
 function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointData2NV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR
@@ -7779,24 +8879,48 @@ function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo)
     ccall((:vkCmdCopyBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
 end
 
+function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
+end
+
 function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo)
     ccall((:vkCmdCopyImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
+end
+
+function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
 end
 
 function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo)
     ccall((:vkCmdCopyBufferToImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
 end
 
+function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
+end
+
 function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo)
     ccall((:vkCmdCopyImageToBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
+end
+
+function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
 end
 
 function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo)
     ccall((:vkCmdBlitImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
 end
 
+function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
+end
+
 function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo)
     ccall((:vkCmdResolveImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
+end
+
+function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
 end
 
 const VkDebugReportCallbackEXT_T = Cvoid
@@ -7882,12 +9006,24 @@ function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCall
     ccall((:vkCreateDebugReportCallbackEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
 end
 
+function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
+end
+
 function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator)
     ccall((:vkDestroyDebugReportCallbackEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
 end
 
+function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
+end
+
 function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
     ccall((:vkDebugReportMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
+end
+
+function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
 end
 
 @cenum VkRasterizationOrderAMD::UInt32 begin
@@ -7946,20 +9082,40 @@ function vkDebugMarkerSetObjectTagEXT(device, pTagInfo)
     ccall((:vkDebugMarkerSetObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
 end
 
+function vkDebugMarkerSetObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
+end
+
 function vkDebugMarkerSetObjectNameEXT(device, pNameInfo)
     ccall((:vkDebugMarkerSetObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
+end
+
+function vkDebugMarkerSetObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
 end
 
 function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerBeginEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdDebugMarkerEndEXT(commandBuffer)
     ccall((:vkCmdDebugMarkerEndEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdDebugMarkerEndEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerInsertEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
 struct VkDedicatedAllocationImageCreateInfoNV
@@ -8034,24 +9190,48 @@ function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindi
     ccall((:vkCmdBindTransformFeedbackBuffersEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
 end
 
+function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
+end
+
 function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdBeginTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
+function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
 function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdEndTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
+function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
 function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index)
     ccall((:vkCmdBeginQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
+end
+
+function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
 end
 
 function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index)
     ccall((:vkCmdEndQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
 end
 
+function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
+end
+
 function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
     ccall((:vkCmdDrawIndirectByteCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
+end
+
+function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
 end
 
 struct VkImageViewHandleInfoNVX
@@ -8079,8 +9259,16 @@ function vkGetImageViewHandleNVX(device, pInfo)
     ccall((:vkGetImageViewHandleNVX, libvulkan), UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
 end
 
+function vkGetImageViewHandleNVX(device, pInfo, fptr)
+    ccall(fptr, UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
+end
+
 function vkGetImageViewAddressNVX(device, imageView, pProperties)
     ccall((:vkGetImageViewAddressNVX, libvulkan), VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
+end
+
+function vkGetImageViewAddressNVX(device, imageView, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
 end
 
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountAMD ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
@@ -8093,8 +9281,16 @@ function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkTextureLODGatherFormatPropertiesAMD
@@ -8135,6 +9331,10 @@ function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, 
     ccall((:vkGetShaderInfoAMD, libvulkan), VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
 end
 
+function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
+end
+
 struct VkPhysicalDeviceCornerSampledImageFeaturesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8172,6 +9372,10 @@ const PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
     ccall((:vkGetPhysicalDeviceExternalImageFormatPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
 end
 
 struct VkExternalMemoryImageCreateInfoNV
@@ -8255,8 +9459,16 @@ function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingB
     ccall((:vkCmdBeginConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
 end
 
+function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
+end
+
 function vkCmdEndConditionalRenderingEXT(commandBuffer)
     ccall((:vkCmdEndConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkCmdEndConditionalRenderingEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
 struct VkViewportWScalingNV
@@ -8279,11 +9491,19 @@ function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount,
     ccall((:vkCmdSetViewportWScalingNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
 end
 
+function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
+end
+
 # typedef VkResult ( VKAPI_PTR * PFN_vkReleaseDisplayEXT ) ( VkPhysicalDevice physicalDevice , VkDisplayKHR display )
 const PFN_vkReleaseDisplayEXT = Ptr{Cvoid}
 
 function vkReleaseDisplayEXT(physicalDevice, display)
     ccall((:vkReleaseDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
+function vkReleaseDisplayEXT(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
 @cenum VkSurfaceCounterFlagBitsEXT::UInt32 begin
@@ -8315,6 +9535,10 @@ const PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2EXT, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
+function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
 @cenum VkDisplayPowerStateEXT::UInt32 begin
@@ -8374,16 +9598,32 @@ function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo)
     ccall((:vkDisplayPowerControlEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
 end
 
+function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
+end
+
 function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDeviceEventEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
+end
+
+function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
 end
 
 function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDisplayEventEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
 end
 
+function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
+end
+
 function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue)
     ccall((:vkGetSwapchainCounterEXT, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
+end
+
+function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
 end
 
 struct VkRefreshCycleDurationGOOGLE
@@ -8420,8 +9660,16 @@ function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProper
     ccall((:vkGetRefreshCycleDurationGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
 end
 
+function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
+end
+
 function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings)
     ccall((:vkGetPastPresentationTimingGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
+end
+
+function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
 end
 
 struct VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX
@@ -8487,6 +9735,10 @@ const PFN_vkCmdSetDiscardRectangleEXT = Ptr{Cvoid}
 
 function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
     ccall((:vkCmdSetDiscardRectangleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
+end
+
+function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
 end
 
 @cenum VkConservativeRasterizationModeEXT::UInt32 begin
@@ -8558,6 +9810,10 @@ const PFN_vkSetHdrMetadataEXT = Ptr{Cvoid}
 
 function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata)
     ccall((:vkSetHdrMetadataEXT, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
+end
+
+function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
 end
 
 const VkDebugUtilsMessengerEXT_T = Cvoid
@@ -8677,44 +9933,88 @@ function vkSetDebugUtilsObjectNameEXT(device, pNameInfo)
     ccall((:vkSetDebugUtilsObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
 end
 
+function vkSetDebugUtilsObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
+end
+
 function vkSetDebugUtilsObjectTagEXT(device, pTagInfo)
     ccall((:vkSetDebugUtilsObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
+end
+
+function vkSetDebugUtilsObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
 end
 
 function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkQueueEndDebugUtilsLabelEXT(queue)
     ccall((:vkQueueEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue,), queue)
+end
+
+function vkQueueEndDebugUtilsLabelEXT(queue, fptr)
+    ccall(fptr, Cvoid, (VkQueue,), queue)
 end
 
 function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCmdEndDebugUtilsLabelEXT(commandBuffer)
     ccall((:vkCmdEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndDebugUtilsLabelEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger)
     ccall((:vkCreateDebugUtilsMessengerEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
 end
 
+function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
+end
+
 function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator)
     ccall((:vkDestroyDebugUtilsMessengerEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
 end
 
+function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
+end
+
 function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData)
     ccall((:vkSubmitDebugUtilsMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
+end
+
+function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
 end
 
 const VkSamplerReductionModeEXT = VkSamplerReductionMode
@@ -8819,8 +10119,16 @@ function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo)
     ccall((:vkCmdSetSampleLocationsEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
 end
 
+function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
+end
+
 function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties)
     ccall((:vkGetPhysicalDeviceMultisamplePropertiesEXT, libvulkan), Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
+end
+
+function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
 end
 
 @cenum VkBlendOverlapEXT::UInt32 begin
@@ -8948,6 +10256,10 @@ function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties)
     ccall((:vkGetImageDrmFormatModifierPropertiesEXT, libvulkan), VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
 end
 
+function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
+end
+
 const VkValidationCacheEXT_T = Cvoid
 
 const VkValidationCacheEXT = Ptr{VkValidationCacheEXT_T}
@@ -8989,16 +10301,32 @@ function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidation
     ccall((:vkCreateValidationCacheEXT, libvulkan), VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
 end
 
+function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
+end
+
 function vkDestroyValidationCacheEXT(device, validationCache, pAllocator)
     ccall((:vkDestroyValidationCacheEXT, libvulkan), Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
+end
+
+function vkDestroyValidationCacheEXT(device, validationCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
 end
 
 function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergeValidationCachesEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData)
     ccall((:vkGetValidationCacheDataEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
+end
+
+function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
 end
 
 const VkDescriptorBindingFlagBitsEXT = VkDescriptorBindingFlagBits
@@ -9101,12 +10429,24 @@ function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout)
     ccall((:vkCmdBindShadingRateImageNV, libvulkan), Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
 end
 
+function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
+end
+
 function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
     ccall((:vkCmdSetViewportShadingRatePaletteNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
 end
 
+function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
+end
+
 function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
     ccall((:vkCmdSetCoarseSampleOrderNV, libvulkan), Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
+end
+
+function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
 end
 
 const VkAccelerationStructureNV_T = Cvoid
@@ -9433,52 +10773,104 @@ function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccel
     ccall((:vkCreateAccelerationStructureNV, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureNV, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements)
     ccall((:vkGetAccelerationStructureMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
+end
+
 function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos)
     ccall((:vkBindAccelerationStructureMemoryNV, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
 end
 
 function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
     ccall((:vkCmdBuildAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
 end
 
+function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
+end
+
 function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode)
     ccall((:vkCmdCopyAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
+end
+
+function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
 end
 
 function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
     ccall((:vkCmdTraceRaysNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
 end
 
+function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesNV, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
+function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
 function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData)
     ccall((:vkGetAccelerationStructureHandleNV, libvulkan), VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
 end
 
+function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
+function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
 function vkCompileDeferredNV(device, pipeline, shader)
     ccall((:vkCompileDeferredNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
+end
+
+function vkCompileDeferredNV(device, pipeline, shader, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
 end
 
 struct VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV
@@ -9546,11 +10938,19 @@ function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, p
     ccall((:vkGetMemoryHostPointerPropertiesEXT, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
 end
 
+function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, pMemoryHostPointerProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdWriteBufferMarkerAMD ) ( VkCommandBuffer commandBuffer , VkPipelineStageFlagBits pipelineStage , VkBuffer dstBuffer , VkDeviceSize dstOffset , uint32_t marker )
 const PFN_vkCmdWriteBufferMarkerAMD = Ptr{Cvoid}
 
 function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarkerAMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
+end
+
+function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
 end
 
 @cenum VkPipelineCompilerControlFlagBitsAMD::UInt32 begin
@@ -9589,8 +10989,16 @@ function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDom
     ccall((:vkGetPhysicalDeviceCalibrateableTimeDomainsEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
 end
 
+function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDomainCount, pTimeDomains, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
+end
+
 function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
     ccall((:vkGetCalibratedTimestampsEXT, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
+end
+
+function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
 end
 
 struct VkPhysicalDeviceShaderCorePropertiesAMD
@@ -9722,12 +11130,24 @@ function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask)
     ccall((:vkCmdDrawMeshTasksNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
 end
 
+function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
+end
+
 function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectCountNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV
@@ -9762,6 +11182,10 @@ function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclus
     ccall((:vkCmdSetExclusiveScissorNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
 end
 
+function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
+end
+
 struct VkQueueFamilyCheckpointPropertiesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -9785,8 +11209,16 @@ function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker)
     ccall((:vkCmdSetCheckpointNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
 end
 
+function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
+end
+
 function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointDataNV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL
@@ -9930,36 +11362,72 @@ function vkInitializePerformanceApiINTEL(device, pInitializeInfo)
     ccall((:vkInitializePerformanceApiINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
 end
 
+function vkInitializePerformanceApiINTEL(device, pInitializeInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
+end
+
 function vkUninitializePerformanceApiINTEL(device)
     ccall((:vkUninitializePerformanceApiINTEL, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkUninitializePerformanceApiINTEL(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceStreamMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
 function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo)
     ccall((:vkCmdSetPerformanceOverrideINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
 end
 
+function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
+end
+
 function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration)
     ccall((:vkAcquirePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
+end
+
+function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
 end
 
 function vkReleasePerformanceConfigurationINTEL(device, configuration)
     ccall((:vkReleasePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
 end
 
+function vkReleasePerformanceConfigurationINTEL(device, configuration, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
+end
+
 function vkQueueSetPerformanceConfigurationINTEL(queue, configuration)
     ccall((:vkQueueSetPerformanceConfigurationINTEL, libvulkan), VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
 end
 
+function vkQueueSetPerformanceConfigurationINTEL(queue, configuration, fptr)
+    ccall(fptr, VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
+end
+
 function vkGetPerformanceParameterINTEL(device, parameter, pValue)
     ccall((:vkGetPerformanceParameterINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
+end
+
+function vkGetPerformanceParameterINTEL(device, parameter, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
 end
 
 struct VkPhysicalDevicePCIBusInfoPropertiesEXT
@@ -9988,6 +11456,10 @@ const PFN_vkSetLocalDimmingAMD = Ptr{Cvoid}
 
 function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable)
     ccall((:vkSetLocalDimmingAMD, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
+end
+
+function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
 end
 
 struct VkPhysicalDeviceFragmentDensityMapFeaturesEXT
@@ -10112,6 +11584,10 @@ function vkGetBufferDeviceAddressEXT(device, pInfo)
     ccall((:vkGetBufferDeviceAddressEXT, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressEXT(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 @cenum VkToolPurposeFlagBitsEXT::UInt32 begin
     VK_TOOL_PURPOSE_VALIDATION_BIT_EXT = 1
     VK_TOOL_PURPOSE_PROFILING_BIT_EXT = 2
@@ -10140,6 +11616,10 @@ const PFN_vkGetPhysicalDeviceToolPropertiesEXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties)
     ccall((:vkGetPhysicalDeviceToolPropertiesEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
+end
+
+function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
 end
 
 const VkImageStencilUsageCreateInfoEXT = VkImageStencilUsageCreateInfo
@@ -10229,6 +11709,10 @@ function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPrope
     ccall((:vkGetPhysicalDeviceCooperativeMatrixPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
+end
+
 @cenum VkCoverageReductionModeNV::UInt32 begin
     VK_COVERAGE_REDUCTION_MODE_MERGE_NV = 0
     VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV = 1
@@ -10264,6 +11748,10 @@ const PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV = Pt
 
 function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations)
     ccall((:vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
+end
+
+function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
 end
 
 struct VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT
@@ -10321,6 +11809,10 @@ function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateHeadlessSurfaceEXT, libvulkan), VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 @cenum VkLineRasterizationModeEXT::UInt32 begin
     VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT = 0
     VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT = 1
@@ -10362,6 +11854,10 @@ function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePat
     ccall((:vkCmdSetLineStippleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
 end
 
+function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
+end
+
 struct VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10386,6 +11882,10 @@ const PFN_vkResetQueryPoolEXT = Ptr{Cvoid}
 
 function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPoolEXT, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
+function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
 struct VkPhysicalDeviceIndexTypeUint8FeaturesEXT
@@ -10440,48 +11940,96 @@ function vkCmdSetCullModeEXT(commandBuffer, cullMode)
     ccall((:vkCmdSetCullModeEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
 end
 
+function vkCmdSetCullModeEXT(commandBuffer, cullMode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
+end
+
 function vkCmdSetFrontFaceEXT(commandBuffer, frontFace)
     ccall((:vkCmdSetFrontFaceEXT, libvulkan), Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
+end
+
+function vkCmdSetFrontFaceEXT(commandBuffer, frontFace, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
 end
 
 function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology)
     ccall((:vkCmdSetPrimitiveTopologyEXT, libvulkan), Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
 end
 
+function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
+end
+
 function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports)
     ccall((:vkCmdSetViewportWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
+end
+
+function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
 end
 
 function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors)
     ccall((:vkCmdSetScissorWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
 end
 
+function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
+end
+
 function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
     ccall((:vkCmdBindVertexBuffers2EXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
+end
+
+function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
 end
 
 function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable)
     ccall((:vkCmdSetDepthTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
 end
 
+function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
+end
+
 function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable)
     ccall((:vkCmdSetDepthWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
+end
+
+function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
 end
 
 function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp)
     ccall((:vkCmdSetDepthCompareOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
 end
 
+function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
+end
+
 function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable)
     ccall((:vkCmdSetDepthBoundsTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
+end
+
+function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
 end
 
 function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable)
     ccall((:vkCmdSetStencilTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
 end
 
+function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
+end
+
 function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
     ccall((:vkCmdSetStencilOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
+end
+
+function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
 end
 
 struct VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT
@@ -10663,24 +12211,48 @@ function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequir
     ccall((:vkGetGeneratedCommandsMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo)
     ccall((:vkCmdPreprocessGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
+end
+
+function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
 end
 
 function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
     ccall((:vkCmdExecuteGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
 end
 
+function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
+end
+
 function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex)
     ccall((:vkCmdBindPipelineShaderGroupNV, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
+end
+
+function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
 end
 
 function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
     ccall((:vkCreateIndirectCommandsLayoutNV, libvulkan), VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
 end
 
+function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
+end
+
 function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator)
     ccall((:vkDestroyIndirectCommandsLayoutNV, libvulkan), Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
+end
+
+function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
 end
 
 struct VkPhysicalDeviceInheritedViewportScissorFeaturesNV
@@ -10844,16 +12416,32 @@ function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDat
     ccall((:vkCreatePrivateDataSlotEXT, libvulkan), VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
 end
 
+function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDataSlot, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
+end
+
 function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator)
     ccall((:vkDestroyPrivateDataSlotEXT, libvulkan), Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
+end
+
+function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
 end
 
 function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data)
     ccall((:vkSetPrivateDataEXT, libvulkan), VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
 end
 
+function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
+end
+
 function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData)
     ccall((:vkGetPrivateDataEXT, libvulkan), Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
+end
+
+function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
 end
 
 struct VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT
@@ -10934,6 +12522,10 @@ function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerO
     ccall((:vkCmdSetFragmentShadingRateEnumNV, libvulkan), Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
 end
 
+function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
+end
+
 struct VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10984,8 +12576,16 @@ function vkAcquireWinrtDisplayNV(physicalDevice, display)
     ccall((:vkAcquireWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
+function vkAcquireWinrtDisplayNV(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
 function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay)
     ccall((:vkGetWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
+end
+
+function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
 end
 
 struct VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE
@@ -11037,6 +12637,10 @@ function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pV
     ccall((:vkCmdSetVertexInputEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
 end
 
+function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
+end
+
 struct VkPhysicalDeviceExtendedDynamicState2FeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -11064,20 +12668,40 @@ function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints)
     ccall((:vkCmdSetPatchControlPointsEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
 end
 
+function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
+end
+
 function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable)
     ccall((:vkCmdSetRasterizerDiscardEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
+end
+
+function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
 end
 
 function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable)
     ccall((:vkCmdSetDepthBiasEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
 end
 
+function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
+end
+
 function vkCmdSetLogicOpEXT(commandBuffer, logicOp)
     ccall((:vkCmdSetLogicOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
 end
 
+function vkCmdSetLogicOpEXT(commandBuffer, logicOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
+end
+
 function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable)
     ccall((:vkCmdSetPrimitiveRestartEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
+end
+
+function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
 end
 
 struct VkPhysicalDeviceColorWriteEnableFeaturesEXT
@@ -11098,6 +12722,10 @@ const PFN_vkCmdSetColorWriteEnableEXT = Ptr{Cvoid}
 
 function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables)
     ccall((:vkCmdSetColorWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
+end
+
+function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
 end
 
 const VkAccelerationStructureKHR_T = Cvoid
@@ -11386,64 +13014,128 @@ function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAcce
     ccall((:vkCreateAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkCmdBuildAccelerationStructuresKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
     ccall((:vkCmdBuildAccelerationStructuresIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
+end
+
+function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
 end
 
 function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkBuildAccelerationStructuresKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureToMemoryKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
 end
 
+function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
+end
+
 function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyMemoryToAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
     ccall((:vkWriteAccelerationStructuresPropertiesKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
 end
 
+function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
+end
+
 function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureToMemoryKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
 end
 
+function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
+end
+
 function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyMemoryToAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo)
     ccall((:vkGetAccelerationStructureDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
 end
 
+function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
+function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
 function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility)
     ccall((:vkGetDeviceAccelerationStructureCompatibilityKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
 end
 
+function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
+end
+
 function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
     ccall((:vkGetAccelerationStructureBuildSizesKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
+end
+
+function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
 end
 
 @cenum VkShaderGroupShaderKHR::UInt32 begin
@@ -11546,24 +13238,48 @@ function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShader
     ccall((:vkCmdTraceRaysKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
 end
 
+function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingCaptureReplayShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
     ccall((:vkCmdTraceRaysIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
+end
+
+function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
 end
 
 function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader)
     ccall((:vkGetRayTracingShaderGroupStackSizeKHR, libvulkan), VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
 end
 
+function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader, fptr)
+    ccall(fptr, VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
+end
+
 function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize)
     ccall((:vkCmdSetRayTracingPipelineStackSizeKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
+end
+
+function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
 end
 
 struct VkPhysicalDeviceRayQueryFeaturesKHR
@@ -11596,8 +13312,16 @@ function vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateWaylandSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkWaylandSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkWaylandSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display)
     ccall((:vkGetPhysicalDeviceWaylandPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{wl_display}), physicalDevice, queueFamilyIndex, display)
+end
+
+function vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{wl_display}), physicalDevice, queueFamilyIndex, display)
 end
 
 const VkXcbSurfaceCreateFlagsKHR = VkFlags
@@ -11620,8 +13344,16 @@ function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXcbSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id)
     ccall((:vkGetPhysicalDeviceXcbPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
+end
+
+function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
 end
 
 const VkXlibSurfaceCreateFlagsKHR = VkFlags
@@ -11644,8 +13376,16 @@ function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXlibSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID)
     ccall((:vkGetPhysicalDeviceXlibPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
+end
+
+function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
 end
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkAcquireXlibDisplayEXT ) ( VkPhysicalDevice physicalDevice , Display * dpy , VkDisplayKHR display )
@@ -11658,8 +13398,16 @@ function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display)
     ccall((:vkAcquireXlibDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
 end
 
+function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
+end
+
 function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay)
     ccall((:vkGetRandROutputDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
+end
+
+function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
 end
 
 const VULKAN_H_ = 1

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -3200,6 +3200,29 @@ function Base.setproperty!(x::Ptr{VkClearColorValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
+
+function VkClearColorValue(float32::NTuple{4, Cfloat})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkClearColorValue(int32::NTuple{4, Int32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkClearColorValue(uint32::NTuple{4, UInt32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
 struct VkClearDepthStencilValue
     depth::Cfloat
     stencil::UInt32
@@ -3224,6 +3247,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkClearValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
+
+function VkClearValue(color::VkClearColorValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.color = color
+    ref[]
+end
+
+function VkClearValue(depthStencil::VkClearDepthStencilValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.depthStencil = depthStencil
+    ref[]
 end
 
 struct VkClearAttachment
@@ -7779,6 +7818,50 @@ function Base.setproperty!(x::Ptr{VkPerformanceCounterResultKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
+
+function VkPerformanceCounterResultKHR(int32::Int32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(int64::Int64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int64 = int64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint32::UInt32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint64::UInt64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint64 = uint64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float32::Cfloat)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float64::Cdouble)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float64 = float64
+    ref[]
+end
+
 struct VkAcquireProfilingLockInfoKHR
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8468,6 +8551,36 @@ end
 
 function Base.setproperty!(x::Ptr{VkPipelineExecutableStatisticValueKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
+
+function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.b32 = b32
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(i64::Int64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.i64 = i64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.u64 = u64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.f64 = f64
+    ref[]
 end
 
 struct VkPipelineExecutableStatisticKHR
@@ -10728,6 +10841,18 @@ function Base.setproperty!(x::Ptr{VkAccelerationStructureInstanceKHR}, f::Symbol
     unsafe_store!(getproperty(x, f), v)
 end
 
+function VkAccelerationStructureInstanceKHR(transform::VkTransformMatrixKHR, instanceCustomIndex::UInt32, mask::UInt32, instanceShaderBindingTableRecordOffset::UInt32, flags::VkGeometryInstanceFlagsKHR, accelerationStructureReference::UInt64)
+    ref = Ref{VkAccelerationStructureInstanceKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureInstanceKHR}, ref)
+    ptr.transform = transform
+    ptr.instanceCustomIndex = instanceCustomIndex
+    ptr.mask = mask
+    ptr.instanceShaderBindingTableRecordOffset = instanceShaderBindingTableRecordOffset
+    ptr.flags = flags
+    ptr.accelerationStructureReference = accelerationStructureReference
+    ref[]
+end
+
 const VkAccelerationStructureInstanceNV = VkAccelerationStructureInstanceKHR
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkCreateAccelerationStructureNV ) ( VkDevice device , const VkAccelerationStructureCreateInfoNV * pCreateInfo , const VkAllocationCallbacks * pAllocator , VkAccelerationStructureNV * pAccelerationStructure )
@@ -11284,6 +11409,43 @@ end
 
 function Base.setproperty!(x::Ptr{VkPerformanceValueDataINTEL}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
+
+function VkPerformanceValueDataINTEL(value32::UInt32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value32 = value32
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(value64::UInt64)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value64 = value64
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueFloat = valueFloat
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueBool::VkBool32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueBool = valueBool
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueString = valueString
+    ref[]
 end
 
 struct VkPerformanceValueINTEL
@@ -12779,6 +12941,22 @@ function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
+end
+
 struct VkDeviceOrHostAddressConstKHR
     data::NTuple{8, UInt8}
 end
@@ -12798,6 +12976,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressConstKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
 end
 
 struct VkAccelerationStructureBuildRangeInfoKHR
@@ -12853,6 +13047,29 @@ end
 
 function Base.setproperty!(x::Ptr{VkAccelerationStructureGeometryDataKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
+
+function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.triangles = triangles
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.aabbs = aabbs
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.instances = instances
+    ref[]
 end
 
 struct VkAccelerationStructureGeometryKHR

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -3202,24 +3202,16 @@ end
 
 const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
 
-function VkClearColorValue(float32::NTuple{4, Cfloat})
+function VkClearColorValue(val::__U_VkClearColorValue)
     ref = Ref{VkClearColorValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkClearColorValue(int32::NTuple{4, Int32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkClearColorValue(uint32::NTuple{4, UInt32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.uint32 = uint32
+    if val isa NTuple{4, Cfloat}
+        ptr.float32 = val
+    elseif val isa NTuple{4, Int32}
+        ptr.int32 = val
+    elseif val isa NTuple{4, UInt32}
+        ptr.uint32 = val
+    end
     ref[]
 end
 
@@ -3251,17 +3243,14 @@ end
 
 const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
 
-function VkClearValue(color::VkClearColorValue)
+function VkClearValue(val::__U_VkClearValue)
     ref = Ref{VkClearValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.color = color
-    ref[]
-end
-
-function VkClearValue(depthStencil::VkClearDepthStencilValue)
-    ref = Ref{VkClearValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.depthStencil = depthStencil
+    if val isa VkClearColorValue
+        ptr.color = val
+    elseif val isa VkClearDepthStencilValue
+        ptr.depthStencil = val
+    end
     ref[]
 end
 
@@ -7820,45 +7809,22 @@ end
 
 const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
 
-function VkPerformanceCounterResultKHR(int32::Int32)
+function VkPerformanceCounterResultKHR(val::__U_VkPerformanceCounterResultKHR)
     ref = Ref{VkPerformanceCounterResultKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(int64::Int64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int64 = int64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint32::UInt32)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint32 = uint32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint64::UInt64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint64 = uint64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float32::Cfloat)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float64::Cdouble)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float64 = float64
+    if val isa Int32
+        ptr.int32 = val
+    elseif val isa Int64
+        ptr.int64 = val
+    elseif val isa UInt32
+        ptr.uint32 = val
+    elseif val isa UInt64
+        ptr.uint64 = val
+    elseif val isa Cfloat
+        ptr.float32 = val
+    elseif val isa Cdouble
+        ptr.float64 = val
+    end
     ref[]
 end
 
@@ -8555,31 +8521,18 @@ end
 
 const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
 
-function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+function VkPipelineExecutableStatisticValueKHR(val::__U_VkPipelineExecutableStatisticValueKHR)
     ref = Ref{VkPipelineExecutableStatisticValueKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.b32 = b32
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(i64::Int64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.i64 = i64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.u64 = u64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.f64 = f64
+    if val isa VkBool32
+        ptr.b32 = val
+    elseif val isa Int64
+        ptr.i64 = val
+    elseif val isa UInt64
+        ptr.u64 = val
+    elseif val isa Cdouble
+        ptr.f64 = val
+    end
     ref[]
 end
 
@@ -11413,38 +11366,20 @@ end
 
 const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
 
-function VkPerformanceValueDataINTEL(value32::UInt32)
+function VkPerformanceValueDataINTEL(val::__U_VkPerformanceValueDataINTEL)
     ref = Ref{VkPerformanceValueDataINTEL}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value32 = value32
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(value64::UInt64)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value64 = value64
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueFloat = valueFloat
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueBool::VkBool32)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueBool = valueBool
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueString = valueString
+    if val isa UInt32
+        ptr.value32 = val
+    elseif val isa UInt64
+        ptr.value64 = val
+    elseif val isa Cfloat
+        ptr.valueFloat = val
+    elseif val isa VkBool32
+        ptr.valueBool = val
+    elseif val isa Ptr{Cchar}
+        ptr.valueString = val
+    end
     ref[]
 end
 
@@ -12943,17 +12878,14 @@ end
 
 const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressKHR(val::__U_VkDeviceOrHostAddressKHR)
     ref = Ref{VkDeviceOrHostAddressKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -12980,17 +12912,14 @@ end
 
 const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressConstKHR(val::__U_VkDeviceOrHostAddressConstKHR)
     ref = Ref{VkDeviceOrHostAddressConstKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressConstKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -13051,24 +12980,16 @@ end
 
 const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
 
-function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+function VkAccelerationStructureGeometryDataKHR(val::__U_VkAccelerationStructureGeometryDataKHR)
     ref = Ref{VkAccelerationStructureGeometryDataKHR}()
     ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.triangles = triangles
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.aabbs = aabbs
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.instances = instances
+    if val isa VkAccelerationStructureGeometryTrianglesDataKHR
+        ptr.triangles = val
+    elseif val isa VkAccelerationStructureGeometryAabbsDataKHR
+        ptr.aabbs = val
+    elseif val isa VkAccelerationStructureGeometryInstancesDataKHR
+        ptr.instances = val
+    end
     ref[]
 end
 

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -3686,548 +3686,1096 @@ function vkCreateInstance(pCreateInfo, pAllocator, pInstance)
     ccall((:vkCreateInstance, libvulkan), VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
 end
 
+function vkCreateInstance(pCreateInfo, pAllocator, pInstance, fptr)
+    ccall(fptr, VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
+end
+
 function vkDestroyInstance(instance, pAllocator)
     ccall((:vkDestroyInstance, libvulkan), Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
+end
+
+function vkDestroyInstance(instance, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
 end
 
 function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices)
     ccall((:vkEnumeratePhysicalDevices, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
 end
 
+function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
+end
+
 function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
+end
+
+function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
 end
 
 function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceProperties(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
 end
 
+function vkGetPhysicalDeviceProperties(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
+end
+
 function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
+function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
 function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetInstanceProcAddr(instance, pName)
     ccall((:vkGetInstanceProcAddr, libvulkan), PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
+end
+
+function vkGetInstanceProcAddr(instance, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
 end
 
 function vkGetDeviceProcAddr(device, pName)
     ccall((:vkGetDeviceProcAddr, libvulkan), PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
 end
 
+function vkGetDeviceProcAddr(device, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
+end
+
 function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice)
     ccall((:vkCreateDevice, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
+end
+
+function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
 end
 
 function vkDestroyDevice(device, pAllocator)
     ccall((:vkDestroyDevice, libvulkan), Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
 end
 
+function vkDestroyDevice(device, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
+end
+
 function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceExtensionProperties, libvulkan), VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceExtensionProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
+end
+
 function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceLayerProperties, libvulkan), VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceLayerProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue)
     ccall((:vkGetDeviceQueue, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
+end
+
+function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
 end
 
 function vkQueueSubmit(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
+function vkQueueSubmit(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
 function vkQueueWaitIdle(queue)
     ccall((:vkQueueWaitIdle, libvulkan), VkResult, (VkQueue,), queue)
+end
+
+function vkQueueWaitIdle(queue, fptr)
+    ccall(fptr, VkResult, (VkQueue,), queue)
 end
 
 function vkDeviceWaitIdle(device)
     ccall((:vkDeviceWaitIdle, libvulkan), VkResult, (VkDevice,), device)
 end
 
+function vkDeviceWaitIdle(device, fptr)
+    ccall(fptr, VkResult, (VkDevice,), device)
+end
+
 function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory)
     ccall((:vkAllocateMemory, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
+end
+
+function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
 end
 
 function vkFreeMemory(device, memory, pAllocator)
     ccall((:vkFreeMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
 end
 
+function vkFreeMemory(device, memory, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
+end
+
 function vkMapMemory(device, memory, offset, size, flags, ppData)
     ccall((:vkMapMemory, libvulkan), VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
+end
+
+function vkMapMemory(device, memory, offset, size, flags, ppData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
 end
 
 function vkUnmapMemory(device, memory)
     ccall((:vkUnmapMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory), device, memory)
 end
 
+function vkUnmapMemory(device, memory, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory), device, memory)
+end
+
 function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkFlushMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
+function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
 function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkInvalidateMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
+function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
 function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes)
     ccall((:vkGetDeviceMemoryCommitment, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
+end
+
+function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
 end
 
 function vkBindBufferMemory(device, buffer, memory, memoryOffset)
     ccall((:vkBindBufferMemory, libvulkan), VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
 end
 
+function vkBindBufferMemory(device, buffer, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
+end
+
 function vkBindImageMemory(device, image, memory, memoryOffset)
     ccall((:vkBindImageMemory, libvulkan), VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
+end
+
+function vkBindImageMemory(device, image, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
 end
 
 function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
+end
+
 function vkGetImageMemoryRequirements(device, image, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements(device, image, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
 end
 
 function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
+function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
 end
 
 function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence)
     ccall((:vkQueueBindSparse, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
 end
 
+function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
+end
+
 function vkCreateFence(device, pCreateInfo, pAllocator, pFence)
     ccall((:vkCreateFence, libvulkan), VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
+end
+
+function vkCreateFence(device, pCreateInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
 end
 
 function vkDestroyFence(device, fence, pAllocator)
     ccall((:vkDestroyFence, libvulkan), Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
 end
 
+function vkDestroyFence(device, fence, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
+end
+
 function vkResetFences(device, fenceCount, pFences)
     ccall((:vkResetFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
+end
+
+function vkResetFences(device, fenceCount, pFences, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
 end
 
 function vkGetFenceStatus(device, fence)
     ccall((:vkGetFenceStatus, libvulkan), VkResult, (VkDevice, VkFence), device, fence)
 end
 
+function vkGetFenceStatus(device, fence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkFence), device, fence)
+end
+
 function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout)
     ccall((:vkWaitForFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
+end
+
+function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
 end
 
 function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore)
     ccall((:vkCreateSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
 end
 
+function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
+end
+
 function vkDestroySemaphore(device, semaphore, pAllocator)
     ccall((:vkDestroySemaphore, libvulkan), Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
+end
+
+function vkDestroySemaphore(device, semaphore, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
 end
 
 function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent)
     ccall((:vkCreateEvent, libvulkan), VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
 end
 
+function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
+end
+
 function vkDestroyEvent(device, event, pAllocator)
     ccall((:vkDestroyEvent, libvulkan), Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
+end
+
+function vkDestroyEvent(device, event, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
 end
 
 function vkGetEventStatus(device, event)
     ccall((:vkGetEventStatus, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkGetEventStatus(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkSetEvent(device, event)
     ccall((:vkSetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
+end
+
+function vkSetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
 end
 
 function vkResetEvent(device, event)
     ccall((:vkResetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkResetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool)
     ccall((:vkCreateQueryPool, libvulkan), VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
+end
+
+function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
 end
 
 function vkDestroyQueryPool(device, queryPool, pAllocator)
     ccall((:vkDestroyQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
 end
 
+function vkDestroyQueryPool(device, queryPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
+end
+
 function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
     ccall((:vkGetQueryPoolResults, libvulkan), VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
+end
+
+function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
 end
 
 function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer)
     ccall((:vkCreateBuffer, libvulkan), VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
 end
 
+function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
+end
+
 function vkDestroyBuffer(device, buffer, pAllocator)
     ccall((:vkDestroyBuffer, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
+end
+
+function vkDestroyBuffer(device, buffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
 end
 
 function vkCreateBufferView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateBufferView, libvulkan), VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
 end
 
+function vkCreateBufferView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
+end
+
 function vkDestroyBufferView(device, bufferView, pAllocator)
     ccall((:vkDestroyBufferView, libvulkan), Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
+end
+
+function vkDestroyBufferView(device, bufferView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
 end
 
 function vkCreateImage(device, pCreateInfo, pAllocator, pImage)
     ccall((:vkCreateImage, libvulkan), VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
 end
 
+function vkCreateImage(device, pCreateInfo, pAllocator, pImage, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
+end
+
 function vkDestroyImage(device, image, pAllocator)
     ccall((:vkDestroyImage, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
+end
+
+function vkDestroyImage(device, image, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
 end
 
 function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout)
     ccall((:vkGetImageSubresourceLayout, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
 end
 
+function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
+end
+
 function vkCreateImageView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateImageView, libvulkan), VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
+end
+
+function vkCreateImageView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
 end
 
 function vkDestroyImageView(device, imageView, pAllocator)
     ccall((:vkDestroyImageView, libvulkan), Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
 end
 
+function vkDestroyImageView(device, imageView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
+end
+
 function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule)
     ccall((:vkCreateShaderModule, libvulkan), VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
+end
+
+function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
 end
 
 function vkDestroyShaderModule(device, shaderModule, pAllocator)
     ccall((:vkDestroyShaderModule, libvulkan), Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
 end
 
+function vkDestroyShaderModule(device, shaderModule, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
+end
+
 function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache)
     ccall((:vkCreatePipelineCache, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
+end
+
+function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
 end
 
 function vkDestroyPipelineCache(device, pipelineCache, pAllocator)
     ccall((:vkDestroyPipelineCache, libvulkan), Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
 end
 
+function vkDestroyPipelineCache(device, pipelineCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
+end
+
 function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData)
     ccall((:vkGetPipelineCacheData, libvulkan), VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
+end
+
+function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
 end
 
 function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergePipelineCaches, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateGraphicsPipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateComputePipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
+function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
 function vkDestroyPipeline(device, pipeline, pAllocator)
     ccall((:vkDestroyPipeline, libvulkan), Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
+end
+
+function vkDestroyPipeline(device, pipeline, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
 end
 
 function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout)
     ccall((:vkCreatePipelineLayout, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
 end
 
+function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
+end
+
 function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator)
     ccall((:vkDestroyPipelineLayout, libvulkan), Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
+end
+
+function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
 end
 
 function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler)
     ccall((:vkCreateSampler, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
 end
 
+function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
+end
+
 function vkDestroySampler(device, sampler, pAllocator)
     ccall((:vkDestroySampler, libvulkan), Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
+end
+
+function vkDestroySampler(device, sampler, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
 end
 
 function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout)
     ccall((:vkCreateDescriptorSetLayout, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
 end
 
+function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
+end
+
 function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator)
     ccall((:vkDestroyDescriptorSetLayout, libvulkan), Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
+end
+
+function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
 end
 
 function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool)
     ccall((:vkCreateDescriptorPool, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
 end
 
+function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
+end
+
 function vkDestroyDescriptorPool(device, descriptorPool, pAllocator)
     ccall((:vkDestroyDescriptorPool, libvulkan), Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
+end
+
+function vkDestroyDescriptorPool(device, descriptorPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
 end
 
 function vkResetDescriptorPool(device, descriptorPool, flags)
     ccall((:vkResetDescriptorPool, libvulkan), VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
 end
 
+function vkResetDescriptorPool(device, descriptorPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
+end
+
 function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets)
     ccall((:vkAllocateDescriptorSets, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
+end
+
+function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
 end
 
 function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets)
     ccall((:vkFreeDescriptorSets, libvulkan), VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
 end
 
+function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
+end
+
 function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
     ccall((:vkUpdateDescriptorSets, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
+end
+
+function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
 end
 
 function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer)
     ccall((:vkCreateFramebuffer, libvulkan), VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
 end
 
+function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
+end
+
 function vkDestroyFramebuffer(device, framebuffer, pAllocator)
     ccall((:vkDestroyFramebuffer, libvulkan), Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
+end
+
+function vkDestroyFramebuffer(device, framebuffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
 end
 
 function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkDestroyRenderPass(device, renderPass, pAllocator)
     ccall((:vkDestroyRenderPass, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
+end
+
+function vkDestroyRenderPass(device, renderPass, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
 end
 
 function vkGetRenderAreaGranularity(device, renderPass, pGranularity)
     ccall((:vkGetRenderAreaGranularity, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
 end
 
+function vkGetRenderAreaGranularity(device, renderPass, pGranularity, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
+end
+
 function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool)
     ccall((:vkCreateCommandPool, libvulkan), VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
+end
+
+function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
 end
 
 function vkDestroyCommandPool(device, commandPool, pAllocator)
     ccall((:vkDestroyCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
 end
 
+function vkDestroyCommandPool(device, commandPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
+end
+
 function vkResetCommandPool(device, commandPool, flags)
     ccall((:vkResetCommandPool, libvulkan), VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
+end
+
+function vkResetCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
 end
 
 function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers)
     ccall((:vkAllocateCommandBuffers, libvulkan), VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
 end
 
+function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
+end
+
 function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers)
     ccall((:vkFreeCommandBuffers, libvulkan), Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
+end
+
+function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
 end
 
 function vkBeginCommandBuffer(commandBuffer, pBeginInfo)
     ccall((:vkBeginCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
 end
 
+function vkBeginCommandBuffer(commandBuffer, pBeginInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
+end
+
 function vkEndCommandBuffer(commandBuffer)
     ccall((:vkEndCommandBuffer, libvulkan), VkResult, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkEndCommandBuffer(commandBuffer, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer,), commandBuffer)
 end
 
 function vkResetCommandBuffer(commandBuffer, flags)
     ccall((:vkResetCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
 end
 
+function vkResetCommandBuffer(commandBuffer, flags, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
+end
+
 function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline)
     ccall((:vkCmdBindPipeline, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
+end
+
+function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
 end
 
 function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports)
     ccall((:vkCmdSetViewport, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
 end
 
+function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
+end
+
 function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors)
     ccall((:vkCmdSetScissor, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
+end
+
+function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
 end
 
 function vkCmdSetLineWidth(commandBuffer, lineWidth)
     ccall((:vkCmdSetLineWidth, libvulkan), Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
 end
 
+function vkCmdSetLineWidth(commandBuffer, lineWidth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
+end
+
 function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
     ccall((:vkCmdSetDepthBias, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
+end
+
+function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
 end
 
 function vkCmdSetBlendConstants(commandBuffer, blendConstants)
     ccall((:vkCmdSetBlendConstants, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
 end
 
+function vkCmdSetBlendConstants(commandBuffer, blendConstants, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
+end
+
 function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds)
     ccall((:vkCmdSetDepthBounds, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
+end
+
+function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
 end
 
 function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask)
     ccall((:vkCmdSetStencilCompareMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
 end
 
+function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
+end
+
 function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask)
     ccall((:vkCmdSetStencilWriteMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
+end
+
+function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
 end
 
 function vkCmdSetStencilReference(commandBuffer, faceMask, reference)
     ccall((:vkCmdSetStencilReference, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
 end
 
+function vkCmdSetStencilReference(commandBuffer, faceMask, reference, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
+end
+
 function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
     ccall((:vkCmdBindDescriptorSets, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
+end
+
+function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
 end
 
 function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType)
     ccall((:vkCmdBindIndexBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
 end
 
+function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
+end
+
 function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
     ccall((:vkCmdBindVertexBuffers, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
+end
+
+function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
 end
 
 function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
     ccall((:vkCmdDraw, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
 end
 
+function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
+end
+
 function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
     ccall((:vkCmdDrawIndexed, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
+end
+
+function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
 end
 
 function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndexedIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
 function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatch, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
 end
 
+function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
+end
+
 function vkCmdDispatchIndirect(commandBuffer, buffer, offset)
     ccall((:vkCmdDispatchIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
+end
+
+function vkCmdDispatchIndirect(commandBuffer, buffer, offset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
 end
 
 function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
     ccall((:vkCmdBlitImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
 end
 
+function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
+end
+
 function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyBufferToImage, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyImageToBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData)
     ccall((:vkCmdUpdateBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
+end
+
+function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
 end
 
 function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data)
     ccall((:vkCmdFillBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
 end
 
+function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
+end
+
 function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
     ccall((:vkCmdClearColorImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
+end
+
+function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
 end
 
 function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
     ccall((:vkCmdClearDepthStencilImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
 end
 
+function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
+end
+
 function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
     ccall((:vkCmdClearAttachments, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
+end
+
+function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
 end
 
 function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdResolveImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
+function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
 function vkCmdSetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdSetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
+function vkCmdSetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
 function vkCmdResetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
+function vkCmdResetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
 function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdWaitEvents, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
+function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
 function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdPipelineBarrier, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
+function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
 function vkCmdBeginQuery(commandBuffer, queryPool, query, flags)
     ccall((:vkCmdBeginQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
+end
+
+function vkCmdBeginQuery(commandBuffer, queryPool, query, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
 end
 
 function vkCmdEndQuery(commandBuffer, queryPool, query)
     ccall((:vkCmdEndQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
 end
 
+function vkCmdEndQuery(commandBuffer, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
+end
+
 function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount)
     ccall((:vkCmdResetQueryPool, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
+end
+
+function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
 end
 
 function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query)
     ccall((:vkCmdWriteTimestamp, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
+end
+
 function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
     ccall((:vkCmdCopyQueryPoolResults, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
+end
+
+function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
 end
 
 function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues)
     ccall((:vkCmdPushConstants, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
 end
 
+function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
+end
+
 function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents)
     ccall((:vkCmdBeginRenderPass, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
+end
+
+function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
 end
 
 function vkCmdNextSubpass(commandBuffer, contents)
     ccall((:vkCmdNextSubpass, libvulkan), Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
 end
 
+function vkCmdNextSubpass(commandBuffer, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
+end
+
 function vkCmdEndRenderPass(commandBuffer)
     ccall((:vkCmdEndRenderPass, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndRenderPass(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers)
     ccall((:vkCmdExecuteCommands, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
+end
+
+function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
 end
 
 const VkSamplerYcbcrConversion_T = Cvoid
@@ -5017,112 +5565,224 @@ function vkEnumerateInstanceVersion(pApiVersion)
     ccall((:vkEnumerateInstanceVersion, libvulkan), VkResult, (Ptr{UInt32},), pApiVersion)
 end
 
+function vkEnumerateInstanceVersion(pApiVersion, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32},), pApiVersion)
+end
+
 function vkBindBufferMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindBufferMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 function vkBindImageMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindImageMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
     ccall((:vkGetDeviceGroupPeerMemoryFeatures, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
+function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
 function vkCmdSetDeviceMask(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMask, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMask(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBase, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroups, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
+function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
 function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
 function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
+function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
 function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
 function vkTrimCommandPool(device, commandPool, flags)
     ccall((:vkTrimCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
+function vkTrimCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
 function vkGetDeviceQueue2(device, pQueueInfo, pQueue)
     ccall((:vkGetDeviceQueue2, libvulkan), Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
 end
 
+function vkGetDeviceQueue2(device, pQueueInfo, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
+end
+
 function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion)
     ccall((:vkCreateSamplerYcbcrConversion, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
+function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
 function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversion, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
+function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
 function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
     ccall((:vkCreateDescriptorUpdateTemplate, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
+function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
 function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
+function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
 function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFenceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphoreProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
+function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
 function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupport, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
+function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
 @cenum VkDriverId::UInt32 begin
@@ -5822,52 +6482,104 @@ function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, coun
     ccall((:vkCmdDrawIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 function vkResetQueryPool(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
+function vkResetQueryPool(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
 function vkGetSemaphoreCounterValue(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValue, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
+function vkGetSemaphoreCounterValue(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
 function vkWaitSemaphores(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphores, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphores(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphore(device, pSignalInfo)
     ccall((:vkSignalSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphore(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 function vkGetBufferDeviceAddress(device, pInfo)
     ccall((:vkGetBufferDeviceAddress, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddress(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkSurfaceKHR_T = Cvoid
@@ -5968,20 +6680,40 @@ function vkDestroySurfaceKHR(instance, surface, pAllocator)
     ccall((:vkDestroySurfaceKHR, libvulkan), Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
 end
 
+function vkDestroySurfaceKHR(instance, surface, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
+end
+
 function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported)
     ccall((:vkGetPhysicalDeviceSurfaceSupportKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
+end
+
+function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
 end
 
 function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormatsKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
 end
 
+function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
+end
+
 function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes)
     ccall((:vkGetPhysicalDeviceSurfacePresentModesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
+end
+
+function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
 end
 
 const VkSwapchainKHR_T = Cvoid
@@ -6114,36 +6846,72 @@ function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain)
     ccall((:vkCreateSwapchainKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
 end
 
+function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
+end
+
 function vkDestroySwapchainKHR(device, swapchain, pAllocator)
     ccall((:vkDestroySwapchainKHR, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
+end
+
+function vkDestroySwapchainKHR(device, swapchain, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
 end
 
 function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages)
     ccall((:vkGetSwapchainImagesKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
 end
 
+function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
+end
+
 function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex)
     ccall((:vkAcquireNextImageKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
+end
+
+function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
 end
 
 function vkQueuePresentKHR(queue, pPresentInfo)
     ccall((:vkQueuePresentKHR, libvulkan), VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
 end
 
+function vkQueuePresentKHR(queue, pPresentInfo, fptr)
+    ccall(fptr, VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
+end
+
 function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities)
     ccall((:vkGetDeviceGroupPresentCapabilitiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
+end
+
+function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
 end
 
 function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes)
     ccall((:vkGetDeviceGroupSurfacePresentModesKHR, libvulkan), VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
 end
 
+function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
+end
+
 function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects)
     ccall((:vkGetPhysicalDevicePresentRectanglesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
 end
 
+function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
+end
+
 function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex)
     ccall((:vkAcquireNextImage2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
+end
+
+function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
 end
 
 const VkDisplayKHR_T = Cvoid
@@ -6250,28 +7018,56 @@ function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount,
     ccall((:vkGetPhysicalDeviceDisplayPropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlanePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays)
     ccall((:vkGetDisplayPlaneSupportedDisplaysKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
 end
 
+function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
+end
+
 function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
+function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
 function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode)
     ccall((:vkCreateDisplayModeKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
 end
 
+function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
+end
+
 function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
 end
 
+function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
+end
+
 function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateDisplayPlaneSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
+function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
 struct VkDisplayPresentInfoKHR
@@ -6287,6 +7083,10 @@ const PFN_vkCreateSharedSwapchainsKHR = Ptr{Cvoid}
 
 function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
     ccall((:vkCreateSharedSwapchainsKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
+end
+
+function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
 end
 
 const VkRenderPassMultiviewCreateInfoKHR = VkRenderPassMultiviewCreateInfo
@@ -6338,28 +7138,56 @@ function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
 const VkPeerMemoryFeatureFlagsKHR = VkPeerMemoryFeatureFlags
@@ -6397,12 +7225,24 @@ function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceInd
     ccall((:vkGetDeviceGroupPeerMemoryFeaturesKHR, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
+function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
 function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMaskKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBaseKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 const VkCommandPoolTrimFlagsKHR = VkCommandPoolTrimFlags
@@ -6414,6 +7254,10 @@ function vkTrimCommandPoolKHR(device, commandPool, flags)
     ccall((:vkTrimCommandPoolKHR, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
+function vkTrimCommandPoolKHR(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
 const VkPhysicalDeviceGroupPropertiesKHR = VkPhysicalDeviceGroupProperties
 
 const VkDeviceGroupDeviceCreateInfoKHR = VkDeviceGroupDeviceCreateInfo
@@ -6423,6 +7267,10 @@ const PFN_vkEnumeratePhysicalDeviceGroupsKHR = Ptr{Cvoid}
 
 function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroupsKHR, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
+function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
 const VkExternalMemoryHandleTypeFlagsKHR = VkExternalMemoryHandleTypeFlags
@@ -6450,6 +7298,10 @@ const PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferPropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
+function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
 const VkExternalMemoryImageCreateInfoKHR = VkExternalMemoryImageCreateInfo
@@ -6488,8 +7340,16 @@ function vkGetMemoryFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetMemoryFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
+function vkGetMemoryFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
 function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties)
     ccall((:vkGetMemoryFdPropertiesKHR, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
+end
+
+function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
 end
 
 const VkExternalSemaphoreHandleTypeFlagsKHR = VkExternalSemaphoreHandleTypeFlags
@@ -6509,6 +7369,10 @@ const PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphorePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
+function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
 const VkSemaphoreImportFlagsKHR = VkSemaphoreImportFlags
@@ -6543,8 +7407,16 @@ function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo)
     ccall((:vkImportSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
 end
 
+function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
+end
+
 function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 struct VkPhysicalDevicePushDescriptorPropertiesKHR
@@ -6563,8 +7435,16 @@ function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set
     ccall((:vkCmdPushDescriptorSetKHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
 end
 
+function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
+end
+
 function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData)
     ccall((:vkCmdPushDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
+end
+
+function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
 end
 
 const VkPhysicalDeviceShaderFloat16Int8FeaturesKHR = VkPhysicalDeviceShaderFloat16Int8Features
@@ -6614,12 +7494,24 @@ function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pD
     ccall((:vkCreateDescriptorUpdateTemplateKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
+function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
 function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 const VkPhysicalDeviceImagelessFramebufferFeaturesKHR = VkPhysicalDeviceImagelessFramebufferFeatures
@@ -6660,16 +7552,32 @@ function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 struct VkSharedPresentSurfaceCapabilitiesKHR
@@ -6683,6 +7591,10 @@ const PFN_vkGetSwapchainStatusKHR = Ptr{Cvoid}
 
 function vkGetSwapchainStatusKHR(device, swapchain)
     ccall((:vkGetSwapchainStatusKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
+end
+
+function vkGetSwapchainStatusKHR(device, swapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
 end
 
 const VkExternalFenceHandleTypeFlagsKHR = VkExternalFenceHandleTypeFlags
@@ -6702,6 +7614,10 @@ const PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFencePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 const VkFenceImportFlagsKHR = VkFenceImportFlags
@@ -6736,8 +7652,16 @@ function vkImportFenceFdKHR(device, pImportFenceFdInfo)
     ccall((:vkImportFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
 end
 
+function vkImportFenceFdKHR(device, pImportFenceFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
+end
+
 function vkGetFenceFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetFenceFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 @cenum VkPerformanceCounterUnitKHR::UInt32 begin
@@ -6884,16 +7808,32 @@ function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physica
     ccall((:vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
 end
 
+function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
+end
+
 function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
     ccall((:vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
+end
+
+function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
 end
 
 function vkAcquireProfilingLockKHR(device, pInfo)
     ccall((:vkAcquireProfilingLockKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
 end
 
+function vkAcquireProfilingLockKHR(device, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
+end
+
 function vkReleaseProfilingLockKHR(device)
     ccall((:vkReleaseProfilingLockKHR, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkReleaseProfilingLockKHR(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 const VkPointClippingBehaviorKHR = VkPointClippingBehavior
@@ -6938,8 +7878,16 @@ function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormats2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
+end
+
+function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
 end
 
 const VkPhysicalDeviceVariablePointerFeaturesKHR = VkPhysicalDeviceVariablePointersFeatures
@@ -6993,16 +7941,32 @@ function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount
     ccall((:vkGetPhysicalDeviceDisplayProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlaneProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModeProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
+function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
 function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
+end
+
+function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
 end
 
 const VkMemoryDedicatedRequirementsKHR = VkMemoryDedicatedRequirements
@@ -7032,12 +7996,24 @@ function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 const VkImageFormatListCreateInfoKHR = VkImageFormatListCreateInfo
@@ -7072,8 +8048,16 @@ function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcb
     ccall((:vkCreateSamplerYcbcrConversionKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
+function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
 function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversionKHR, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
+function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
 const VkBindBufferMemoryInfoKHR = VkBindBufferMemoryInfo
@@ -7090,8 +8074,16 @@ function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 const VkPhysicalDeviceMaintenance3PropertiesKHR = VkPhysicalDeviceMaintenance3Properties
@@ -7105,6 +8097,10 @@ function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupportKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
+function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountKHR ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
 const PFN_vkCmdDrawIndirectCountKHR = Ptr{Cvoid}
 
@@ -7115,8 +8111,16 @@ function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 const VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR = VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures
@@ -7181,12 +8185,24 @@ function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValueKHR, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
+function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
 function vkWaitSemaphoresKHR(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphoresKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphoresKHR(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphoreKHR(device, pSignalInfo)
     ccall((:vkSignalSemaphoreKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphoreKHR(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR = VkPhysicalDeviceVulkanMemoryModelFeatures
@@ -7267,8 +8283,16 @@ function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentSha
     ccall((:vkGetPhysicalDeviceFragmentShadingRatesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
 end
 
+function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
+end
+
 function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps)
     ccall((:vkCmdSetFragmentShadingRateKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
+end
+
+function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
 end
 
 struct VkSurfaceProtectedCapabilitiesKHR
@@ -7308,12 +8332,24 @@ function vkGetBufferDeviceAddressKHR(device, pInfo)
     ccall((:vkGetBufferDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkDeferredOperationKHR_T = Cvoid
@@ -7339,20 +8375,40 @@ function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation)
     ccall((:vkCreateDeferredOperationKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
 end
 
+function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
+end
+
 function vkDestroyDeferredOperationKHR(device, operation, pAllocator)
     ccall((:vkDestroyDeferredOperationKHR, libvulkan), Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
+end
+
+function vkDestroyDeferredOperationKHR(device, operation, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
 end
 
 function vkGetDeferredOperationMaxConcurrencyKHR(device, operation)
     ccall((:vkGetDeferredOperationMaxConcurrencyKHR, libvulkan), UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationMaxConcurrencyKHR(device, operation, fptr)
+    ccall(fptr, UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkGetDeferredOperationResultKHR(device, operation)
     ccall((:vkGetDeferredOperationResultKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationResultKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkDeferredOperationJoinKHR(device, operation)
     ccall((:vkDeferredOperationJoinKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
+function vkDeferredOperationJoinKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
 @cenum VkPipelineExecutableStatisticFormatKHR::UInt32 begin
@@ -7446,12 +8502,24 @@ function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutable
     ccall((:vkGetPipelineExecutablePropertiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
 end
 
+function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutableCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
+end
+
 function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics)
     ccall((:vkGetPipelineExecutableStatisticsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
 end
 
+function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
+end
+
 function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
     ccall((:vkGetPipelineExecutableInternalRepresentationsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
+end
+
+function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
 end
 
 struct VkPipelineLibraryCreateInfoKHR
@@ -7603,32 +8671,64 @@ function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo)
     ccall((:vkCmdSetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
 end
 
+function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
+end
+
 function vkCmdResetEvent2KHR(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
+end
+
+function vkCmdResetEvent2KHR(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
 end
 
 function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos)
     ccall((:vkCmdWaitEvents2KHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
 end
 
+function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
+end
+
 function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo)
     ccall((:vkCmdPipelineBarrier2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
+end
+
+function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
 end
 
 function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query)
     ccall((:vkCmdWriteTimestamp2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
+end
+
 function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit2KHR, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
+function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
 function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarker2AMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
 end
 
+function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
+end
+
 function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointData2NV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR
@@ -7779,24 +8879,48 @@ function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo)
     ccall((:vkCmdCopyBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
 end
 
+function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
+end
+
 function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo)
     ccall((:vkCmdCopyImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
+end
+
+function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
 end
 
 function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo)
     ccall((:vkCmdCopyBufferToImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
 end
 
+function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
+end
+
 function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo)
     ccall((:vkCmdCopyImageToBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
+end
+
+function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
 end
 
 function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo)
     ccall((:vkCmdBlitImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
 end
 
+function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
+end
+
 function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo)
     ccall((:vkCmdResolveImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
+end
+
+function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
 end
 
 const VkDebugReportCallbackEXT_T = Cvoid
@@ -7882,12 +9006,24 @@ function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCall
     ccall((:vkCreateDebugReportCallbackEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
 end
 
+function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
+end
+
 function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator)
     ccall((:vkDestroyDebugReportCallbackEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
 end
 
+function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
+end
+
 function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
     ccall((:vkDebugReportMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
+end
+
+function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
 end
 
 @cenum VkRasterizationOrderAMD::UInt32 begin
@@ -7946,20 +9082,40 @@ function vkDebugMarkerSetObjectTagEXT(device, pTagInfo)
     ccall((:vkDebugMarkerSetObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
 end
 
+function vkDebugMarkerSetObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
+end
+
 function vkDebugMarkerSetObjectNameEXT(device, pNameInfo)
     ccall((:vkDebugMarkerSetObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
+end
+
+function vkDebugMarkerSetObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
 end
 
 function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerBeginEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdDebugMarkerEndEXT(commandBuffer)
     ccall((:vkCmdDebugMarkerEndEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdDebugMarkerEndEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerInsertEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
 struct VkDedicatedAllocationImageCreateInfoNV
@@ -8034,24 +9190,48 @@ function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindi
     ccall((:vkCmdBindTransformFeedbackBuffersEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
 end
 
+function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
+end
+
 function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdBeginTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
+function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
 function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdEndTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
+function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
 function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index)
     ccall((:vkCmdBeginQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
+end
+
+function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
 end
 
 function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index)
     ccall((:vkCmdEndQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
 end
 
+function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
+end
+
 function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
     ccall((:vkCmdDrawIndirectByteCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
+end
+
+function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
 end
 
 struct VkImageViewHandleInfoNVX
@@ -8079,8 +9259,16 @@ function vkGetImageViewHandleNVX(device, pInfo)
     ccall((:vkGetImageViewHandleNVX, libvulkan), UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
 end
 
+function vkGetImageViewHandleNVX(device, pInfo, fptr)
+    ccall(fptr, UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
+end
+
 function vkGetImageViewAddressNVX(device, imageView, pProperties)
     ccall((:vkGetImageViewAddressNVX, libvulkan), VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
+end
+
+function vkGetImageViewAddressNVX(device, imageView, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
 end
 
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountAMD ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
@@ -8093,8 +9281,16 @@ function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkTextureLODGatherFormatPropertiesAMD
@@ -8135,6 +9331,10 @@ function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, 
     ccall((:vkGetShaderInfoAMD, libvulkan), VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
 end
 
+function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
+end
+
 struct VkPhysicalDeviceCornerSampledImageFeaturesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8172,6 +9372,10 @@ const PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
     ccall((:vkGetPhysicalDeviceExternalImageFormatPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
 end
 
 struct VkExternalMemoryImageCreateInfoNV
@@ -8255,8 +9459,16 @@ function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingB
     ccall((:vkCmdBeginConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
 end
 
+function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
+end
+
 function vkCmdEndConditionalRenderingEXT(commandBuffer)
     ccall((:vkCmdEndConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkCmdEndConditionalRenderingEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
 struct VkViewportWScalingNV
@@ -8279,11 +9491,19 @@ function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount,
     ccall((:vkCmdSetViewportWScalingNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
 end
 
+function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
+end
+
 # typedef VkResult ( VKAPI_PTR * PFN_vkReleaseDisplayEXT ) ( VkPhysicalDevice physicalDevice , VkDisplayKHR display )
 const PFN_vkReleaseDisplayEXT = Ptr{Cvoid}
 
 function vkReleaseDisplayEXT(physicalDevice, display)
     ccall((:vkReleaseDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
+function vkReleaseDisplayEXT(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
 @cenum VkSurfaceCounterFlagBitsEXT::UInt32 begin
@@ -8315,6 +9535,10 @@ const PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2EXT, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
+function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
 @cenum VkDisplayPowerStateEXT::UInt32 begin
@@ -8374,16 +9598,32 @@ function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo)
     ccall((:vkDisplayPowerControlEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
 end
 
+function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
+end
+
 function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDeviceEventEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
+end
+
+function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
 end
 
 function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDisplayEventEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
 end
 
+function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
+end
+
 function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue)
     ccall((:vkGetSwapchainCounterEXT, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
+end
+
+function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
 end
 
 struct VkRefreshCycleDurationGOOGLE
@@ -8420,8 +9660,16 @@ function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProper
     ccall((:vkGetRefreshCycleDurationGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
 end
 
+function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
+end
+
 function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings)
     ccall((:vkGetPastPresentationTimingGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
+end
+
+function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
 end
 
 struct VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX
@@ -8487,6 +9735,10 @@ const PFN_vkCmdSetDiscardRectangleEXT = Ptr{Cvoid}
 
 function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
     ccall((:vkCmdSetDiscardRectangleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
+end
+
+function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
 end
 
 @cenum VkConservativeRasterizationModeEXT::UInt32 begin
@@ -8558,6 +9810,10 @@ const PFN_vkSetHdrMetadataEXT = Ptr{Cvoid}
 
 function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata)
     ccall((:vkSetHdrMetadataEXT, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
+end
+
+function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
 end
 
 const VkDebugUtilsMessengerEXT_T = Cvoid
@@ -8677,44 +9933,88 @@ function vkSetDebugUtilsObjectNameEXT(device, pNameInfo)
     ccall((:vkSetDebugUtilsObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
 end
 
+function vkSetDebugUtilsObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
+end
+
 function vkSetDebugUtilsObjectTagEXT(device, pTagInfo)
     ccall((:vkSetDebugUtilsObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
+end
+
+function vkSetDebugUtilsObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
 end
 
 function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkQueueEndDebugUtilsLabelEXT(queue)
     ccall((:vkQueueEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue,), queue)
+end
+
+function vkQueueEndDebugUtilsLabelEXT(queue, fptr)
+    ccall(fptr, Cvoid, (VkQueue,), queue)
 end
 
 function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCmdEndDebugUtilsLabelEXT(commandBuffer)
     ccall((:vkCmdEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndDebugUtilsLabelEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger)
     ccall((:vkCreateDebugUtilsMessengerEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
 end
 
+function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
+end
+
 function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator)
     ccall((:vkDestroyDebugUtilsMessengerEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
 end
 
+function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
+end
+
 function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData)
     ccall((:vkSubmitDebugUtilsMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
+end
+
+function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
 end
 
 const VkSamplerReductionModeEXT = VkSamplerReductionMode
@@ -8819,8 +10119,16 @@ function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo)
     ccall((:vkCmdSetSampleLocationsEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
 end
 
+function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
+end
+
 function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties)
     ccall((:vkGetPhysicalDeviceMultisamplePropertiesEXT, libvulkan), Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
+end
+
+function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
 end
 
 @cenum VkBlendOverlapEXT::UInt32 begin
@@ -8948,6 +10256,10 @@ function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties)
     ccall((:vkGetImageDrmFormatModifierPropertiesEXT, libvulkan), VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
 end
 
+function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
+end
+
 const VkValidationCacheEXT_T = Cvoid
 
 const VkValidationCacheEXT = Ptr{VkValidationCacheEXT_T}
@@ -8989,16 +10301,32 @@ function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidation
     ccall((:vkCreateValidationCacheEXT, libvulkan), VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
 end
 
+function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
+end
+
 function vkDestroyValidationCacheEXT(device, validationCache, pAllocator)
     ccall((:vkDestroyValidationCacheEXT, libvulkan), Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
+end
+
+function vkDestroyValidationCacheEXT(device, validationCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
 end
 
 function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergeValidationCachesEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData)
     ccall((:vkGetValidationCacheDataEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
+end
+
+function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
 end
 
 const VkDescriptorBindingFlagBitsEXT = VkDescriptorBindingFlagBits
@@ -9101,12 +10429,24 @@ function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout)
     ccall((:vkCmdBindShadingRateImageNV, libvulkan), Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
 end
 
+function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
+end
+
 function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
     ccall((:vkCmdSetViewportShadingRatePaletteNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
 end
 
+function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
+end
+
 function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
     ccall((:vkCmdSetCoarseSampleOrderNV, libvulkan), Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
+end
+
+function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
 end
 
 const VkAccelerationStructureNV_T = Cvoid
@@ -9433,52 +10773,104 @@ function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccel
     ccall((:vkCreateAccelerationStructureNV, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureNV, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements)
     ccall((:vkGetAccelerationStructureMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
+end
+
 function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos)
     ccall((:vkBindAccelerationStructureMemoryNV, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
 end
 
 function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
     ccall((:vkCmdBuildAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
 end
 
+function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
+end
+
 function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode)
     ccall((:vkCmdCopyAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
+end
+
+function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
 end
 
 function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
     ccall((:vkCmdTraceRaysNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
 end
 
+function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesNV, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
+function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
 function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData)
     ccall((:vkGetAccelerationStructureHandleNV, libvulkan), VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
 end
 
+function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
+function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
 function vkCompileDeferredNV(device, pipeline, shader)
     ccall((:vkCompileDeferredNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
+end
+
+function vkCompileDeferredNV(device, pipeline, shader, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
 end
 
 struct VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV
@@ -9546,11 +10938,19 @@ function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, p
     ccall((:vkGetMemoryHostPointerPropertiesEXT, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
 end
 
+function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, pMemoryHostPointerProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdWriteBufferMarkerAMD ) ( VkCommandBuffer commandBuffer , VkPipelineStageFlagBits pipelineStage , VkBuffer dstBuffer , VkDeviceSize dstOffset , uint32_t marker )
 const PFN_vkCmdWriteBufferMarkerAMD = Ptr{Cvoid}
 
 function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarkerAMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
+end
+
+function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
 end
 
 @cenum VkPipelineCompilerControlFlagBitsAMD::UInt32 begin
@@ -9589,8 +10989,16 @@ function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDom
     ccall((:vkGetPhysicalDeviceCalibrateableTimeDomainsEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
 end
 
+function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDomainCount, pTimeDomains, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
+end
+
 function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
     ccall((:vkGetCalibratedTimestampsEXT, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
+end
+
+function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
 end
 
 struct VkPhysicalDeviceShaderCorePropertiesAMD
@@ -9722,12 +11130,24 @@ function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask)
     ccall((:vkCmdDrawMeshTasksNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
 end
 
+function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
+end
+
 function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectCountNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV
@@ -9762,6 +11182,10 @@ function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclus
     ccall((:vkCmdSetExclusiveScissorNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
 end
 
+function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
+end
+
 struct VkQueueFamilyCheckpointPropertiesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -9785,8 +11209,16 @@ function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker)
     ccall((:vkCmdSetCheckpointNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
 end
 
+function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
+end
+
 function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointDataNV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL
@@ -9930,36 +11362,72 @@ function vkInitializePerformanceApiINTEL(device, pInitializeInfo)
     ccall((:vkInitializePerformanceApiINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
 end
 
+function vkInitializePerformanceApiINTEL(device, pInitializeInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
+end
+
 function vkUninitializePerformanceApiINTEL(device)
     ccall((:vkUninitializePerformanceApiINTEL, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkUninitializePerformanceApiINTEL(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceStreamMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
 function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo)
     ccall((:vkCmdSetPerformanceOverrideINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
 end
 
+function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
+end
+
 function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration)
     ccall((:vkAcquirePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
+end
+
+function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
 end
 
 function vkReleasePerformanceConfigurationINTEL(device, configuration)
     ccall((:vkReleasePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
 end
 
+function vkReleasePerformanceConfigurationINTEL(device, configuration, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
+end
+
 function vkQueueSetPerformanceConfigurationINTEL(queue, configuration)
     ccall((:vkQueueSetPerformanceConfigurationINTEL, libvulkan), VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
 end
 
+function vkQueueSetPerformanceConfigurationINTEL(queue, configuration, fptr)
+    ccall(fptr, VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
+end
+
 function vkGetPerformanceParameterINTEL(device, parameter, pValue)
     ccall((:vkGetPerformanceParameterINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
+end
+
+function vkGetPerformanceParameterINTEL(device, parameter, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
 end
 
 struct VkPhysicalDevicePCIBusInfoPropertiesEXT
@@ -9988,6 +11456,10 @@ const PFN_vkSetLocalDimmingAMD = Ptr{Cvoid}
 
 function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable)
     ccall((:vkSetLocalDimmingAMD, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
+end
+
+function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
 end
 
 struct VkPhysicalDeviceFragmentDensityMapFeaturesEXT
@@ -10112,6 +11584,10 @@ function vkGetBufferDeviceAddressEXT(device, pInfo)
     ccall((:vkGetBufferDeviceAddressEXT, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressEXT(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 @cenum VkToolPurposeFlagBitsEXT::UInt32 begin
     VK_TOOL_PURPOSE_VALIDATION_BIT_EXT = 1
     VK_TOOL_PURPOSE_PROFILING_BIT_EXT = 2
@@ -10140,6 +11616,10 @@ const PFN_vkGetPhysicalDeviceToolPropertiesEXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties)
     ccall((:vkGetPhysicalDeviceToolPropertiesEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
+end
+
+function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
 end
 
 const VkImageStencilUsageCreateInfoEXT = VkImageStencilUsageCreateInfo
@@ -10229,6 +11709,10 @@ function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPrope
     ccall((:vkGetPhysicalDeviceCooperativeMatrixPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
+end
+
 @cenum VkCoverageReductionModeNV::UInt32 begin
     VK_COVERAGE_REDUCTION_MODE_MERGE_NV = 0
     VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV = 1
@@ -10264,6 +11748,10 @@ const PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV = Pt
 
 function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations)
     ccall((:vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
+end
+
+function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
 end
 
 struct VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT
@@ -10321,6 +11809,10 @@ function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateHeadlessSurfaceEXT, libvulkan), VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 @cenum VkLineRasterizationModeEXT::UInt32 begin
     VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT = 0
     VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT = 1
@@ -10362,6 +11854,10 @@ function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePat
     ccall((:vkCmdSetLineStippleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
 end
 
+function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
+end
+
 struct VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10386,6 +11882,10 @@ const PFN_vkResetQueryPoolEXT = Ptr{Cvoid}
 
 function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPoolEXT, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
+function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
 struct VkPhysicalDeviceIndexTypeUint8FeaturesEXT
@@ -10440,48 +11940,96 @@ function vkCmdSetCullModeEXT(commandBuffer, cullMode)
     ccall((:vkCmdSetCullModeEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
 end
 
+function vkCmdSetCullModeEXT(commandBuffer, cullMode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
+end
+
 function vkCmdSetFrontFaceEXT(commandBuffer, frontFace)
     ccall((:vkCmdSetFrontFaceEXT, libvulkan), Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
+end
+
+function vkCmdSetFrontFaceEXT(commandBuffer, frontFace, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
 end
 
 function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology)
     ccall((:vkCmdSetPrimitiveTopologyEXT, libvulkan), Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
 end
 
+function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
+end
+
 function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports)
     ccall((:vkCmdSetViewportWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
+end
+
+function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
 end
 
 function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors)
     ccall((:vkCmdSetScissorWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
 end
 
+function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
+end
+
 function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
     ccall((:vkCmdBindVertexBuffers2EXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
+end
+
+function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
 end
 
 function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable)
     ccall((:vkCmdSetDepthTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
 end
 
+function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
+end
+
 function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable)
     ccall((:vkCmdSetDepthWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
+end
+
+function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
 end
 
 function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp)
     ccall((:vkCmdSetDepthCompareOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
 end
 
+function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
+end
+
 function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable)
     ccall((:vkCmdSetDepthBoundsTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
+end
+
+function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
 end
 
 function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable)
     ccall((:vkCmdSetStencilTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
 end
 
+function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
+end
+
 function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
     ccall((:vkCmdSetStencilOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
+end
+
+function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
 end
 
 struct VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT
@@ -10663,24 +12211,48 @@ function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequir
     ccall((:vkGetGeneratedCommandsMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo)
     ccall((:vkCmdPreprocessGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
+end
+
+function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
 end
 
 function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
     ccall((:vkCmdExecuteGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
 end
 
+function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
+end
+
 function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex)
     ccall((:vkCmdBindPipelineShaderGroupNV, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
+end
+
+function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
 end
 
 function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
     ccall((:vkCreateIndirectCommandsLayoutNV, libvulkan), VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
 end
 
+function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
+end
+
 function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator)
     ccall((:vkDestroyIndirectCommandsLayoutNV, libvulkan), Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
+end
+
+function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
 end
 
 struct VkPhysicalDeviceInheritedViewportScissorFeaturesNV
@@ -10844,16 +12416,32 @@ function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDat
     ccall((:vkCreatePrivateDataSlotEXT, libvulkan), VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
 end
 
+function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDataSlot, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
+end
+
 function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator)
     ccall((:vkDestroyPrivateDataSlotEXT, libvulkan), Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
+end
+
+function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
 end
 
 function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data)
     ccall((:vkSetPrivateDataEXT, libvulkan), VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
 end
 
+function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
+end
+
 function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData)
     ccall((:vkGetPrivateDataEXT, libvulkan), Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
+end
+
+function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
 end
 
 struct VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT
@@ -10934,6 +12522,10 @@ function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerO
     ccall((:vkCmdSetFragmentShadingRateEnumNV, libvulkan), Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
 end
 
+function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
+end
+
 struct VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10984,8 +12576,16 @@ function vkAcquireWinrtDisplayNV(physicalDevice, display)
     ccall((:vkAcquireWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
+function vkAcquireWinrtDisplayNV(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
 function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay)
     ccall((:vkGetWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
+end
+
+function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
 end
 
 struct VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE
@@ -11037,6 +12637,10 @@ function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pV
     ccall((:vkCmdSetVertexInputEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
 end
 
+function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
+end
+
 struct VkPhysicalDeviceExtendedDynamicState2FeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -11064,20 +12668,40 @@ function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints)
     ccall((:vkCmdSetPatchControlPointsEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
 end
 
+function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
+end
+
 function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable)
     ccall((:vkCmdSetRasterizerDiscardEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
+end
+
+function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
 end
 
 function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable)
     ccall((:vkCmdSetDepthBiasEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
 end
 
+function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
+end
+
 function vkCmdSetLogicOpEXT(commandBuffer, logicOp)
     ccall((:vkCmdSetLogicOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
 end
 
+function vkCmdSetLogicOpEXT(commandBuffer, logicOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
+end
+
 function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable)
     ccall((:vkCmdSetPrimitiveRestartEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
+end
+
+function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
 end
 
 struct VkPhysicalDeviceColorWriteEnableFeaturesEXT
@@ -11098,6 +12722,10 @@ const PFN_vkCmdSetColorWriteEnableEXT = Ptr{Cvoid}
 
 function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables)
     ccall((:vkCmdSetColorWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
+end
+
+function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
 end
 
 const VkAccelerationStructureKHR_T = Cvoid
@@ -11386,64 +13014,128 @@ function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAcce
     ccall((:vkCreateAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkCmdBuildAccelerationStructuresKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
     ccall((:vkCmdBuildAccelerationStructuresIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
+end
+
+function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
 end
 
 function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkBuildAccelerationStructuresKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureToMemoryKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
 end
 
+function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
+end
+
 function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyMemoryToAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
     ccall((:vkWriteAccelerationStructuresPropertiesKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
 end
 
+function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
+end
+
 function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureToMemoryKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
 end
 
+function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
+end
+
 function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyMemoryToAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo)
     ccall((:vkGetAccelerationStructureDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
 end
 
+function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
+function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
 function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility)
     ccall((:vkGetDeviceAccelerationStructureCompatibilityKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
 end
 
+function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
+end
+
 function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
     ccall((:vkGetAccelerationStructureBuildSizesKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
+end
+
+function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
 end
 
 @cenum VkShaderGroupShaderKHR::UInt32 begin
@@ -11546,24 +13238,48 @@ function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShader
     ccall((:vkCmdTraceRaysKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
 end
 
+function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingCaptureReplayShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
     ccall((:vkCmdTraceRaysIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
+end
+
+function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
 end
 
 function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader)
     ccall((:vkGetRayTracingShaderGroupStackSizeKHR, libvulkan), VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
 end
 
+function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader, fptr)
+    ccall(fptr, VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
+end
+
 function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize)
     ccall((:vkCmdSetRayTracingPipelineStackSizeKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
+end
+
+function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
 end
 
 struct VkPhysicalDeviceRayQueryFeaturesKHR
@@ -11596,8 +13312,16 @@ function vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateWaylandSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkWaylandSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkWaylandSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display)
     ccall((:vkGetPhysicalDeviceWaylandPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{wl_display}), physicalDevice, queueFamilyIndex, display)
+end
+
+function vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{wl_display}), physicalDevice, queueFamilyIndex, display)
 end
 
 const VkXcbSurfaceCreateFlagsKHR = VkFlags
@@ -11620,8 +13344,16 @@ function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXcbSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id)
     ccall((:vkGetPhysicalDeviceXcbPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
+end
+
+function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
 end
 
 const VkXlibSurfaceCreateFlagsKHR = VkFlags
@@ -11644,8 +13376,16 @@ function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXlibSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID)
     ccall((:vkGetPhysicalDeviceXlibPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
+end
+
+function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
 end
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkAcquireXlibDisplayEXT ) ( VkPhysicalDevice physicalDevice , Display * dpy , VkDisplayKHR display )
@@ -11658,8 +13398,16 @@ function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display)
     ccall((:vkAcquireXlibDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
 end
 
+function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
+end
+
 function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay)
     ccall((:vkGetRandROutputDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
+end
+
+function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
 end
 
 const VULKAN_H_ = 1

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -3200,6 +3200,29 @@ function Base.setproperty!(x::Ptr{VkClearColorValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
+
+function VkClearColorValue(float32::NTuple{4, Cfloat})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkClearColorValue(int32::NTuple{4, Int32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkClearColorValue(uint32::NTuple{4, UInt32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
 struct VkClearDepthStencilValue
     depth::Cfloat
     stencil::UInt32
@@ -3224,6 +3247,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkClearValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
+
+function VkClearValue(color::VkClearColorValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.color = color
+    ref[]
+end
+
+function VkClearValue(depthStencil::VkClearDepthStencilValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.depthStencil = depthStencil
+    ref[]
 end
 
 struct VkClearAttachment
@@ -7779,6 +7818,50 @@ function Base.setproperty!(x::Ptr{VkPerformanceCounterResultKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
+
+function VkPerformanceCounterResultKHR(int32::Int32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(int64::Int64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int64 = int64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint32::UInt32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint64::UInt64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint64 = uint64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float32::Cfloat)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float64::Cdouble)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float64 = float64
+    ref[]
+end
+
 struct VkAcquireProfilingLockInfoKHR
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8468,6 +8551,36 @@ end
 
 function Base.setproperty!(x::Ptr{VkPipelineExecutableStatisticValueKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
+
+function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.b32 = b32
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(i64::Int64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.i64 = i64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.u64 = u64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.f64 = f64
+    ref[]
 end
 
 struct VkPipelineExecutableStatisticKHR
@@ -10728,6 +10841,18 @@ function Base.setproperty!(x::Ptr{VkAccelerationStructureInstanceKHR}, f::Symbol
     unsafe_store!(getproperty(x, f), v)
 end
 
+function VkAccelerationStructureInstanceKHR(transform::VkTransformMatrixKHR, instanceCustomIndex::UInt32, mask::UInt32, instanceShaderBindingTableRecordOffset::UInt32, flags::VkGeometryInstanceFlagsKHR, accelerationStructureReference::UInt64)
+    ref = Ref{VkAccelerationStructureInstanceKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureInstanceKHR}, ref)
+    ptr.transform = transform
+    ptr.instanceCustomIndex = instanceCustomIndex
+    ptr.mask = mask
+    ptr.instanceShaderBindingTableRecordOffset = instanceShaderBindingTableRecordOffset
+    ptr.flags = flags
+    ptr.accelerationStructureReference = accelerationStructureReference
+    ref[]
+end
+
 const VkAccelerationStructureInstanceNV = VkAccelerationStructureInstanceKHR
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkCreateAccelerationStructureNV ) ( VkDevice device , const VkAccelerationStructureCreateInfoNV * pCreateInfo , const VkAllocationCallbacks * pAllocator , VkAccelerationStructureNV * pAccelerationStructure )
@@ -11284,6 +11409,43 @@ end
 
 function Base.setproperty!(x::Ptr{VkPerformanceValueDataINTEL}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
+
+function VkPerformanceValueDataINTEL(value32::UInt32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value32 = value32
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(value64::UInt64)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value64 = value64
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueFloat = valueFloat
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueBool::VkBool32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueBool = valueBool
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueString = valueString
+    ref[]
 end
 
 struct VkPerformanceValueINTEL
@@ -12779,6 +12941,22 @@ function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
+end
+
 struct VkDeviceOrHostAddressConstKHR
     data::NTuple{8, UInt8}
 end
@@ -12798,6 +12976,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressConstKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
 end
 
 struct VkAccelerationStructureBuildRangeInfoKHR
@@ -12853,6 +13047,29 @@ end
 
 function Base.setproperty!(x::Ptr{VkAccelerationStructureGeometryDataKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
+
+function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.triangles = triangles
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.aabbs = aabbs
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.instances = instances
+    ref[]
 end
 
 struct VkAccelerationStructureGeometryKHR

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -3202,24 +3202,16 @@ end
 
 const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
 
-function VkClearColorValue(float32::NTuple{4, Cfloat})
+function VkClearColorValue(val::__U_VkClearColorValue)
     ref = Ref{VkClearColorValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkClearColorValue(int32::NTuple{4, Int32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkClearColorValue(uint32::NTuple{4, UInt32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.uint32 = uint32
+    if val isa NTuple{4, Cfloat}
+        ptr.float32 = val
+    elseif val isa NTuple{4, Int32}
+        ptr.int32 = val
+    elseif val isa NTuple{4, UInt32}
+        ptr.uint32 = val
+    end
     ref[]
 end
 
@@ -3251,17 +3243,14 @@ end
 
 const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
 
-function VkClearValue(color::VkClearColorValue)
+function VkClearValue(val::__U_VkClearValue)
     ref = Ref{VkClearValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.color = color
-    ref[]
-end
-
-function VkClearValue(depthStencil::VkClearDepthStencilValue)
-    ref = Ref{VkClearValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.depthStencil = depthStencil
+    if val isa VkClearColorValue
+        ptr.color = val
+    elseif val isa VkClearDepthStencilValue
+        ptr.depthStencil = val
+    end
     ref[]
 end
 
@@ -7820,45 +7809,22 @@ end
 
 const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
 
-function VkPerformanceCounterResultKHR(int32::Int32)
+function VkPerformanceCounterResultKHR(val::__U_VkPerformanceCounterResultKHR)
     ref = Ref{VkPerformanceCounterResultKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(int64::Int64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int64 = int64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint32::UInt32)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint32 = uint32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint64::UInt64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint64 = uint64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float32::Cfloat)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float64::Cdouble)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float64 = float64
+    if val isa Int32
+        ptr.int32 = val
+    elseif val isa Int64
+        ptr.int64 = val
+    elseif val isa UInt32
+        ptr.uint32 = val
+    elseif val isa UInt64
+        ptr.uint64 = val
+    elseif val isa Cfloat
+        ptr.float32 = val
+    elseif val isa Cdouble
+        ptr.float64 = val
+    end
     ref[]
 end
 
@@ -8555,31 +8521,18 @@ end
 
 const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
 
-function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+function VkPipelineExecutableStatisticValueKHR(val::__U_VkPipelineExecutableStatisticValueKHR)
     ref = Ref{VkPipelineExecutableStatisticValueKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.b32 = b32
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(i64::Int64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.i64 = i64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.u64 = u64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.f64 = f64
+    if val isa VkBool32
+        ptr.b32 = val
+    elseif val isa Int64
+        ptr.i64 = val
+    elseif val isa UInt64
+        ptr.u64 = val
+    elseif val isa Cdouble
+        ptr.f64 = val
+    end
     ref[]
 end
 
@@ -11413,38 +11366,20 @@ end
 
 const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
 
-function VkPerformanceValueDataINTEL(value32::UInt32)
+function VkPerformanceValueDataINTEL(val::__U_VkPerformanceValueDataINTEL)
     ref = Ref{VkPerformanceValueDataINTEL}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value32 = value32
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(value64::UInt64)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value64 = value64
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueFloat = valueFloat
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueBool::VkBool32)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueBool = valueBool
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueString = valueString
+    if val isa UInt32
+        ptr.value32 = val
+    elseif val isa UInt64
+        ptr.value64 = val
+    elseif val isa Cfloat
+        ptr.valueFloat = val
+    elseif val isa VkBool32
+        ptr.valueBool = val
+    elseif val isa Ptr{Cchar}
+        ptr.valueString = val
+    end
     ref[]
 end
 
@@ -12943,17 +12878,14 @@ end
 
 const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressKHR(val::__U_VkDeviceOrHostAddressKHR)
     ref = Ref{VkDeviceOrHostAddressKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -12980,17 +12912,14 @@ end
 
 const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressConstKHR(val::__U_VkDeviceOrHostAddressConstKHR)
     ref = Ref{VkDeviceOrHostAddressConstKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressConstKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -13051,24 +12980,16 @@ end
 
 const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
 
-function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+function VkAccelerationStructureGeometryDataKHR(val::__U_VkAccelerationStructureGeometryDataKHR)
     ref = Ref{VkAccelerationStructureGeometryDataKHR}()
     ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.triangles = triangles
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.aabbs = aabbs
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.instances = instances
+    if val isa VkAccelerationStructureGeometryTrianglesDataKHR
+        ptr.triangles = val
+    elseif val isa VkAccelerationStructureGeometryAabbsDataKHR
+        ptr.aabbs = val
+    elseif val isa VkAccelerationStructureGeometryInstancesDataKHR
+        ptr.instances = val
+    end
     ref[]
 end
 

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -3160,6 +3160,29 @@ function Base.setproperty!(x::Ptr{VkClearColorValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
+
+function VkClearColorValue(float32::NTuple{4, Cfloat})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkClearColorValue(int32::NTuple{4, Int32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkClearColorValue(uint32::NTuple{4, UInt32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
 struct VkClearDepthStencilValue
     depth::Cfloat
     stencil::UInt32
@@ -3184,6 +3207,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkClearValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
+
+function VkClearValue(color::VkClearColorValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.color = color
+    ref[]
+end
+
+function VkClearValue(depthStencil::VkClearDepthStencilValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.depthStencil = depthStencil
+    ref[]
 end
 
 struct VkClearAttachment
@@ -7727,6 +7766,50 @@ function Base.setproperty!(x::Ptr{VkPerformanceCounterResultKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
+
+function VkPerformanceCounterResultKHR(int32::Int32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(int64::Int64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int64 = int64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint32::UInt32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint64::UInt64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint64 = uint64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float32::Cfloat)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float64::Cdouble)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float64 = float64
+    ref[]
+end
+
 struct VkAcquireProfilingLockInfoKHR
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8414,6 +8497,36 @@ end
 
 function Base.setproperty!(x::Ptr{VkPipelineExecutableStatisticValueKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
+
+function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.b32 = b32
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(i64::Int64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.i64 = i64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.u64 = u64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.f64 = f64
+    ref[]
 end
 
 struct VkPipelineExecutableStatisticKHR
@@ -10666,6 +10779,18 @@ function Base.setproperty!(x::Ptr{VkAccelerationStructureInstanceKHR}, f::Symbol
     unsafe_store!(getproperty(x, f), v)
 end
 
+function VkAccelerationStructureInstanceKHR(transform::VkTransformMatrixKHR, instanceCustomIndex::UInt32, mask::UInt32, instanceShaderBindingTableRecordOffset::UInt32, flags::VkGeometryInstanceFlagsKHR, accelerationStructureReference::UInt64)
+    ref = Ref{VkAccelerationStructureInstanceKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureInstanceKHR}, ref)
+    ptr.transform = transform
+    ptr.instanceCustomIndex = instanceCustomIndex
+    ptr.mask = mask
+    ptr.instanceShaderBindingTableRecordOffset = instanceShaderBindingTableRecordOffset
+    ptr.flags = flags
+    ptr.accelerationStructureReference = accelerationStructureReference
+    ref[]
+end
+
 const VkAccelerationStructureInstanceNV = VkAccelerationStructureInstanceKHR
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkCreateAccelerationStructureNV ) ( VkDevice device , const VkAccelerationStructureCreateInfoNV * pCreateInfo , const VkAllocationCallbacks * pAllocator , VkAccelerationStructureNV * pAccelerationStructure )
@@ -11220,6 +11345,43 @@ end
 
 function Base.setproperty!(x::Ptr{VkPerformanceValueDataINTEL}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
+
+function VkPerformanceValueDataINTEL(value32::UInt32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value32 = value32
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(value64::UInt64)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value64 = value64
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueFloat = valueFloat
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueBool::VkBool32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueBool = valueBool
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueString = valueString
+    ref[]
 end
 
 struct VkPerformanceValueINTEL
@@ -12709,6 +12871,22 @@ function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
+end
+
 struct VkDeviceOrHostAddressConstKHR
     data::NTuple{8, UInt8}
 end
@@ -12728,6 +12906,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressConstKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
 end
 
 struct VkAccelerationStructureBuildRangeInfoKHR
@@ -12783,6 +12977,29 @@ end
 
 function Base.setproperty!(x::Ptr{VkAccelerationStructureGeometryDataKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
+
+function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.triangles = triangles
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.aabbs = aabbs
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.instances = instances
+    ref[]
 end
 
 struct VkAccelerationStructureGeometryKHR

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -3646,548 +3646,1096 @@ function vkCreateInstance(pCreateInfo, pAllocator, pInstance)
     ccall((:vkCreateInstance, libvulkan), VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
 end
 
+function vkCreateInstance(pCreateInfo, pAllocator, pInstance, fptr)
+    ccall(fptr, VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
+end
+
 function vkDestroyInstance(instance, pAllocator)
     ccall((:vkDestroyInstance, libvulkan), Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
+end
+
+function vkDestroyInstance(instance, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
 end
 
 function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices)
     ccall((:vkEnumeratePhysicalDevices, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
 end
 
+function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
+end
+
 function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
+end
+
+function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
 end
 
 function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceProperties(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
 end
 
+function vkGetPhysicalDeviceProperties(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
+end
+
 function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
+function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
 function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetInstanceProcAddr(instance, pName)
     ccall((:vkGetInstanceProcAddr, libvulkan), PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
+end
+
+function vkGetInstanceProcAddr(instance, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
 end
 
 function vkGetDeviceProcAddr(device, pName)
     ccall((:vkGetDeviceProcAddr, libvulkan), PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
 end
 
+function vkGetDeviceProcAddr(device, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
+end
+
 function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice)
     ccall((:vkCreateDevice, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
+end
+
+function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
 end
 
 function vkDestroyDevice(device, pAllocator)
     ccall((:vkDestroyDevice, libvulkan), Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
 end
 
+function vkDestroyDevice(device, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
+end
+
 function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceExtensionProperties, libvulkan), VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceExtensionProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
+end
+
 function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceLayerProperties, libvulkan), VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceLayerProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue)
     ccall((:vkGetDeviceQueue, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
+end
+
+function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
 end
 
 function vkQueueSubmit(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
+function vkQueueSubmit(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
 function vkQueueWaitIdle(queue)
     ccall((:vkQueueWaitIdle, libvulkan), VkResult, (VkQueue,), queue)
+end
+
+function vkQueueWaitIdle(queue, fptr)
+    ccall(fptr, VkResult, (VkQueue,), queue)
 end
 
 function vkDeviceWaitIdle(device)
     ccall((:vkDeviceWaitIdle, libvulkan), VkResult, (VkDevice,), device)
 end
 
+function vkDeviceWaitIdle(device, fptr)
+    ccall(fptr, VkResult, (VkDevice,), device)
+end
+
 function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory)
     ccall((:vkAllocateMemory, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
+end
+
+function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
 end
 
 function vkFreeMemory(device, memory, pAllocator)
     ccall((:vkFreeMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
 end
 
+function vkFreeMemory(device, memory, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
+end
+
 function vkMapMemory(device, memory, offset, size, flags, ppData)
     ccall((:vkMapMemory, libvulkan), VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
+end
+
+function vkMapMemory(device, memory, offset, size, flags, ppData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
 end
 
 function vkUnmapMemory(device, memory)
     ccall((:vkUnmapMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory), device, memory)
 end
 
+function vkUnmapMemory(device, memory, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory), device, memory)
+end
+
 function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkFlushMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
+function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
 function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkInvalidateMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
+function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
 function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes)
     ccall((:vkGetDeviceMemoryCommitment, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
+end
+
+function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
 end
 
 function vkBindBufferMemory(device, buffer, memory, memoryOffset)
     ccall((:vkBindBufferMemory, libvulkan), VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
 end
 
+function vkBindBufferMemory(device, buffer, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
+end
+
 function vkBindImageMemory(device, image, memory, memoryOffset)
     ccall((:vkBindImageMemory, libvulkan), VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
+end
+
+function vkBindImageMemory(device, image, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
 end
 
 function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
+end
+
 function vkGetImageMemoryRequirements(device, image, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements(device, image, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
 end
 
 function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
+function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
 end
 
 function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence)
     ccall((:vkQueueBindSparse, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
 end
 
+function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
+end
+
 function vkCreateFence(device, pCreateInfo, pAllocator, pFence)
     ccall((:vkCreateFence, libvulkan), VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
+end
+
+function vkCreateFence(device, pCreateInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
 end
 
 function vkDestroyFence(device, fence, pAllocator)
     ccall((:vkDestroyFence, libvulkan), Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
 end
 
+function vkDestroyFence(device, fence, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
+end
+
 function vkResetFences(device, fenceCount, pFences)
     ccall((:vkResetFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
+end
+
+function vkResetFences(device, fenceCount, pFences, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
 end
 
 function vkGetFenceStatus(device, fence)
     ccall((:vkGetFenceStatus, libvulkan), VkResult, (VkDevice, VkFence), device, fence)
 end
 
+function vkGetFenceStatus(device, fence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkFence), device, fence)
+end
+
 function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout)
     ccall((:vkWaitForFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
+end
+
+function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
 end
 
 function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore)
     ccall((:vkCreateSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
 end
 
+function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
+end
+
 function vkDestroySemaphore(device, semaphore, pAllocator)
     ccall((:vkDestroySemaphore, libvulkan), Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
+end
+
+function vkDestroySemaphore(device, semaphore, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
 end
 
 function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent)
     ccall((:vkCreateEvent, libvulkan), VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
 end
 
+function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
+end
+
 function vkDestroyEvent(device, event, pAllocator)
     ccall((:vkDestroyEvent, libvulkan), Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
+end
+
+function vkDestroyEvent(device, event, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
 end
 
 function vkGetEventStatus(device, event)
     ccall((:vkGetEventStatus, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkGetEventStatus(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkSetEvent(device, event)
     ccall((:vkSetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
+end
+
+function vkSetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
 end
 
 function vkResetEvent(device, event)
     ccall((:vkResetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkResetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool)
     ccall((:vkCreateQueryPool, libvulkan), VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
+end
+
+function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
 end
 
 function vkDestroyQueryPool(device, queryPool, pAllocator)
     ccall((:vkDestroyQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
 end
 
+function vkDestroyQueryPool(device, queryPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
+end
+
 function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
     ccall((:vkGetQueryPoolResults, libvulkan), VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
+end
+
+function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
 end
 
 function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer)
     ccall((:vkCreateBuffer, libvulkan), VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
 end
 
+function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
+end
+
 function vkDestroyBuffer(device, buffer, pAllocator)
     ccall((:vkDestroyBuffer, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
+end
+
+function vkDestroyBuffer(device, buffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
 end
 
 function vkCreateBufferView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateBufferView, libvulkan), VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
 end
 
+function vkCreateBufferView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
+end
+
 function vkDestroyBufferView(device, bufferView, pAllocator)
     ccall((:vkDestroyBufferView, libvulkan), Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
+end
+
+function vkDestroyBufferView(device, bufferView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
 end
 
 function vkCreateImage(device, pCreateInfo, pAllocator, pImage)
     ccall((:vkCreateImage, libvulkan), VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
 end
 
+function vkCreateImage(device, pCreateInfo, pAllocator, pImage, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
+end
+
 function vkDestroyImage(device, image, pAllocator)
     ccall((:vkDestroyImage, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
+end
+
+function vkDestroyImage(device, image, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
 end
 
 function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout)
     ccall((:vkGetImageSubresourceLayout, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
 end
 
+function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
+end
+
 function vkCreateImageView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateImageView, libvulkan), VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
+end
+
+function vkCreateImageView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
 end
 
 function vkDestroyImageView(device, imageView, pAllocator)
     ccall((:vkDestroyImageView, libvulkan), Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
 end
 
+function vkDestroyImageView(device, imageView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
+end
+
 function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule)
     ccall((:vkCreateShaderModule, libvulkan), VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
+end
+
+function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
 end
 
 function vkDestroyShaderModule(device, shaderModule, pAllocator)
     ccall((:vkDestroyShaderModule, libvulkan), Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
 end
 
+function vkDestroyShaderModule(device, shaderModule, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
+end
+
 function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache)
     ccall((:vkCreatePipelineCache, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
+end
+
+function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
 end
 
 function vkDestroyPipelineCache(device, pipelineCache, pAllocator)
     ccall((:vkDestroyPipelineCache, libvulkan), Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
 end
 
+function vkDestroyPipelineCache(device, pipelineCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
+end
+
 function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData)
     ccall((:vkGetPipelineCacheData, libvulkan), VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
+end
+
+function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
 end
 
 function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergePipelineCaches, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateGraphicsPipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateComputePipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
+function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
 function vkDestroyPipeline(device, pipeline, pAllocator)
     ccall((:vkDestroyPipeline, libvulkan), Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
+end
+
+function vkDestroyPipeline(device, pipeline, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
 end
 
 function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout)
     ccall((:vkCreatePipelineLayout, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
 end
 
+function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
+end
+
 function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator)
     ccall((:vkDestroyPipelineLayout, libvulkan), Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
+end
+
+function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
 end
 
 function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler)
     ccall((:vkCreateSampler, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
 end
 
+function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
+end
+
 function vkDestroySampler(device, sampler, pAllocator)
     ccall((:vkDestroySampler, libvulkan), Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
+end
+
+function vkDestroySampler(device, sampler, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
 end
 
 function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout)
     ccall((:vkCreateDescriptorSetLayout, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
 end
 
+function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
+end
+
 function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator)
     ccall((:vkDestroyDescriptorSetLayout, libvulkan), Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
+end
+
+function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
 end
 
 function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool)
     ccall((:vkCreateDescriptorPool, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
 end
 
+function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
+end
+
 function vkDestroyDescriptorPool(device, descriptorPool, pAllocator)
     ccall((:vkDestroyDescriptorPool, libvulkan), Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
+end
+
+function vkDestroyDescriptorPool(device, descriptorPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
 end
 
 function vkResetDescriptorPool(device, descriptorPool, flags)
     ccall((:vkResetDescriptorPool, libvulkan), VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
 end
 
+function vkResetDescriptorPool(device, descriptorPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
+end
+
 function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets)
     ccall((:vkAllocateDescriptorSets, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
+end
+
+function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
 end
 
 function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets)
     ccall((:vkFreeDescriptorSets, libvulkan), VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
 end
 
+function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
+end
+
 function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
     ccall((:vkUpdateDescriptorSets, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
+end
+
+function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
 end
 
 function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer)
     ccall((:vkCreateFramebuffer, libvulkan), VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
 end
 
+function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
+end
+
 function vkDestroyFramebuffer(device, framebuffer, pAllocator)
     ccall((:vkDestroyFramebuffer, libvulkan), Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
+end
+
+function vkDestroyFramebuffer(device, framebuffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
 end
 
 function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkDestroyRenderPass(device, renderPass, pAllocator)
     ccall((:vkDestroyRenderPass, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
+end
+
+function vkDestroyRenderPass(device, renderPass, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
 end
 
 function vkGetRenderAreaGranularity(device, renderPass, pGranularity)
     ccall((:vkGetRenderAreaGranularity, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
 end
 
+function vkGetRenderAreaGranularity(device, renderPass, pGranularity, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
+end
+
 function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool)
     ccall((:vkCreateCommandPool, libvulkan), VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
+end
+
+function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
 end
 
 function vkDestroyCommandPool(device, commandPool, pAllocator)
     ccall((:vkDestroyCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
 end
 
+function vkDestroyCommandPool(device, commandPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
+end
+
 function vkResetCommandPool(device, commandPool, flags)
     ccall((:vkResetCommandPool, libvulkan), VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
+end
+
+function vkResetCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
 end
 
 function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers)
     ccall((:vkAllocateCommandBuffers, libvulkan), VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
 end
 
+function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
+end
+
 function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers)
     ccall((:vkFreeCommandBuffers, libvulkan), Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
+end
+
+function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
 end
 
 function vkBeginCommandBuffer(commandBuffer, pBeginInfo)
     ccall((:vkBeginCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
 end
 
+function vkBeginCommandBuffer(commandBuffer, pBeginInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
+end
+
 function vkEndCommandBuffer(commandBuffer)
     ccall((:vkEndCommandBuffer, libvulkan), VkResult, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkEndCommandBuffer(commandBuffer, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer,), commandBuffer)
 end
 
 function vkResetCommandBuffer(commandBuffer, flags)
     ccall((:vkResetCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
 end
 
+function vkResetCommandBuffer(commandBuffer, flags, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
+end
+
 function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline)
     ccall((:vkCmdBindPipeline, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
+end
+
+function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
 end
 
 function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports)
     ccall((:vkCmdSetViewport, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
 end
 
+function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
+end
+
 function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors)
     ccall((:vkCmdSetScissor, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
+end
+
+function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
 end
 
 function vkCmdSetLineWidth(commandBuffer, lineWidth)
     ccall((:vkCmdSetLineWidth, libvulkan), Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
 end
 
+function vkCmdSetLineWidth(commandBuffer, lineWidth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
+end
+
 function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
     ccall((:vkCmdSetDepthBias, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
+end
+
+function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
 end
 
 function vkCmdSetBlendConstants(commandBuffer, blendConstants)
     ccall((:vkCmdSetBlendConstants, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
 end
 
+function vkCmdSetBlendConstants(commandBuffer, blendConstants, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
+end
+
 function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds)
     ccall((:vkCmdSetDepthBounds, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
+end
+
+function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
 end
 
 function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask)
     ccall((:vkCmdSetStencilCompareMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
 end
 
+function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
+end
+
 function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask)
     ccall((:vkCmdSetStencilWriteMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
+end
+
+function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
 end
 
 function vkCmdSetStencilReference(commandBuffer, faceMask, reference)
     ccall((:vkCmdSetStencilReference, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
 end
 
+function vkCmdSetStencilReference(commandBuffer, faceMask, reference, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
+end
+
 function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
     ccall((:vkCmdBindDescriptorSets, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
+end
+
+function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
 end
 
 function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType)
     ccall((:vkCmdBindIndexBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
 end
 
+function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
+end
+
 function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
     ccall((:vkCmdBindVertexBuffers, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
+end
+
+function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
 end
 
 function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
     ccall((:vkCmdDraw, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
 end
 
+function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
+end
+
 function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
     ccall((:vkCmdDrawIndexed, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
+end
+
+function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
 end
 
 function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndexedIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
 function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatch, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
 end
 
+function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
+end
+
 function vkCmdDispatchIndirect(commandBuffer, buffer, offset)
     ccall((:vkCmdDispatchIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
+end
+
+function vkCmdDispatchIndirect(commandBuffer, buffer, offset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
 end
 
 function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
     ccall((:vkCmdBlitImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
 end
 
+function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
+end
+
 function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyBufferToImage, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyImageToBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData)
     ccall((:vkCmdUpdateBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
+end
+
+function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
 end
 
 function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data)
     ccall((:vkCmdFillBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
 end
 
+function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
+end
+
 function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
     ccall((:vkCmdClearColorImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
+end
+
+function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
 end
 
 function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
     ccall((:vkCmdClearDepthStencilImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
 end
 
+function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
+end
+
 function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
     ccall((:vkCmdClearAttachments, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
+end
+
+function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
 end
 
 function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdResolveImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
+function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
 function vkCmdSetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdSetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
+function vkCmdSetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
 function vkCmdResetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
+function vkCmdResetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
 function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdWaitEvents, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
+function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
 function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdPipelineBarrier, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
+function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
 function vkCmdBeginQuery(commandBuffer, queryPool, query, flags)
     ccall((:vkCmdBeginQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
+end
+
+function vkCmdBeginQuery(commandBuffer, queryPool, query, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
 end
 
 function vkCmdEndQuery(commandBuffer, queryPool, query)
     ccall((:vkCmdEndQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
 end
 
+function vkCmdEndQuery(commandBuffer, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
+end
+
 function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount)
     ccall((:vkCmdResetQueryPool, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
+end
+
+function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
 end
 
 function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query)
     ccall((:vkCmdWriteTimestamp, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
+end
+
 function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
     ccall((:vkCmdCopyQueryPoolResults, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
+end
+
+function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
 end
 
 function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues)
     ccall((:vkCmdPushConstants, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
 end
 
+function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
+end
+
 function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents)
     ccall((:vkCmdBeginRenderPass, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
+end
+
+function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
 end
 
 function vkCmdNextSubpass(commandBuffer, contents)
     ccall((:vkCmdNextSubpass, libvulkan), Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
 end
 
+function vkCmdNextSubpass(commandBuffer, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
+end
+
 function vkCmdEndRenderPass(commandBuffer)
     ccall((:vkCmdEndRenderPass, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndRenderPass(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers)
     ccall((:vkCmdExecuteCommands, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
+end
+
+function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
 end
 
 const VkSamplerYcbcrConversion = UInt64
@@ -4973,112 +5521,224 @@ function vkEnumerateInstanceVersion(pApiVersion)
     ccall((:vkEnumerateInstanceVersion, libvulkan), VkResult, (Ptr{UInt32},), pApiVersion)
 end
 
+function vkEnumerateInstanceVersion(pApiVersion, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32},), pApiVersion)
+end
+
 function vkBindBufferMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindBufferMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 function vkBindImageMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindImageMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
     ccall((:vkGetDeviceGroupPeerMemoryFeatures, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
+function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
 function vkCmdSetDeviceMask(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMask, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMask(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBase, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroups, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
+function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
 function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
 function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
+function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
 function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
 function vkTrimCommandPool(device, commandPool, flags)
     ccall((:vkTrimCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
+function vkTrimCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
 function vkGetDeviceQueue2(device, pQueueInfo, pQueue)
     ccall((:vkGetDeviceQueue2, libvulkan), Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
 end
 
+function vkGetDeviceQueue2(device, pQueueInfo, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
+end
+
 function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion)
     ccall((:vkCreateSamplerYcbcrConversion, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
+function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
 function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversion, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
+function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
 function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
     ccall((:vkCreateDescriptorUpdateTemplate, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
+function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
 function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
+function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
 function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFenceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphoreProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
+function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
 function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupport, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
+function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
 @cenum VkDriverId::UInt32 begin
@@ -5778,52 +6438,104 @@ function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, coun
     ccall((:vkCmdDrawIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 function vkResetQueryPool(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
+function vkResetQueryPool(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
 function vkGetSemaphoreCounterValue(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValue, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
+function vkGetSemaphoreCounterValue(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
 function vkWaitSemaphores(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphores, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphores(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphore(device, pSignalInfo)
     ccall((:vkSignalSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphore(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 function vkGetBufferDeviceAddress(device, pInfo)
     ccall((:vkGetBufferDeviceAddress, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddress(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkSurfaceKHR = UInt64
@@ -5922,20 +6634,40 @@ function vkDestroySurfaceKHR(instance, surface, pAllocator)
     ccall((:vkDestroySurfaceKHR, libvulkan), Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
 end
 
+function vkDestroySurfaceKHR(instance, surface, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
+end
+
 function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported)
     ccall((:vkGetPhysicalDeviceSurfaceSupportKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
+end
+
+function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
 end
 
 function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormatsKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
 end
 
+function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
+end
+
 function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes)
     ccall((:vkGetPhysicalDeviceSurfacePresentModesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
+end
+
+function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
 end
 
 const VkSwapchainKHR = UInt64
@@ -6066,36 +6798,72 @@ function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain)
     ccall((:vkCreateSwapchainKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
 end
 
+function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
+end
+
 function vkDestroySwapchainKHR(device, swapchain, pAllocator)
     ccall((:vkDestroySwapchainKHR, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
+end
+
+function vkDestroySwapchainKHR(device, swapchain, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
 end
 
 function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages)
     ccall((:vkGetSwapchainImagesKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
 end
 
+function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
+end
+
 function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex)
     ccall((:vkAcquireNextImageKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
+end
+
+function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
 end
 
 function vkQueuePresentKHR(queue, pPresentInfo)
     ccall((:vkQueuePresentKHR, libvulkan), VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
 end
 
+function vkQueuePresentKHR(queue, pPresentInfo, fptr)
+    ccall(fptr, VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
+end
+
 function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities)
     ccall((:vkGetDeviceGroupPresentCapabilitiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
+end
+
+function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
 end
 
 function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes)
     ccall((:vkGetDeviceGroupSurfacePresentModesKHR, libvulkan), VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
 end
 
+function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
+end
+
 function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects)
     ccall((:vkGetPhysicalDevicePresentRectanglesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
 end
 
+function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
+end
+
 function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex)
     ccall((:vkAcquireNextImage2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
+end
+
+function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
 end
 
 const VkDisplayKHR = UInt64
@@ -6198,28 +6966,56 @@ function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount,
     ccall((:vkGetPhysicalDeviceDisplayPropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlanePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays)
     ccall((:vkGetDisplayPlaneSupportedDisplaysKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
 end
 
+function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
+end
+
 function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
+function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
 function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode)
     ccall((:vkCreateDisplayModeKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
 end
 
+function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
+end
+
 function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
 end
 
+function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
+end
+
 function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateDisplayPlaneSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
+function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
 struct VkDisplayPresentInfoKHR
@@ -6235,6 +7031,10 @@ const PFN_vkCreateSharedSwapchainsKHR = Ptr{Cvoid}
 
 function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
     ccall((:vkCreateSharedSwapchainsKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
+end
+
+function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
 end
 
 const VkRenderPassMultiviewCreateInfoKHR = VkRenderPassMultiviewCreateInfo
@@ -6286,28 +7086,56 @@ function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
 const VkPeerMemoryFeatureFlagsKHR = VkPeerMemoryFeatureFlags
@@ -6345,12 +7173,24 @@ function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceInd
     ccall((:vkGetDeviceGroupPeerMemoryFeaturesKHR, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
+function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
 function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMaskKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBaseKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 const VkCommandPoolTrimFlagsKHR = VkCommandPoolTrimFlags
@@ -6362,6 +7202,10 @@ function vkTrimCommandPoolKHR(device, commandPool, flags)
     ccall((:vkTrimCommandPoolKHR, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
+function vkTrimCommandPoolKHR(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
 const VkPhysicalDeviceGroupPropertiesKHR = VkPhysicalDeviceGroupProperties
 
 const VkDeviceGroupDeviceCreateInfoKHR = VkDeviceGroupDeviceCreateInfo
@@ -6371,6 +7215,10 @@ const PFN_vkEnumeratePhysicalDeviceGroupsKHR = Ptr{Cvoid}
 
 function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroupsKHR, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
+function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
 const VkExternalMemoryHandleTypeFlagsKHR = VkExternalMemoryHandleTypeFlags
@@ -6398,6 +7246,10 @@ const PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferPropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
+function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
 const VkExternalMemoryImageCreateInfoKHR = VkExternalMemoryImageCreateInfo
@@ -6436,8 +7288,16 @@ function vkGetMemoryFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetMemoryFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
+function vkGetMemoryFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
 function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties)
     ccall((:vkGetMemoryFdPropertiesKHR, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
+end
+
+function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
 end
 
 const VkExternalSemaphoreHandleTypeFlagsKHR = VkExternalSemaphoreHandleTypeFlags
@@ -6457,6 +7317,10 @@ const PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphorePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
+function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
 const VkSemaphoreImportFlagsKHR = VkSemaphoreImportFlags
@@ -6491,8 +7355,16 @@ function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo)
     ccall((:vkImportSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
 end
 
+function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
+end
+
 function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 struct VkPhysicalDevicePushDescriptorPropertiesKHR
@@ -6511,8 +7383,16 @@ function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set
     ccall((:vkCmdPushDescriptorSetKHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
 end
 
+function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
+end
+
 function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData)
     ccall((:vkCmdPushDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
+end
+
+function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
 end
 
 const VkPhysicalDeviceShaderFloat16Int8FeaturesKHR = VkPhysicalDeviceShaderFloat16Int8Features
@@ -6562,12 +7442,24 @@ function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pD
     ccall((:vkCreateDescriptorUpdateTemplateKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
+function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
 function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 const VkPhysicalDeviceImagelessFramebufferFeaturesKHR = VkPhysicalDeviceImagelessFramebufferFeatures
@@ -6608,16 +7500,32 @@ function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 struct VkSharedPresentSurfaceCapabilitiesKHR
@@ -6631,6 +7539,10 @@ const PFN_vkGetSwapchainStatusKHR = Ptr{Cvoid}
 
 function vkGetSwapchainStatusKHR(device, swapchain)
     ccall((:vkGetSwapchainStatusKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
+end
+
+function vkGetSwapchainStatusKHR(device, swapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
 end
 
 const VkExternalFenceHandleTypeFlagsKHR = VkExternalFenceHandleTypeFlags
@@ -6650,6 +7562,10 @@ const PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFencePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 const VkFenceImportFlagsKHR = VkFenceImportFlags
@@ -6684,8 +7600,16 @@ function vkImportFenceFdKHR(device, pImportFenceFdInfo)
     ccall((:vkImportFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
 end
 
+function vkImportFenceFdKHR(device, pImportFenceFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
+end
+
 function vkGetFenceFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetFenceFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 @cenum VkPerformanceCounterUnitKHR::UInt32 begin
@@ -6832,16 +7756,32 @@ function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physica
     ccall((:vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
 end
 
+function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
+end
+
 function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
     ccall((:vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
+end
+
+function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
 end
 
 function vkAcquireProfilingLockKHR(device, pInfo)
     ccall((:vkAcquireProfilingLockKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
 end
 
+function vkAcquireProfilingLockKHR(device, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
+end
+
 function vkReleaseProfilingLockKHR(device)
     ccall((:vkReleaseProfilingLockKHR, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkReleaseProfilingLockKHR(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 const VkPointClippingBehaviorKHR = VkPointClippingBehavior
@@ -6886,8 +7826,16 @@ function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormats2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
+end
+
+function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
 end
 
 const VkPhysicalDeviceVariablePointerFeaturesKHR = VkPhysicalDeviceVariablePointersFeatures
@@ -6941,16 +7889,32 @@ function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount
     ccall((:vkGetPhysicalDeviceDisplayProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlaneProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModeProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
+function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
 function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
+end
+
+function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
 end
 
 const VkMemoryDedicatedRequirementsKHR = VkMemoryDedicatedRequirements
@@ -6980,12 +7944,24 @@ function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 const VkImageFormatListCreateInfoKHR = VkImageFormatListCreateInfo
@@ -7020,8 +7996,16 @@ function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcb
     ccall((:vkCreateSamplerYcbcrConversionKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
+function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
 function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversionKHR, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
+function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
 const VkBindBufferMemoryInfoKHR = VkBindBufferMemoryInfo
@@ -7038,8 +8022,16 @@ function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 const VkPhysicalDeviceMaintenance3PropertiesKHR = VkPhysicalDeviceMaintenance3Properties
@@ -7053,6 +8045,10 @@ function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupportKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
+function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountKHR ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
 const PFN_vkCmdDrawIndirectCountKHR = Ptr{Cvoid}
 
@@ -7063,8 +8059,16 @@ function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 const VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR = VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures
@@ -7129,12 +8133,24 @@ function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValueKHR, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
+function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
 function vkWaitSemaphoresKHR(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphoresKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphoresKHR(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphoreKHR(device, pSignalInfo)
     ccall((:vkSignalSemaphoreKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphoreKHR(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR = VkPhysicalDeviceVulkanMemoryModelFeatures
@@ -7215,8 +8231,16 @@ function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentSha
     ccall((:vkGetPhysicalDeviceFragmentShadingRatesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
 end
 
+function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
+end
+
 function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps)
     ccall((:vkCmdSetFragmentShadingRateKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
+end
+
+function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
 end
 
 struct VkSurfaceProtectedCapabilitiesKHR
@@ -7256,12 +8280,24 @@ function vkGetBufferDeviceAddressKHR(device, pInfo)
     ccall((:vkGetBufferDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkDeferredOperationKHR = UInt64
@@ -7285,20 +8321,40 @@ function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation)
     ccall((:vkCreateDeferredOperationKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
 end
 
+function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
+end
+
 function vkDestroyDeferredOperationKHR(device, operation, pAllocator)
     ccall((:vkDestroyDeferredOperationKHR, libvulkan), Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
+end
+
+function vkDestroyDeferredOperationKHR(device, operation, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
 end
 
 function vkGetDeferredOperationMaxConcurrencyKHR(device, operation)
     ccall((:vkGetDeferredOperationMaxConcurrencyKHR, libvulkan), UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationMaxConcurrencyKHR(device, operation, fptr)
+    ccall(fptr, UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkGetDeferredOperationResultKHR(device, operation)
     ccall((:vkGetDeferredOperationResultKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationResultKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkDeferredOperationJoinKHR(device, operation)
     ccall((:vkDeferredOperationJoinKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
+function vkDeferredOperationJoinKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
 @cenum VkPipelineExecutableStatisticFormatKHR::UInt32 begin
@@ -7392,12 +8448,24 @@ function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutable
     ccall((:vkGetPipelineExecutablePropertiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
 end
 
+function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutableCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
+end
+
 function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics)
     ccall((:vkGetPipelineExecutableStatisticsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
 end
 
+function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
+end
+
 function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
     ccall((:vkGetPipelineExecutableInternalRepresentationsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
+end
+
+function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
 end
 
 struct VkPipelineLibraryCreateInfoKHR
@@ -7549,32 +8617,64 @@ function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo)
     ccall((:vkCmdSetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
 end
 
+function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
+end
+
 function vkCmdResetEvent2KHR(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
+end
+
+function vkCmdResetEvent2KHR(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
 end
 
 function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos)
     ccall((:vkCmdWaitEvents2KHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
 end
 
+function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
+end
+
 function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo)
     ccall((:vkCmdPipelineBarrier2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
+end
+
+function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
 end
 
 function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query)
     ccall((:vkCmdWriteTimestamp2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
+end
+
 function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit2KHR, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
+function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
 function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarker2AMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
 end
 
+function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
+end
+
 function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointData2NV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR
@@ -7725,24 +8825,48 @@ function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo)
     ccall((:vkCmdCopyBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
 end
 
+function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
+end
+
 function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo)
     ccall((:vkCmdCopyImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
+end
+
+function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
 end
 
 function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo)
     ccall((:vkCmdCopyBufferToImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
 end
 
+function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
+end
+
 function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo)
     ccall((:vkCmdCopyImageToBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
+end
+
+function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
 end
 
 function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo)
     ccall((:vkCmdBlitImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
 end
 
+function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
+end
+
 function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo)
     ccall((:vkCmdResolveImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
+end
+
+function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
 end
 
 const VkDebugReportCallbackEXT = UInt64
@@ -7826,12 +8950,24 @@ function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCall
     ccall((:vkCreateDebugReportCallbackEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
 end
 
+function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
+end
+
 function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator)
     ccall((:vkDestroyDebugReportCallbackEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
 end
 
+function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
+end
+
 function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
     ccall((:vkDebugReportMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
+end
+
+function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
 end
 
 @cenum VkRasterizationOrderAMD::UInt32 begin
@@ -7890,20 +9026,40 @@ function vkDebugMarkerSetObjectTagEXT(device, pTagInfo)
     ccall((:vkDebugMarkerSetObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
 end
 
+function vkDebugMarkerSetObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
+end
+
 function vkDebugMarkerSetObjectNameEXT(device, pNameInfo)
     ccall((:vkDebugMarkerSetObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
+end
+
+function vkDebugMarkerSetObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
 end
 
 function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerBeginEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdDebugMarkerEndEXT(commandBuffer)
     ccall((:vkCmdDebugMarkerEndEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdDebugMarkerEndEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerInsertEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
 struct VkDedicatedAllocationImageCreateInfoNV
@@ -7978,24 +9134,48 @@ function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindi
     ccall((:vkCmdBindTransformFeedbackBuffersEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
 end
 
+function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
+end
+
 function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdBeginTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
+function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
 function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdEndTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
+function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
 function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index)
     ccall((:vkCmdBeginQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
+end
+
+function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
 end
 
 function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index)
     ccall((:vkCmdEndQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
 end
 
+function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
+end
+
 function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
     ccall((:vkCmdDrawIndirectByteCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
+end
+
+function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
 end
 
 struct VkImageViewHandleInfoNVX
@@ -8023,8 +9203,16 @@ function vkGetImageViewHandleNVX(device, pInfo)
     ccall((:vkGetImageViewHandleNVX, libvulkan), UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
 end
 
+function vkGetImageViewHandleNVX(device, pInfo, fptr)
+    ccall(fptr, UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
+end
+
 function vkGetImageViewAddressNVX(device, imageView, pProperties)
     ccall((:vkGetImageViewAddressNVX, libvulkan), VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
+end
+
+function vkGetImageViewAddressNVX(device, imageView, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
 end
 
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountAMD ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
@@ -8037,8 +9225,16 @@ function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkTextureLODGatherFormatPropertiesAMD
@@ -8079,6 +9275,10 @@ function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, 
     ccall((:vkGetShaderInfoAMD, libvulkan), VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
 end
 
+function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
+end
+
 struct VkPhysicalDeviceCornerSampledImageFeaturesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8116,6 +9316,10 @@ const PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
     ccall((:vkGetPhysicalDeviceExternalImageFormatPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
 end
 
 struct VkExternalMemoryImageCreateInfoNV
@@ -8199,8 +9403,16 @@ function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingB
     ccall((:vkCmdBeginConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
 end
 
+function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
+end
+
 function vkCmdEndConditionalRenderingEXT(commandBuffer)
     ccall((:vkCmdEndConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkCmdEndConditionalRenderingEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
 struct VkViewportWScalingNV
@@ -8223,11 +9435,19 @@ function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount,
     ccall((:vkCmdSetViewportWScalingNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
 end
 
+function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
+end
+
 # typedef VkResult ( VKAPI_PTR * PFN_vkReleaseDisplayEXT ) ( VkPhysicalDevice physicalDevice , VkDisplayKHR display )
 const PFN_vkReleaseDisplayEXT = Ptr{Cvoid}
 
 function vkReleaseDisplayEXT(physicalDevice, display)
     ccall((:vkReleaseDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
+function vkReleaseDisplayEXT(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
 @cenum VkSurfaceCounterFlagBitsEXT::UInt32 begin
@@ -8259,6 +9479,10 @@ const PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2EXT, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
+function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
 @cenum VkDisplayPowerStateEXT::UInt32 begin
@@ -8318,16 +9542,32 @@ function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo)
     ccall((:vkDisplayPowerControlEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
 end
 
+function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
+end
+
 function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDeviceEventEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
+end
+
+function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
 end
 
 function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDisplayEventEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
 end
 
+function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
+end
+
 function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue)
     ccall((:vkGetSwapchainCounterEXT, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
+end
+
+function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
 end
 
 struct VkRefreshCycleDurationGOOGLE
@@ -8364,8 +9604,16 @@ function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProper
     ccall((:vkGetRefreshCycleDurationGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
 end
 
+function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
+end
+
 function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings)
     ccall((:vkGetPastPresentationTimingGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
+end
+
+function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
 end
 
 struct VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX
@@ -8431,6 +9679,10 @@ const PFN_vkCmdSetDiscardRectangleEXT = Ptr{Cvoid}
 
 function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
     ccall((:vkCmdSetDiscardRectangleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
+end
+
+function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
 end
 
 @cenum VkConservativeRasterizationModeEXT::UInt32 begin
@@ -8502,6 +9754,10 @@ const PFN_vkSetHdrMetadataEXT = Ptr{Cvoid}
 
 function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata)
     ccall((:vkSetHdrMetadataEXT, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
+end
+
+function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
 end
 
 const VkDebugUtilsMessengerEXT = UInt64
@@ -8619,44 +9875,88 @@ function vkSetDebugUtilsObjectNameEXT(device, pNameInfo)
     ccall((:vkSetDebugUtilsObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
 end
 
+function vkSetDebugUtilsObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
+end
+
 function vkSetDebugUtilsObjectTagEXT(device, pTagInfo)
     ccall((:vkSetDebugUtilsObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
+end
+
+function vkSetDebugUtilsObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
 end
 
 function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkQueueEndDebugUtilsLabelEXT(queue)
     ccall((:vkQueueEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue,), queue)
+end
+
+function vkQueueEndDebugUtilsLabelEXT(queue, fptr)
+    ccall(fptr, Cvoid, (VkQueue,), queue)
 end
 
 function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCmdEndDebugUtilsLabelEXT(commandBuffer)
     ccall((:vkCmdEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndDebugUtilsLabelEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger)
     ccall((:vkCreateDebugUtilsMessengerEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
 end
 
+function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
+end
+
 function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator)
     ccall((:vkDestroyDebugUtilsMessengerEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
 end
 
+function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
+end
+
 function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData)
     ccall((:vkSubmitDebugUtilsMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
+end
+
+function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
 end
 
 const VkSamplerReductionModeEXT = VkSamplerReductionMode
@@ -8761,8 +10061,16 @@ function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo)
     ccall((:vkCmdSetSampleLocationsEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
 end
 
+function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
+end
+
 function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties)
     ccall((:vkGetPhysicalDeviceMultisamplePropertiesEXT, libvulkan), Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
+end
+
+function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
 end
 
 @cenum VkBlendOverlapEXT::UInt32 begin
@@ -8890,6 +10198,10 @@ function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties)
     ccall((:vkGetImageDrmFormatModifierPropertiesEXT, libvulkan), VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
 end
 
+function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
+end
+
 const VkValidationCacheEXT = UInt64
 
 @cenum VkValidationCacheHeaderVersionEXT::UInt32 begin
@@ -8929,16 +10241,32 @@ function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidation
     ccall((:vkCreateValidationCacheEXT, libvulkan), VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
 end
 
+function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
+end
+
 function vkDestroyValidationCacheEXT(device, validationCache, pAllocator)
     ccall((:vkDestroyValidationCacheEXT, libvulkan), Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
+end
+
+function vkDestroyValidationCacheEXT(device, validationCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
 end
 
 function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergeValidationCachesEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData)
     ccall((:vkGetValidationCacheDataEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
+end
+
+function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
 end
 
 const VkDescriptorBindingFlagBitsEXT = VkDescriptorBindingFlagBits
@@ -9041,12 +10369,24 @@ function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout)
     ccall((:vkCmdBindShadingRateImageNV, libvulkan), Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
 end
 
+function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
+end
+
 function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
     ccall((:vkCmdSetViewportShadingRatePaletteNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
 end
 
+function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
+end
+
 function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
     ccall((:vkCmdSetCoarseSampleOrderNV, libvulkan), Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
+end
+
+function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
 end
 
 const VkAccelerationStructureNV = UInt64
@@ -9371,52 +10711,104 @@ function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccel
     ccall((:vkCreateAccelerationStructureNV, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureNV, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements)
     ccall((:vkGetAccelerationStructureMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
+end
+
 function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos)
     ccall((:vkBindAccelerationStructureMemoryNV, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
 end
 
 function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
     ccall((:vkCmdBuildAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
 end
 
+function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
+end
+
 function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode)
     ccall((:vkCmdCopyAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
+end
+
+function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
 end
 
 function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
     ccall((:vkCmdTraceRaysNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
 end
 
+function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesNV, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
+function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
 function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData)
     ccall((:vkGetAccelerationStructureHandleNV, libvulkan), VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
 end
 
+function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
+function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
 function vkCompileDeferredNV(device, pipeline, shader)
     ccall((:vkCompileDeferredNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
+end
+
+function vkCompileDeferredNV(device, pipeline, shader, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
 end
 
 struct VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV
@@ -9484,11 +10876,19 @@ function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, p
     ccall((:vkGetMemoryHostPointerPropertiesEXT, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
 end
 
+function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, pMemoryHostPointerProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdWriteBufferMarkerAMD ) ( VkCommandBuffer commandBuffer , VkPipelineStageFlagBits pipelineStage , VkBuffer dstBuffer , VkDeviceSize dstOffset , uint32_t marker )
 const PFN_vkCmdWriteBufferMarkerAMD = Ptr{Cvoid}
 
 function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarkerAMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
+end
+
+function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
 end
 
 @cenum VkPipelineCompilerControlFlagBitsAMD::UInt32 begin
@@ -9527,8 +10927,16 @@ function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDom
     ccall((:vkGetPhysicalDeviceCalibrateableTimeDomainsEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
 end
 
+function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDomainCount, pTimeDomains, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
+end
+
 function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
     ccall((:vkGetCalibratedTimestampsEXT, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
+end
+
+function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
 end
 
 struct VkPhysicalDeviceShaderCorePropertiesAMD
@@ -9660,12 +11068,24 @@ function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask)
     ccall((:vkCmdDrawMeshTasksNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
 end
 
+function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
+end
+
 function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectCountNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV
@@ -9700,6 +11120,10 @@ function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclus
     ccall((:vkCmdSetExclusiveScissorNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
 end
 
+function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
+end
+
 struct VkQueueFamilyCheckpointPropertiesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -9723,8 +11147,16 @@ function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker)
     ccall((:vkCmdSetCheckpointNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
 end
 
+function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
+end
+
 function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointDataNV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL
@@ -9866,36 +11298,72 @@ function vkInitializePerformanceApiINTEL(device, pInitializeInfo)
     ccall((:vkInitializePerformanceApiINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
 end
 
+function vkInitializePerformanceApiINTEL(device, pInitializeInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
+end
+
 function vkUninitializePerformanceApiINTEL(device)
     ccall((:vkUninitializePerformanceApiINTEL, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkUninitializePerformanceApiINTEL(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceStreamMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
 function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo)
     ccall((:vkCmdSetPerformanceOverrideINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
 end
 
+function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
+end
+
 function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration)
     ccall((:vkAcquirePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
+end
+
+function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
 end
 
 function vkReleasePerformanceConfigurationINTEL(device, configuration)
     ccall((:vkReleasePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
 end
 
+function vkReleasePerformanceConfigurationINTEL(device, configuration, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
+end
+
 function vkQueueSetPerformanceConfigurationINTEL(queue, configuration)
     ccall((:vkQueueSetPerformanceConfigurationINTEL, libvulkan), VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
 end
 
+function vkQueueSetPerformanceConfigurationINTEL(queue, configuration, fptr)
+    ccall(fptr, VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
+end
+
 function vkGetPerformanceParameterINTEL(device, parameter, pValue)
     ccall((:vkGetPerformanceParameterINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
+end
+
+function vkGetPerformanceParameterINTEL(device, parameter, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
 end
 
 struct VkPhysicalDevicePCIBusInfoPropertiesEXT
@@ -9924,6 +11392,10 @@ const PFN_vkSetLocalDimmingAMD = Ptr{Cvoid}
 
 function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable)
     ccall((:vkSetLocalDimmingAMD, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
+end
+
+function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
 end
 
 struct VkPhysicalDeviceFragmentDensityMapFeaturesEXT
@@ -10048,6 +11520,10 @@ function vkGetBufferDeviceAddressEXT(device, pInfo)
     ccall((:vkGetBufferDeviceAddressEXT, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressEXT(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 @cenum VkToolPurposeFlagBitsEXT::UInt32 begin
     VK_TOOL_PURPOSE_VALIDATION_BIT_EXT = 1
     VK_TOOL_PURPOSE_PROFILING_BIT_EXT = 2
@@ -10076,6 +11552,10 @@ const PFN_vkGetPhysicalDeviceToolPropertiesEXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties)
     ccall((:vkGetPhysicalDeviceToolPropertiesEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
+end
+
+function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
 end
 
 const VkImageStencilUsageCreateInfoEXT = VkImageStencilUsageCreateInfo
@@ -10165,6 +11645,10 @@ function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPrope
     ccall((:vkGetPhysicalDeviceCooperativeMatrixPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
+end
+
 @cenum VkCoverageReductionModeNV::UInt32 begin
     VK_COVERAGE_REDUCTION_MODE_MERGE_NV = 0
     VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV = 1
@@ -10200,6 +11684,10 @@ const PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV = Pt
 
 function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations)
     ccall((:vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
+end
+
+function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
 end
 
 struct VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT
@@ -10257,6 +11745,10 @@ function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateHeadlessSurfaceEXT, libvulkan), VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 @cenum VkLineRasterizationModeEXT::UInt32 begin
     VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT = 0
     VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT = 1
@@ -10298,6 +11790,10 @@ function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePat
     ccall((:vkCmdSetLineStippleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
 end
 
+function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
+end
+
 struct VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10322,6 +11818,10 @@ const PFN_vkResetQueryPoolEXT = Ptr{Cvoid}
 
 function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPoolEXT, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
+function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
 struct VkPhysicalDeviceIndexTypeUint8FeaturesEXT
@@ -10376,48 +11876,96 @@ function vkCmdSetCullModeEXT(commandBuffer, cullMode)
     ccall((:vkCmdSetCullModeEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
 end
 
+function vkCmdSetCullModeEXT(commandBuffer, cullMode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
+end
+
 function vkCmdSetFrontFaceEXT(commandBuffer, frontFace)
     ccall((:vkCmdSetFrontFaceEXT, libvulkan), Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
+end
+
+function vkCmdSetFrontFaceEXT(commandBuffer, frontFace, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
 end
 
 function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology)
     ccall((:vkCmdSetPrimitiveTopologyEXT, libvulkan), Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
 end
 
+function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
+end
+
 function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports)
     ccall((:vkCmdSetViewportWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
+end
+
+function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
 end
 
 function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors)
     ccall((:vkCmdSetScissorWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
 end
 
+function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
+end
+
 function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
     ccall((:vkCmdBindVertexBuffers2EXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
+end
+
+function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
 end
 
 function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable)
     ccall((:vkCmdSetDepthTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
 end
 
+function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
+end
+
 function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable)
     ccall((:vkCmdSetDepthWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
+end
+
+function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
 end
 
 function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp)
     ccall((:vkCmdSetDepthCompareOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
 end
 
+function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
+end
+
 function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable)
     ccall((:vkCmdSetDepthBoundsTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
+end
+
+function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
 end
 
 function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable)
     ccall((:vkCmdSetStencilTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
 end
 
+function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
+end
+
 function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
     ccall((:vkCmdSetStencilOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
+end
+
+function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
 end
 
 struct VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT
@@ -10597,24 +12145,48 @@ function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequir
     ccall((:vkGetGeneratedCommandsMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo)
     ccall((:vkCmdPreprocessGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
+end
+
+function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
 end
 
 function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
     ccall((:vkCmdExecuteGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
 end
 
+function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
+end
+
 function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex)
     ccall((:vkCmdBindPipelineShaderGroupNV, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
+end
+
+function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
 end
 
 function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
     ccall((:vkCreateIndirectCommandsLayoutNV, libvulkan), VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
 end
 
+function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
+end
+
 function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator)
     ccall((:vkDestroyIndirectCommandsLayoutNV, libvulkan), Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
+end
+
+function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
 end
 
 struct VkPhysicalDeviceInheritedViewportScissorFeaturesNV
@@ -10776,16 +12348,32 @@ function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDat
     ccall((:vkCreatePrivateDataSlotEXT, libvulkan), VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
 end
 
+function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDataSlot, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
+end
+
 function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator)
     ccall((:vkDestroyPrivateDataSlotEXT, libvulkan), Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
+end
+
+function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
 end
 
 function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data)
     ccall((:vkSetPrivateDataEXT, libvulkan), VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
 end
 
+function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
+end
+
 function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData)
     ccall((:vkGetPrivateDataEXT, libvulkan), Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
+end
+
+function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
 end
 
 struct VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT
@@ -10866,6 +12454,10 @@ function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerO
     ccall((:vkCmdSetFragmentShadingRateEnumNV, libvulkan), Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
 end
 
+function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
+end
+
 struct VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10916,8 +12508,16 @@ function vkAcquireWinrtDisplayNV(physicalDevice, display)
     ccall((:vkAcquireWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
+function vkAcquireWinrtDisplayNV(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
 function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay)
     ccall((:vkGetWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
+end
+
+function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
 end
 
 struct VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE
@@ -10969,6 +12569,10 @@ function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pV
     ccall((:vkCmdSetVertexInputEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
 end
 
+function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
+end
+
 struct VkPhysicalDeviceExtendedDynamicState2FeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10996,20 +12600,40 @@ function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints)
     ccall((:vkCmdSetPatchControlPointsEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
 end
 
+function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
+end
+
 function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable)
     ccall((:vkCmdSetRasterizerDiscardEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
+end
+
+function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
 end
 
 function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable)
     ccall((:vkCmdSetDepthBiasEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
 end
 
+function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
+end
+
 function vkCmdSetLogicOpEXT(commandBuffer, logicOp)
     ccall((:vkCmdSetLogicOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
 end
 
+function vkCmdSetLogicOpEXT(commandBuffer, logicOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
+end
+
 function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable)
     ccall((:vkCmdSetPrimitiveRestartEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
+end
+
+function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
 end
 
 struct VkPhysicalDeviceColorWriteEnableFeaturesEXT
@@ -11030,6 +12654,10 @@ const PFN_vkCmdSetColorWriteEnableEXT = Ptr{Cvoid}
 
 function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables)
     ccall((:vkCmdSetColorWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
+end
+
+function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
 end
 
 const VkAccelerationStructureKHR = UInt64
@@ -11316,64 +12944,128 @@ function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAcce
     ccall((:vkCreateAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkCmdBuildAccelerationStructuresKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
     ccall((:vkCmdBuildAccelerationStructuresIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
+end
+
+function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
 end
 
 function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkBuildAccelerationStructuresKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureToMemoryKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
 end
 
+function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
+end
+
 function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyMemoryToAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
     ccall((:vkWriteAccelerationStructuresPropertiesKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
 end
 
+function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
+end
+
 function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureToMemoryKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
 end
 
+function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
+end
+
 function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyMemoryToAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo)
     ccall((:vkGetAccelerationStructureDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
 end
 
+function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
+function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
 function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility)
     ccall((:vkGetDeviceAccelerationStructureCompatibilityKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
 end
 
+function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
+end
+
 function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
     ccall((:vkGetAccelerationStructureBuildSizesKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
+end
+
+function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
 end
 
 @cenum VkShaderGroupShaderKHR::UInt32 begin
@@ -11476,24 +13168,48 @@ function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShader
     ccall((:vkCmdTraceRaysKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
 end
 
+function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingCaptureReplayShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
     ccall((:vkCmdTraceRaysIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
+end
+
+function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
 end
 
 function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader)
     ccall((:vkGetRayTracingShaderGroupStackSizeKHR, libvulkan), VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
 end
 
+function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader, fptr)
+    ccall(fptr, VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
+end
+
 function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize)
     ccall((:vkCmdSetRayTracingPipelineStackSizeKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
+end
+
+function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
 end
 
 struct VkPhysicalDeviceRayQueryFeaturesKHR
@@ -11526,8 +13242,16 @@ function vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateWaylandSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkWaylandSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkWaylandSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display)
     ccall((:vkGetPhysicalDeviceWaylandPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{wl_display}), physicalDevice, queueFamilyIndex, display)
+end
+
+function vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{wl_display}), physicalDevice, queueFamilyIndex, display)
 end
 
 const VkXcbSurfaceCreateFlagsKHR = VkFlags
@@ -11550,8 +13274,16 @@ function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXcbSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id)
     ccall((:vkGetPhysicalDeviceXcbPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
+end
+
+function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
 end
 
 const VkXlibSurfaceCreateFlagsKHR = VkFlags
@@ -11574,8 +13306,16 @@ function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXlibSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID)
     ccall((:vkGetPhysicalDeviceXlibPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
+end
+
+function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
 end
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkAcquireXlibDisplayEXT ) ( VkPhysicalDevice physicalDevice , Display * dpy , VkDisplayKHR display )
@@ -11588,8 +13328,16 @@ function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display)
     ccall((:vkAcquireXlibDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
 end
 
+function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
+end
+
 function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay)
     ccall((:vkGetRandROutputDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
+end
+
+function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
 end
 
 const VULKAN_H_ = 1

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -3162,24 +3162,16 @@ end
 
 const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
 
-function VkClearColorValue(float32::NTuple{4, Cfloat})
+function VkClearColorValue(val::__U_VkClearColorValue)
     ref = Ref{VkClearColorValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkClearColorValue(int32::NTuple{4, Int32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkClearColorValue(uint32::NTuple{4, UInt32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.uint32 = uint32
+    if val isa NTuple{4, Cfloat}
+        ptr.float32 = val
+    elseif val isa NTuple{4, Int32}
+        ptr.int32 = val
+    elseif val isa NTuple{4, UInt32}
+        ptr.uint32 = val
+    end
     ref[]
 end
 
@@ -3211,17 +3203,14 @@ end
 
 const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
 
-function VkClearValue(color::VkClearColorValue)
+function VkClearValue(val::__U_VkClearValue)
     ref = Ref{VkClearValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.color = color
-    ref[]
-end
-
-function VkClearValue(depthStencil::VkClearDepthStencilValue)
-    ref = Ref{VkClearValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.depthStencil = depthStencil
+    if val isa VkClearColorValue
+        ptr.color = val
+    elseif val isa VkClearDepthStencilValue
+        ptr.depthStencil = val
+    end
     ref[]
 end
 
@@ -7768,45 +7757,22 @@ end
 
 const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
 
-function VkPerformanceCounterResultKHR(int32::Int32)
+function VkPerformanceCounterResultKHR(val::__U_VkPerformanceCounterResultKHR)
     ref = Ref{VkPerformanceCounterResultKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(int64::Int64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int64 = int64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint32::UInt32)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint32 = uint32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint64::UInt64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint64 = uint64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float32::Cfloat)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float64::Cdouble)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float64 = float64
+    if val isa Int32
+        ptr.int32 = val
+    elseif val isa Int64
+        ptr.int64 = val
+    elseif val isa UInt32
+        ptr.uint32 = val
+    elseif val isa UInt64
+        ptr.uint64 = val
+    elseif val isa Cfloat
+        ptr.float32 = val
+    elseif val isa Cdouble
+        ptr.float64 = val
+    end
     ref[]
 end
 
@@ -8501,31 +8467,18 @@ end
 
 const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
 
-function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+function VkPipelineExecutableStatisticValueKHR(val::__U_VkPipelineExecutableStatisticValueKHR)
     ref = Ref{VkPipelineExecutableStatisticValueKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.b32 = b32
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(i64::Int64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.i64 = i64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.u64 = u64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.f64 = f64
+    if val isa VkBool32
+        ptr.b32 = val
+    elseif val isa Int64
+        ptr.i64 = val
+    elseif val isa UInt64
+        ptr.u64 = val
+    elseif val isa Cdouble
+        ptr.f64 = val
+    end
     ref[]
 end
 
@@ -11349,38 +11302,20 @@ end
 
 const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
 
-function VkPerformanceValueDataINTEL(value32::UInt32)
+function VkPerformanceValueDataINTEL(val::__U_VkPerformanceValueDataINTEL)
     ref = Ref{VkPerformanceValueDataINTEL}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value32 = value32
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(value64::UInt64)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value64 = value64
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueFloat = valueFloat
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueBool::VkBool32)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueBool = valueBool
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueString = valueString
+    if val isa UInt32
+        ptr.value32 = val
+    elseif val isa UInt64
+        ptr.value64 = val
+    elseif val isa Cfloat
+        ptr.valueFloat = val
+    elseif val isa VkBool32
+        ptr.valueBool = val
+    elseif val isa Ptr{Cchar}
+        ptr.valueString = val
+    end
     ref[]
 end
 
@@ -12873,17 +12808,14 @@ end
 
 const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressKHR(val::__U_VkDeviceOrHostAddressKHR)
     ref = Ref{VkDeviceOrHostAddressKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -12910,17 +12842,14 @@ end
 
 const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressConstKHR(val::__U_VkDeviceOrHostAddressConstKHR)
     ref = Ref{VkDeviceOrHostAddressConstKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressConstKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -12981,24 +12910,16 @@ end
 
 const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
 
-function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+function VkAccelerationStructureGeometryDataKHR(val::__U_VkAccelerationStructureGeometryDataKHR)
     ref = Ref{VkAccelerationStructureGeometryDataKHR}()
     ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.triangles = triangles
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.aabbs = aabbs
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.instances = instances
+    if val isa VkAccelerationStructureGeometryTrianglesDataKHR
+        ptr.triangles = val
+    elseif val isa VkAccelerationStructureGeometryAabbsDataKHR
+        ptr.aabbs = val
+    elseif val isa VkAccelerationStructureGeometryInstancesDataKHR
+        ptr.instances = val
+    end
     ref[]
 end
 

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -3160,6 +3160,29 @@ function Base.setproperty!(x::Ptr{VkClearColorValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
+
+function VkClearColorValue(float32::NTuple{4, Cfloat})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkClearColorValue(int32::NTuple{4, Int32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkClearColorValue(uint32::NTuple{4, UInt32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
 struct VkClearDepthStencilValue
     depth::Cfloat
     stencil::UInt32
@@ -3184,6 +3207,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkClearValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
+
+function VkClearValue(color::VkClearColorValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.color = color
+    ref[]
+end
+
+function VkClearValue(depthStencil::VkClearDepthStencilValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.depthStencil = depthStencil
+    ref[]
 end
 
 struct VkClearAttachment
@@ -7727,6 +7766,50 @@ function Base.setproperty!(x::Ptr{VkPerformanceCounterResultKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
+
+function VkPerformanceCounterResultKHR(int32::Int32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(int64::Int64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int64 = int64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint32::UInt32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint64::UInt64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint64 = uint64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float32::Cfloat)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float64::Cdouble)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float64 = float64
+    ref[]
+end
+
 struct VkAcquireProfilingLockInfoKHR
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8414,6 +8497,36 @@ end
 
 function Base.setproperty!(x::Ptr{VkPipelineExecutableStatisticValueKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
+
+function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.b32 = b32
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(i64::Int64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.i64 = i64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.u64 = u64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.f64 = f64
+    ref[]
 end
 
 struct VkPipelineExecutableStatisticKHR
@@ -10666,6 +10779,18 @@ function Base.setproperty!(x::Ptr{VkAccelerationStructureInstanceKHR}, f::Symbol
     unsafe_store!(getproperty(x, f), v)
 end
 
+function VkAccelerationStructureInstanceKHR(transform::VkTransformMatrixKHR, instanceCustomIndex::UInt32, mask::UInt32, instanceShaderBindingTableRecordOffset::UInt32, flags::VkGeometryInstanceFlagsKHR, accelerationStructureReference::UInt64)
+    ref = Ref{VkAccelerationStructureInstanceKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureInstanceKHR}, ref)
+    ptr.transform = transform
+    ptr.instanceCustomIndex = instanceCustomIndex
+    ptr.mask = mask
+    ptr.instanceShaderBindingTableRecordOffset = instanceShaderBindingTableRecordOffset
+    ptr.flags = flags
+    ptr.accelerationStructureReference = accelerationStructureReference
+    ref[]
+end
+
 const VkAccelerationStructureInstanceNV = VkAccelerationStructureInstanceKHR
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkCreateAccelerationStructureNV ) ( VkDevice device , const VkAccelerationStructureCreateInfoNV * pCreateInfo , const VkAllocationCallbacks * pAllocator , VkAccelerationStructureNV * pAccelerationStructure )
@@ -11220,6 +11345,43 @@ end
 
 function Base.setproperty!(x::Ptr{VkPerformanceValueDataINTEL}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
+
+function VkPerformanceValueDataINTEL(value32::UInt32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value32 = value32
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(value64::UInt64)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value64 = value64
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueFloat = valueFloat
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueBool::VkBool32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueBool = valueBool
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueString = valueString
+    ref[]
 end
 
 struct VkPerformanceValueINTEL
@@ -12709,6 +12871,22 @@ function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
+end
+
 struct VkDeviceOrHostAddressConstKHR
     data::NTuple{8, UInt8}
 end
@@ -12728,6 +12906,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressConstKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
 end
 
 struct VkAccelerationStructureBuildRangeInfoKHR
@@ -12783,6 +12977,29 @@ end
 
 function Base.setproperty!(x::Ptr{VkAccelerationStructureGeometryDataKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
+
+function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.triangles = triangles
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.aabbs = aabbs
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.instances = instances
+    ref[]
 end
 
 struct VkAccelerationStructureGeometryKHR

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -3646,548 +3646,1096 @@ function vkCreateInstance(pCreateInfo, pAllocator, pInstance)
     ccall((:vkCreateInstance, libvulkan), VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
 end
 
+function vkCreateInstance(pCreateInfo, pAllocator, pInstance, fptr)
+    ccall(fptr, VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
+end
+
 function vkDestroyInstance(instance, pAllocator)
     ccall((:vkDestroyInstance, libvulkan), Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
+end
+
+function vkDestroyInstance(instance, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
 end
 
 function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices)
     ccall((:vkEnumeratePhysicalDevices, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
 end
 
+function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
+end
+
 function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
+end
+
+function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
 end
 
 function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceProperties(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
 end
 
+function vkGetPhysicalDeviceProperties(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
+end
+
 function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
+function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
 function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetInstanceProcAddr(instance, pName)
     ccall((:vkGetInstanceProcAddr, libvulkan), PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
+end
+
+function vkGetInstanceProcAddr(instance, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
 end
 
 function vkGetDeviceProcAddr(device, pName)
     ccall((:vkGetDeviceProcAddr, libvulkan), PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
 end
 
+function vkGetDeviceProcAddr(device, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
+end
+
 function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice)
     ccall((:vkCreateDevice, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
+end
+
+function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
 end
 
 function vkDestroyDevice(device, pAllocator)
     ccall((:vkDestroyDevice, libvulkan), Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
 end
 
+function vkDestroyDevice(device, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
+end
+
 function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceExtensionProperties, libvulkan), VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceExtensionProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
+end
+
 function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceLayerProperties, libvulkan), VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceLayerProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue)
     ccall((:vkGetDeviceQueue, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
+end
+
+function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
 end
 
 function vkQueueSubmit(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
+function vkQueueSubmit(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
 function vkQueueWaitIdle(queue)
     ccall((:vkQueueWaitIdle, libvulkan), VkResult, (VkQueue,), queue)
+end
+
+function vkQueueWaitIdle(queue, fptr)
+    ccall(fptr, VkResult, (VkQueue,), queue)
 end
 
 function vkDeviceWaitIdle(device)
     ccall((:vkDeviceWaitIdle, libvulkan), VkResult, (VkDevice,), device)
 end
 
+function vkDeviceWaitIdle(device, fptr)
+    ccall(fptr, VkResult, (VkDevice,), device)
+end
+
 function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory)
     ccall((:vkAllocateMemory, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
+end
+
+function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
 end
 
 function vkFreeMemory(device, memory, pAllocator)
     ccall((:vkFreeMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
 end
 
+function vkFreeMemory(device, memory, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
+end
+
 function vkMapMemory(device, memory, offset, size, flags, ppData)
     ccall((:vkMapMemory, libvulkan), VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
+end
+
+function vkMapMemory(device, memory, offset, size, flags, ppData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
 end
 
 function vkUnmapMemory(device, memory)
     ccall((:vkUnmapMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory), device, memory)
 end
 
+function vkUnmapMemory(device, memory, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory), device, memory)
+end
+
 function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkFlushMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
+function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
 function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkInvalidateMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
+function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
 function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes)
     ccall((:vkGetDeviceMemoryCommitment, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
+end
+
+function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
 end
 
 function vkBindBufferMemory(device, buffer, memory, memoryOffset)
     ccall((:vkBindBufferMemory, libvulkan), VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
 end
 
+function vkBindBufferMemory(device, buffer, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
+end
+
 function vkBindImageMemory(device, image, memory, memoryOffset)
     ccall((:vkBindImageMemory, libvulkan), VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
+end
+
+function vkBindImageMemory(device, image, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
 end
 
 function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
+end
+
 function vkGetImageMemoryRequirements(device, image, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements(device, image, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
 end
 
 function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
+function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
 end
 
 function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence)
     ccall((:vkQueueBindSparse, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
 end
 
+function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
+end
+
 function vkCreateFence(device, pCreateInfo, pAllocator, pFence)
     ccall((:vkCreateFence, libvulkan), VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
+end
+
+function vkCreateFence(device, pCreateInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
 end
 
 function vkDestroyFence(device, fence, pAllocator)
     ccall((:vkDestroyFence, libvulkan), Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
 end
 
+function vkDestroyFence(device, fence, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
+end
+
 function vkResetFences(device, fenceCount, pFences)
     ccall((:vkResetFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
+end
+
+function vkResetFences(device, fenceCount, pFences, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
 end
 
 function vkGetFenceStatus(device, fence)
     ccall((:vkGetFenceStatus, libvulkan), VkResult, (VkDevice, VkFence), device, fence)
 end
 
+function vkGetFenceStatus(device, fence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkFence), device, fence)
+end
+
 function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout)
     ccall((:vkWaitForFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
+end
+
+function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
 end
 
 function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore)
     ccall((:vkCreateSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
 end
 
+function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
+end
+
 function vkDestroySemaphore(device, semaphore, pAllocator)
     ccall((:vkDestroySemaphore, libvulkan), Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
+end
+
+function vkDestroySemaphore(device, semaphore, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
 end
 
 function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent)
     ccall((:vkCreateEvent, libvulkan), VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
 end
 
+function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
+end
+
 function vkDestroyEvent(device, event, pAllocator)
     ccall((:vkDestroyEvent, libvulkan), Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
+end
+
+function vkDestroyEvent(device, event, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
 end
 
 function vkGetEventStatus(device, event)
     ccall((:vkGetEventStatus, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkGetEventStatus(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkSetEvent(device, event)
     ccall((:vkSetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
+end
+
+function vkSetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
 end
 
 function vkResetEvent(device, event)
     ccall((:vkResetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkResetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool)
     ccall((:vkCreateQueryPool, libvulkan), VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
+end
+
+function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
 end
 
 function vkDestroyQueryPool(device, queryPool, pAllocator)
     ccall((:vkDestroyQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
 end
 
+function vkDestroyQueryPool(device, queryPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
+end
+
 function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
     ccall((:vkGetQueryPoolResults, libvulkan), VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
+end
+
+function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
 end
 
 function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer)
     ccall((:vkCreateBuffer, libvulkan), VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
 end
 
+function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
+end
+
 function vkDestroyBuffer(device, buffer, pAllocator)
     ccall((:vkDestroyBuffer, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
+end
+
+function vkDestroyBuffer(device, buffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
 end
 
 function vkCreateBufferView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateBufferView, libvulkan), VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
 end
 
+function vkCreateBufferView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
+end
+
 function vkDestroyBufferView(device, bufferView, pAllocator)
     ccall((:vkDestroyBufferView, libvulkan), Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
+end
+
+function vkDestroyBufferView(device, bufferView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
 end
 
 function vkCreateImage(device, pCreateInfo, pAllocator, pImage)
     ccall((:vkCreateImage, libvulkan), VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
 end
 
+function vkCreateImage(device, pCreateInfo, pAllocator, pImage, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
+end
+
 function vkDestroyImage(device, image, pAllocator)
     ccall((:vkDestroyImage, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
+end
+
+function vkDestroyImage(device, image, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
 end
 
 function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout)
     ccall((:vkGetImageSubresourceLayout, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
 end
 
+function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
+end
+
 function vkCreateImageView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateImageView, libvulkan), VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
+end
+
+function vkCreateImageView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
 end
 
 function vkDestroyImageView(device, imageView, pAllocator)
     ccall((:vkDestroyImageView, libvulkan), Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
 end
 
+function vkDestroyImageView(device, imageView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
+end
+
 function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule)
     ccall((:vkCreateShaderModule, libvulkan), VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
+end
+
+function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
 end
 
 function vkDestroyShaderModule(device, shaderModule, pAllocator)
     ccall((:vkDestroyShaderModule, libvulkan), Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
 end
 
+function vkDestroyShaderModule(device, shaderModule, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
+end
+
 function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache)
     ccall((:vkCreatePipelineCache, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
+end
+
+function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
 end
 
 function vkDestroyPipelineCache(device, pipelineCache, pAllocator)
     ccall((:vkDestroyPipelineCache, libvulkan), Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
 end
 
+function vkDestroyPipelineCache(device, pipelineCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
+end
+
 function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData)
     ccall((:vkGetPipelineCacheData, libvulkan), VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
+end
+
+function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
 end
 
 function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergePipelineCaches, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateGraphicsPipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateComputePipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
+function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
 function vkDestroyPipeline(device, pipeline, pAllocator)
     ccall((:vkDestroyPipeline, libvulkan), Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
+end
+
+function vkDestroyPipeline(device, pipeline, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
 end
 
 function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout)
     ccall((:vkCreatePipelineLayout, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
 end
 
+function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
+end
+
 function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator)
     ccall((:vkDestroyPipelineLayout, libvulkan), Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
+end
+
+function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
 end
 
 function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler)
     ccall((:vkCreateSampler, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
 end
 
+function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
+end
+
 function vkDestroySampler(device, sampler, pAllocator)
     ccall((:vkDestroySampler, libvulkan), Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
+end
+
+function vkDestroySampler(device, sampler, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
 end
 
 function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout)
     ccall((:vkCreateDescriptorSetLayout, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
 end
 
+function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
+end
+
 function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator)
     ccall((:vkDestroyDescriptorSetLayout, libvulkan), Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
+end
+
+function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
 end
 
 function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool)
     ccall((:vkCreateDescriptorPool, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
 end
 
+function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
+end
+
 function vkDestroyDescriptorPool(device, descriptorPool, pAllocator)
     ccall((:vkDestroyDescriptorPool, libvulkan), Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
+end
+
+function vkDestroyDescriptorPool(device, descriptorPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
 end
 
 function vkResetDescriptorPool(device, descriptorPool, flags)
     ccall((:vkResetDescriptorPool, libvulkan), VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
 end
 
+function vkResetDescriptorPool(device, descriptorPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
+end
+
 function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets)
     ccall((:vkAllocateDescriptorSets, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
+end
+
+function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
 end
 
 function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets)
     ccall((:vkFreeDescriptorSets, libvulkan), VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
 end
 
+function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
+end
+
 function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
     ccall((:vkUpdateDescriptorSets, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
+end
+
+function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
 end
 
 function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer)
     ccall((:vkCreateFramebuffer, libvulkan), VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
 end
 
+function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
+end
+
 function vkDestroyFramebuffer(device, framebuffer, pAllocator)
     ccall((:vkDestroyFramebuffer, libvulkan), Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
+end
+
+function vkDestroyFramebuffer(device, framebuffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
 end
 
 function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkDestroyRenderPass(device, renderPass, pAllocator)
     ccall((:vkDestroyRenderPass, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
+end
+
+function vkDestroyRenderPass(device, renderPass, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
 end
 
 function vkGetRenderAreaGranularity(device, renderPass, pGranularity)
     ccall((:vkGetRenderAreaGranularity, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
 end
 
+function vkGetRenderAreaGranularity(device, renderPass, pGranularity, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
+end
+
 function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool)
     ccall((:vkCreateCommandPool, libvulkan), VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
+end
+
+function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
 end
 
 function vkDestroyCommandPool(device, commandPool, pAllocator)
     ccall((:vkDestroyCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
 end
 
+function vkDestroyCommandPool(device, commandPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
+end
+
 function vkResetCommandPool(device, commandPool, flags)
     ccall((:vkResetCommandPool, libvulkan), VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
+end
+
+function vkResetCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
 end
 
 function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers)
     ccall((:vkAllocateCommandBuffers, libvulkan), VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
 end
 
+function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
+end
+
 function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers)
     ccall((:vkFreeCommandBuffers, libvulkan), Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
+end
+
+function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
 end
 
 function vkBeginCommandBuffer(commandBuffer, pBeginInfo)
     ccall((:vkBeginCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
 end
 
+function vkBeginCommandBuffer(commandBuffer, pBeginInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
+end
+
 function vkEndCommandBuffer(commandBuffer)
     ccall((:vkEndCommandBuffer, libvulkan), VkResult, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkEndCommandBuffer(commandBuffer, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer,), commandBuffer)
 end
 
 function vkResetCommandBuffer(commandBuffer, flags)
     ccall((:vkResetCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
 end
 
+function vkResetCommandBuffer(commandBuffer, flags, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
+end
+
 function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline)
     ccall((:vkCmdBindPipeline, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
+end
+
+function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
 end
 
 function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports)
     ccall((:vkCmdSetViewport, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
 end
 
+function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
+end
+
 function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors)
     ccall((:vkCmdSetScissor, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
+end
+
+function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
 end
 
 function vkCmdSetLineWidth(commandBuffer, lineWidth)
     ccall((:vkCmdSetLineWidth, libvulkan), Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
 end
 
+function vkCmdSetLineWidth(commandBuffer, lineWidth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
+end
+
 function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
     ccall((:vkCmdSetDepthBias, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
+end
+
+function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
 end
 
 function vkCmdSetBlendConstants(commandBuffer, blendConstants)
     ccall((:vkCmdSetBlendConstants, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
 end
 
+function vkCmdSetBlendConstants(commandBuffer, blendConstants, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
+end
+
 function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds)
     ccall((:vkCmdSetDepthBounds, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
+end
+
+function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
 end
 
 function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask)
     ccall((:vkCmdSetStencilCompareMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
 end
 
+function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
+end
+
 function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask)
     ccall((:vkCmdSetStencilWriteMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
+end
+
+function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
 end
 
 function vkCmdSetStencilReference(commandBuffer, faceMask, reference)
     ccall((:vkCmdSetStencilReference, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
 end
 
+function vkCmdSetStencilReference(commandBuffer, faceMask, reference, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
+end
+
 function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
     ccall((:vkCmdBindDescriptorSets, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
+end
+
+function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
 end
 
 function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType)
     ccall((:vkCmdBindIndexBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
 end
 
+function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
+end
+
 function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
     ccall((:vkCmdBindVertexBuffers, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
+end
+
+function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
 end
 
 function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
     ccall((:vkCmdDraw, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
 end
 
+function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
+end
+
 function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
     ccall((:vkCmdDrawIndexed, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
+end
+
+function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
 end
 
 function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndexedIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
 function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatch, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
 end
 
+function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
+end
+
 function vkCmdDispatchIndirect(commandBuffer, buffer, offset)
     ccall((:vkCmdDispatchIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
+end
+
+function vkCmdDispatchIndirect(commandBuffer, buffer, offset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
 end
 
 function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
     ccall((:vkCmdBlitImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
 end
 
+function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
+end
+
 function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyBufferToImage, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyImageToBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData)
     ccall((:vkCmdUpdateBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
+end
+
+function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
 end
 
 function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data)
     ccall((:vkCmdFillBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
 end
 
+function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
+end
+
 function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
     ccall((:vkCmdClearColorImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
+end
+
+function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
 end
 
 function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
     ccall((:vkCmdClearDepthStencilImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
 end
 
+function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
+end
+
 function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
     ccall((:vkCmdClearAttachments, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
+end
+
+function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
 end
 
 function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdResolveImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
+function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
 function vkCmdSetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdSetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
+function vkCmdSetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
 function vkCmdResetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
+function vkCmdResetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
 function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdWaitEvents, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
+function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
 function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdPipelineBarrier, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
+function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
 function vkCmdBeginQuery(commandBuffer, queryPool, query, flags)
     ccall((:vkCmdBeginQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
+end
+
+function vkCmdBeginQuery(commandBuffer, queryPool, query, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
 end
 
 function vkCmdEndQuery(commandBuffer, queryPool, query)
     ccall((:vkCmdEndQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
 end
 
+function vkCmdEndQuery(commandBuffer, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
+end
+
 function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount)
     ccall((:vkCmdResetQueryPool, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
+end
+
+function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
 end
 
 function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query)
     ccall((:vkCmdWriteTimestamp, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
+end
+
 function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
     ccall((:vkCmdCopyQueryPoolResults, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
+end
+
+function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
 end
 
 function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues)
     ccall((:vkCmdPushConstants, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
 end
 
+function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
+end
+
 function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents)
     ccall((:vkCmdBeginRenderPass, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
+end
+
+function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
 end
 
 function vkCmdNextSubpass(commandBuffer, contents)
     ccall((:vkCmdNextSubpass, libvulkan), Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
 end
 
+function vkCmdNextSubpass(commandBuffer, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
+end
+
 function vkCmdEndRenderPass(commandBuffer)
     ccall((:vkCmdEndRenderPass, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndRenderPass(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers)
     ccall((:vkCmdExecuteCommands, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
+end
+
+function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
 end
 
 const VkSamplerYcbcrConversion = UInt64
@@ -4973,112 +5521,224 @@ function vkEnumerateInstanceVersion(pApiVersion)
     ccall((:vkEnumerateInstanceVersion, libvulkan), VkResult, (Ptr{UInt32},), pApiVersion)
 end
 
+function vkEnumerateInstanceVersion(pApiVersion, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32},), pApiVersion)
+end
+
 function vkBindBufferMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindBufferMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 function vkBindImageMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindImageMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
     ccall((:vkGetDeviceGroupPeerMemoryFeatures, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
+function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
 function vkCmdSetDeviceMask(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMask, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMask(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBase, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroups, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
+function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
 function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
 function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
+function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
 function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
 function vkTrimCommandPool(device, commandPool, flags)
     ccall((:vkTrimCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
+function vkTrimCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
 function vkGetDeviceQueue2(device, pQueueInfo, pQueue)
     ccall((:vkGetDeviceQueue2, libvulkan), Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
 end
 
+function vkGetDeviceQueue2(device, pQueueInfo, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
+end
+
 function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion)
     ccall((:vkCreateSamplerYcbcrConversion, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
+function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
 function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversion, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
+function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
 function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
     ccall((:vkCreateDescriptorUpdateTemplate, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
+function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
 function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
+function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
 function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFenceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphoreProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
+function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
 function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupport, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
+function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
 @cenum VkDriverId::UInt32 begin
@@ -5778,52 +6438,104 @@ function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, coun
     ccall((:vkCmdDrawIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 function vkResetQueryPool(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
+function vkResetQueryPool(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
 function vkGetSemaphoreCounterValue(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValue, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
+function vkGetSemaphoreCounterValue(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
 function vkWaitSemaphores(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphores, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphores(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphore(device, pSignalInfo)
     ccall((:vkSignalSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphore(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 function vkGetBufferDeviceAddress(device, pInfo)
     ccall((:vkGetBufferDeviceAddress, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddress(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkSurfaceKHR = UInt64
@@ -5922,20 +6634,40 @@ function vkDestroySurfaceKHR(instance, surface, pAllocator)
     ccall((:vkDestroySurfaceKHR, libvulkan), Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
 end
 
+function vkDestroySurfaceKHR(instance, surface, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
+end
+
 function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported)
     ccall((:vkGetPhysicalDeviceSurfaceSupportKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
+end
+
+function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
 end
 
 function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormatsKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
 end
 
+function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
+end
+
 function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes)
     ccall((:vkGetPhysicalDeviceSurfacePresentModesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
+end
+
+function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
 end
 
 const VkSwapchainKHR = UInt64
@@ -6066,36 +6798,72 @@ function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain)
     ccall((:vkCreateSwapchainKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
 end
 
+function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
+end
+
 function vkDestroySwapchainKHR(device, swapchain, pAllocator)
     ccall((:vkDestroySwapchainKHR, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
+end
+
+function vkDestroySwapchainKHR(device, swapchain, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
 end
 
 function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages)
     ccall((:vkGetSwapchainImagesKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
 end
 
+function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
+end
+
 function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex)
     ccall((:vkAcquireNextImageKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
+end
+
+function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
 end
 
 function vkQueuePresentKHR(queue, pPresentInfo)
     ccall((:vkQueuePresentKHR, libvulkan), VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
 end
 
+function vkQueuePresentKHR(queue, pPresentInfo, fptr)
+    ccall(fptr, VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
+end
+
 function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities)
     ccall((:vkGetDeviceGroupPresentCapabilitiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
+end
+
+function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
 end
 
 function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes)
     ccall((:vkGetDeviceGroupSurfacePresentModesKHR, libvulkan), VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
 end
 
+function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
+end
+
 function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects)
     ccall((:vkGetPhysicalDevicePresentRectanglesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
 end
 
+function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
+end
+
 function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex)
     ccall((:vkAcquireNextImage2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
+end
+
+function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
 end
 
 const VkDisplayKHR = UInt64
@@ -6198,28 +6966,56 @@ function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount,
     ccall((:vkGetPhysicalDeviceDisplayPropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlanePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays)
     ccall((:vkGetDisplayPlaneSupportedDisplaysKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
 end
 
+function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
+end
+
 function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
+function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
 function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode)
     ccall((:vkCreateDisplayModeKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
 end
 
+function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
+end
+
 function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
 end
 
+function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
+end
+
 function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateDisplayPlaneSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
+function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
 struct VkDisplayPresentInfoKHR
@@ -6235,6 +7031,10 @@ const PFN_vkCreateSharedSwapchainsKHR = Ptr{Cvoid}
 
 function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
     ccall((:vkCreateSharedSwapchainsKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
+end
+
+function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
 end
 
 const VkRenderPassMultiviewCreateInfoKHR = VkRenderPassMultiviewCreateInfo
@@ -6286,28 +7086,56 @@ function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
 const VkPeerMemoryFeatureFlagsKHR = VkPeerMemoryFeatureFlags
@@ -6345,12 +7173,24 @@ function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceInd
     ccall((:vkGetDeviceGroupPeerMemoryFeaturesKHR, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
+function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
 function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMaskKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBaseKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 const VkCommandPoolTrimFlagsKHR = VkCommandPoolTrimFlags
@@ -6362,6 +7202,10 @@ function vkTrimCommandPoolKHR(device, commandPool, flags)
     ccall((:vkTrimCommandPoolKHR, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
+function vkTrimCommandPoolKHR(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
 const VkPhysicalDeviceGroupPropertiesKHR = VkPhysicalDeviceGroupProperties
 
 const VkDeviceGroupDeviceCreateInfoKHR = VkDeviceGroupDeviceCreateInfo
@@ -6371,6 +7215,10 @@ const PFN_vkEnumeratePhysicalDeviceGroupsKHR = Ptr{Cvoid}
 
 function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroupsKHR, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
+function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
 const VkExternalMemoryHandleTypeFlagsKHR = VkExternalMemoryHandleTypeFlags
@@ -6398,6 +7246,10 @@ const PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferPropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
+function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
 const VkExternalMemoryImageCreateInfoKHR = VkExternalMemoryImageCreateInfo
@@ -6436,8 +7288,16 @@ function vkGetMemoryFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetMemoryFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
+function vkGetMemoryFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
 function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties)
     ccall((:vkGetMemoryFdPropertiesKHR, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
+end
+
+function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
 end
 
 const VkExternalSemaphoreHandleTypeFlagsKHR = VkExternalSemaphoreHandleTypeFlags
@@ -6457,6 +7317,10 @@ const PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphorePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
+function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
 const VkSemaphoreImportFlagsKHR = VkSemaphoreImportFlags
@@ -6491,8 +7355,16 @@ function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo)
     ccall((:vkImportSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
 end
 
+function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
+end
+
 function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 struct VkPhysicalDevicePushDescriptorPropertiesKHR
@@ -6511,8 +7383,16 @@ function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set
     ccall((:vkCmdPushDescriptorSetKHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
 end
 
+function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
+end
+
 function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData)
     ccall((:vkCmdPushDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
+end
+
+function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
 end
 
 const VkPhysicalDeviceShaderFloat16Int8FeaturesKHR = VkPhysicalDeviceShaderFloat16Int8Features
@@ -6562,12 +7442,24 @@ function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pD
     ccall((:vkCreateDescriptorUpdateTemplateKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
+function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
 function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 const VkPhysicalDeviceImagelessFramebufferFeaturesKHR = VkPhysicalDeviceImagelessFramebufferFeatures
@@ -6608,16 +7500,32 @@ function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 struct VkSharedPresentSurfaceCapabilitiesKHR
@@ -6631,6 +7539,10 @@ const PFN_vkGetSwapchainStatusKHR = Ptr{Cvoid}
 
 function vkGetSwapchainStatusKHR(device, swapchain)
     ccall((:vkGetSwapchainStatusKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
+end
+
+function vkGetSwapchainStatusKHR(device, swapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
 end
 
 const VkExternalFenceHandleTypeFlagsKHR = VkExternalFenceHandleTypeFlags
@@ -6650,6 +7562,10 @@ const PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFencePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 const VkFenceImportFlagsKHR = VkFenceImportFlags
@@ -6684,8 +7600,16 @@ function vkImportFenceFdKHR(device, pImportFenceFdInfo)
     ccall((:vkImportFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
 end
 
+function vkImportFenceFdKHR(device, pImportFenceFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
+end
+
 function vkGetFenceFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetFenceFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 @cenum VkPerformanceCounterUnitKHR::UInt32 begin
@@ -6832,16 +7756,32 @@ function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physica
     ccall((:vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
 end
 
+function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
+end
+
 function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
     ccall((:vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
+end
+
+function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
 end
 
 function vkAcquireProfilingLockKHR(device, pInfo)
     ccall((:vkAcquireProfilingLockKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
 end
 
+function vkAcquireProfilingLockKHR(device, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
+end
+
 function vkReleaseProfilingLockKHR(device)
     ccall((:vkReleaseProfilingLockKHR, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkReleaseProfilingLockKHR(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 const VkPointClippingBehaviorKHR = VkPointClippingBehavior
@@ -6886,8 +7826,16 @@ function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormats2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
+end
+
+function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
 end
 
 const VkPhysicalDeviceVariablePointerFeaturesKHR = VkPhysicalDeviceVariablePointersFeatures
@@ -6941,16 +7889,32 @@ function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount
     ccall((:vkGetPhysicalDeviceDisplayProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlaneProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModeProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
+function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
 function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
+end
+
+function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
 end
 
 const VkMemoryDedicatedRequirementsKHR = VkMemoryDedicatedRequirements
@@ -6980,12 +7944,24 @@ function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 const VkImageFormatListCreateInfoKHR = VkImageFormatListCreateInfo
@@ -7020,8 +7996,16 @@ function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcb
     ccall((:vkCreateSamplerYcbcrConversionKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
+function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
 function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversionKHR, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
+function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
 const VkBindBufferMemoryInfoKHR = VkBindBufferMemoryInfo
@@ -7038,8 +8022,16 @@ function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 const VkPhysicalDeviceMaintenance3PropertiesKHR = VkPhysicalDeviceMaintenance3Properties
@@ -7053,6 +8045,10 @@ function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupportKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
+function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountKHR ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
 const PFN_vkCmdDrawIndirectCountKHR = Ptr{Cvoid}
 
@@ -7063,8 +8059,16 @@ function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 const VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR = VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures
@@ -7129,12 +8133,24 @@ function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValueKHR, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
+function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
 function vkWaitSemaphoresKHR(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphoresKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphoresKHR(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphoreKHR(device, pSignalInfo)
     ccall((:vkSignalSemaphoreKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphoreKHR(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR = VkPhysicalDeviceVulkanMemoryModelFeatures
@@ -7215,8 +8231,16 @@ function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentSha
     ccall((:vkGetPhysicalDeviceFragmentShadingRatesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
 end
 
+function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
+end
+
 function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps)
     ccall((:vkCmdSetFragmentShadingRateKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
+end
+
+function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
 end
 
 struct VkSurfaceProtectedCapabilitiesKHR
@@ -7256,12 +8280,24 @@ function vkGetBufferDeviceAddressKHR(device, pInfo)
     ccall((:vkGetBufferDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkDeferredOperationKHR = UInt64
@@ -7285,20 +8321,40 @@ function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation)
     ccall((:vkCreateDeferredOperationKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
 end
 
+function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
+end
+
 function vkDestroyDeferredOperationKHR(device, operation, pAllocator)
     ccall((:vkDestroyDeferredOperationKHR, libvulkan), Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
+end
+
+function vkDestroyDeferredOperationKHR(device, operation, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
 end
 
 function vkGetDeferredOperationMaxConcurrencyKHR(device, operation)
     ccall((:vkGetDeferredOperationMaxConcurrencyKHR, libvulkan), UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationMaxConcurrencyKHR(device, operation, fptr)
+    ccall(fptr, UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkGetDeferredOperationResultKHR(device, operation)
     ccall((:vkGetDeferredOperationResultKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationResultKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkDeferredOperationJoinKHR(device, operation)
     ccall((:vkDeferredOperationJoinKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
+function vkDeferredOperationJoinKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
 @cenum VkPipelineExecutableStatisticFormatKHR::UInt32 begin
@@ -7392,12 +8448,24 @@ function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutable
     ccall((:vkGetPipelineExecutablePropertiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
 end
 
+function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutableCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
+end
+
 function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics)
     ccall((:vkGetPipelineExecutableStatisticsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
 end
 
+function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
+end
+
 function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
     ccall((:vkGetPipelineExecutableInternalRepresentationsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
+end
+
+function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
 end
 
 struct VkPipelineLibraryCreateInfoKHR
@@ -7549,32 +8617,64 @@ function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo)
     ccall((:vkCmdSetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
 end
 
+function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
+end
+
 function vkCmdResetEvent2KHR(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
+end
+
+function vkCmdResetEvent2KHR(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
 end
 
 function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos)
     ccall((:vkCmdWaitEvents2KHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
 end
 
+function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
+end
+
 function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo)
     ccall((:vkCmdPipelineBarrier2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
+end
+
+function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
 end
 
 function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query)
     ccall((:vkCmdWriteTimestamp2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
+end
+
 function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit2KHR, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
+function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
 function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarker2AMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
 end
 
+function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
+end
+
 function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointData2NV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR
@@ -7725,24 +8825,48 @@ function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo)
     ccall((:vkCmdCopyBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
 end
 
+function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
+end
+
 function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo)
     ccall((:vkCmdCopyImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
+end
+
+function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
 end
 
 function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo)
     ccall((:vkCmdCopyBufferToImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
 end
 
+function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
+end
+
 function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo)
     ccall((:vkCmdCopyImageToBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
+end
+
+function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
 end
 
 function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo)
     ccall((:vkCmdBlitImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
 end
 
+function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
+end
+
 function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo)
     ccall((:vkCmdResolveImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
+end
+
+function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
 end
 
 const VkDebugReportCallbackEXT = UInt64
@@ -7826,12 +8950,24 @@ function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCall
     ccall((:vkCreateDebugReportCallbackEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
 end
 
+function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
+end
+
 function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator)
     ccall((:vkDestroyDebugReportCallbackEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
 end
 
+function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
+end
+
 function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
     ccall((:vkDebugReportMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
+end
+
+function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
 end
 
 @cenum VkRasterizationOrderAMD::UInt32 begin
@@ -7890,20 +9026,40 @@ function vkDebugMarkerSetObjectTagEXT(device, pTagInfo)
     ccall((:vkDebugMarkerSetObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
 end
 
+function vkDebugMarkerSetObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
+end
+
 function vkDebugMarkerSetObjectNameEXT(device, pNameInfo)
     ccall((:vkDebugMarkerSetObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
+end
+
+function vkDebugMarkerSetObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
 end
 
 function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerBeginEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdDebugMarkerEndEXT(commandBuffer)
     ccall((:vkCmdDebugMarkerEndEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdDebugMarkerEndEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerInsertEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
 struct VkDedicatedAllocationImageCreateInfoNV
@@ -7978,24 +9134,48 @@ function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindi
     ccall((:vkCmdBindTransformFeedbackBuffersEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
 end
 
+function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
+end
+
 function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdBeginTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
+function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
 function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdEndTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
+function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
 function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index)
     ccall((:vkCmdBeginQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
+end
+
+function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
 end
 
 function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index)
     ccall((:vkCmdEndQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
 end
 
+function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
+end
+
 function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
     ccall((:vkCmdDrawIndirectByteCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
+end
+
+function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
 end
 
 struct VkImageViewHandleInfoNVX
@@ -8023,8 +9203,16 @@ function vkGetImageViewHandleNVX(device, pInfo)
     ccall((:vkGetImageViewHandleNVX, libvulkan), UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
 end
 
+function vkGetImageViewHandleNVX(device, pInfo, fptr)
+    ccall(fptr, UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
+end
+
 function vkGetImageViewAddressNVX(device, imageView, pProperties)
     ccall((:vkGetImageViewAddressNVX, libvulkan), VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
+end
+
+function vkGetImageViewAddressNVX(device, imageView, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
 end
 
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountAMD ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
@@ -8037,8 +9225,16 @@ function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkTextureLODGatherFormatPropertiesAMD
@@ -8079,6 +9275,10 @@ function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, 
     ccall((:vkGetShaderInfoAMD, libvulkan), VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
 end
 
+function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
+end
+
 struct VkPhysicalDeviceCornerSampledImageFeaturesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8116,6 +9316,10 @@ const PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
     ccall((:vkGetPhysicalDeviceExternalImageFormatPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
 end
 
 struct VkExternalMemoryImageCreateInfoNV
@@ -8199,8 +9403,16 @@ function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingB
     ccall((:vkCmdBeginConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
 end
 
+function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
+end
+
 function vkCmdEndConditionalRenderingEXT(commandBuffer)
     ccall((:vkCmdEndConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkCmdEndConditionalRenderingEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
 struct VkViewportWScalingNV
@@ -8223,11 +9435,19 @@ function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount,
     ccall((:vkCmdSetViewportWScalingNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
 end
 
+function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
+end
+
 # typedef VkResult ( VKAPI_PTR * PFN_vkReleaseDisplayEXT ) ( VkPhysicalDevice physicalDevice , VkDisplayKHR display )
 const PFN_vkReleaseDisplayEXT = Ptr{Cvoid}
 
 function vkReleaseDisplayEXT(physicalDevice, display)
     ccall((:vkReleaseDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
+function vkReleaseDisplayEXT(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
 @cenum VkSurfaceCounterFlagBitsEXT::UInt32 begin
@@ -8259,6 +9479,10 @@ const PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2EXT, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
+function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
 @cenum VkDisplayPowerStateEXT::UInt32 begin
@@ -8318,16 +9542,32 @@ function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo)
     ccall((:vkDisplayPowerControlEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
 end
 
+function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
+end
+
 function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDeviceEventEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
+end
+
+function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
 end
 
 function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDisplayEventEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
 end
 
+function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
+end
+
 function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue)
     ccall((:vkGetSwapchainCounterEXT, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
+end
+
+function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
 end
 
 struct VkRefreshCycleDurationGOOGLE
@@ -8364,8 +9604,16 @@ function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProper
     ccall((:vkGetRefreshCycleDurationGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
 end
 
+function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
+end
+
 function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings)
     ccall((:vkGetPastPresentationTimingGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
+end
+
+function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
 end
 
 struct VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX
@@ -8431,6 +9679,10 @@ const PFN_vkCmdSetDiscardRectangleEXT = Ptr{Cvoid}
 
 function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
     ccall((:vkCmdSetDiscardRectangleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
+end
+
+function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
 end
 
 @cenum VkConservativeRasterizationModeEXT::UInt32 begin
@@ -8502,6 +9754,10 @@ const PFN_vkSetHdrMetadataEXT = Ptr{Cvoid}
 
 function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata)
     ccall((:vkSetHdrMetadataEXT, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
+end
+
+function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
 end
 
 const VkDebugUtilsMessengerEXT = UInt64
@@ -8619,44 +9875,88 @@ function vkSetDebugUtilsObjectNameEXT(device, pNameInfo)
     ccall((:vkSetDebugUtilsObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
 end
 
+function vkSetDebugUtilsObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
+end
+
 function vkSetDebugUtilsObjectTagEXT(device, pTagInfo)
     ccall((:vkSetDebugUtilsObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
+end
+
+function vkSetDebugUtilsObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
 end
 
 function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkQueueEndDebugUtilsLabelEXT(queue)
     ccall((:vkQueueEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue,), queue)
+end
+
+function vkQueueEndDebugUtilsLabelEXT(queue, fptr)
+    ccall(fptr, Cvoid, (VkQueue,), queue)
 end
 
 function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCmdEndDebugUtilsLabelEXT(commandBuffer)
     ccall((:vkCmdEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndDebugUtilsLabelEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger)
     ccall((:vkCreateDebugUtilsMessengerEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
 end
 
+function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
+end
+
 function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator)
     ccall((:vkDestroyDebugUtilsMessengerEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
 end
 
+function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
+end
+
 function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData)
     ccall((:vkSubmitDebugUtilsMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
+end
+
+function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
 end
 
 const VkSamplerReductionModeEXT = VkSamplerReductionMode
@@ -8761,8 +10061,16 @@ function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo)
     ccall((:vkCmdSetSampleLocationsEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
 end
 
+function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
+end
+
 function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties)
     ccall((:vkGetPhysicalDeviceMultisamplePropertiesEXT, libvulkan), Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
+end
+
+function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
 end
 
 @cenum VkBlendOverlapEXT::UInt32 begin
@@ -8890,6 +10198,10 @@ function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties)
     ccall((:vkGetImageDrmFormatModifierPropertiesEXT, libvulkan), VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
 end
 
+function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
+end
+
 const VkValidationCacheEXT = UInt64
 
 @cenum VkValidationCacheHeaderVersionEXT::UInt32 begin
@@ -8929,16 +10241,32 @@ function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidation
     ccall((:vkCreateValidationCacheEXT, libvulkan), VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
 end
 
+function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
+end
+
 function vkDestroyValidationCacheEXT(device, validationCache, pAllocator)
     ccall((:vkDestroyValidationCacheEXT, libvulkan), Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
+end
+
+function vkDestroyValidationCacheEXT(device, validationCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
 end
 
 function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergeValidationCachesEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData)
     ccall((:vkGetValidationCacheDataEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
+end
+
+function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
 end
 
 const VkDescriptorBindingFlagBitsEXT = VkDescriptorBindingFlagBits
@@ -9041,12 +10369,24 @@ function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout)
     ccall((:vkCmdBindShadingRateImageNV, libvulkan), Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
 end
 
+function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
+end
+
 function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
     ccall((:vkCmdSetViewportShadingRatePaletteNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
 end
 
+function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
+end
+
 function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
     ccall((:vkCmdSetCoarseSampleOrderNV, libvulkan), Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
+end
+
+function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
 end
 
 const VkAccelerationStructureNV = UInt64
@@ -9371,52 +10711,104 @@ function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccel
     ccall((:vkCreateAccelerationStructureNV, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureNV, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements)
     ccall((:vkGetAccelerationStructureMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
+end
+
 function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos)
     ccall((:vkBindAccelerationStructureMemoryNV, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
 end
 
 function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
     ccall((:vkCmdBuildAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
 end
 
+function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
+end
+
 function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode)
     ccall((:vkCmdCopyAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
+end
+
+function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
 end
 
 function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
     ccall((:vkCmdTraceRaysNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
 end
 
+function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesNV, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
+function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
 function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData)
     ccall((:vkGetAccelerationStructureHandleNV, libvulkan), VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
 end
 
+function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
+function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
 function vkCompileDeferredNV(device, pipeline, shader)
     ccall((:vkCompileDeferredNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
+end
+
+function vkCompileDeferredNV(device, pipeline, shader, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
 end
 
 struct VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV
@@ -9484,11 +10876,19 @@ function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, p
     ccall((:vkGetMemoryHostPointerPropertiesEXT, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
 end
 
+function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, pMemoryHostPointerProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdWriteBufferMarkerAMD ) ( VkCommandBuffer commandBuffer , VkPipelineStageFlagBits pipelineStage , VkBuffer dstBuffer , VkDeviceSize dstOffset , uint32_t marker )
 const PFN_vkCmdWriteBufferMarkerAMD = Ptr{Cvoid}
 
 function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarkerAMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
+end
+
+function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
 end
 
 @cenum VkPipelineCompilerControlFlagBitsAMD::UInt32 begin
@@ -9527,8 +10927,16 @@ function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDom
     ccall((:vkGetPhysicalDeviceCalibrateableTimeDomainsEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
 end
 
+function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDomainCount, pTimeDomains, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
+end
+
 function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
     ccall((:vkGetCalibratedTimestampsEXT, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
+end
+
+function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
 end
 
 struct VkPhysicalDeviceShaderCorePropertiesAMD
@@ -9660,12 +11068,24 @@ function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask)
     ccall((:vkCmdDrawMeshTasksNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
 end
 
+function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
+end
+
 function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectCountNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV
@@ -9700,6 +11120,10 @@ function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclus
     ccall((:vkCmdSetExclusiveScissorNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
 end
 
+function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
+end
+
 struct VkQueueFamilyCheckpointPropertiesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -9723,8 +11147,16 @@ function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker)
     ccall((:vkCmdSetCheckpointNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
 end
 
+function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
+end
+
 function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointDataNV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL
@@ -9866,36 +11298,72 @@ function vkInitializePerformanceApiINTEL(device, pInitializeInfo)
     ccall((:vkInitializePerformanceApiINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
 end
 
+function vkInitializePerformanceApiINTEL(device, pInitializeInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
+end
+
 function vkUninitializePerformanceApiINTEL(device)
     ccall((:vkUninitializePerformanceApiINTEL, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkUninitializePerformanceApiINTEL(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceStreamMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
 function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo)
     ccall((:vkCmdSetPerformanceOverrideINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
 end
 
+function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
+end
+
 function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration)
     ccall((:vkAcquirePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
+end
+
+function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
 end
 
 function vkReleasePerformanceConfigurationINTEL(device, configuration)
     ccall((:vkReleasePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
 end
 
+function vkReleasePerformanceConfigurationINTEL(device, configuration, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
+end
+
 function vkQueueSetPerformanceConfigurationINTEL(queue, configuration)
     ccall((:vkQueueSetPerformanceConfigurationINTEL, libvulkan), VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
 end
 
+function vkQueueSetPerformanceConfigurationINTEL(queue, configuration, fptr)
+    ccall(fptr, VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
+end
+
 function vkGetPerformanceParameterINTEL(device, parameter, pValue)
     ccall((:vkGetPerformanceParameterINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
+end
+
+function vkGetPerformanceParameterINTEL(device, parameter, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
 end
 
 struct VkPhysicalDevicePCIBusInfoPropertiesEXT
@@ -9924,6 +11392,10 @@ const PFN_vkSetLocalDimmingAMD = Ptr{Cvoid}
 
 function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable)
     ccall((:vkSetLocalDimmingAMD, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
+end
+
+function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
 end
 
 struct VkPhysicalDeviceFragmentDensityMapFeaturesEXT
@@ -10048,6 +11520,10 @@ function vkGetBufferDeviceAddressEXT(device, pInfo)
     ccall((:vkGetBufferDeviceAddressEXT, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressEXT(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 @cenum VkToolPurposeFlagBitsEXT::UInt32 begin
     VK_TOOL_PURPOSE_VALIDATION_BIT_EXT = 1
     VK_TOOL_PURPOSE_PROFILING_BIT_EXT = 2
@@ -10076,6 +11552,10 @@ const PFN_vkGetPhysicalDeviceToolPropertiesEXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties)
     ccall((:vkGetPhysicalDeviceToolPropertiesEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
+end
+
+function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
 end
 
 const VkImageStencilUsageCreateInfoEXT = VkImageStencilUsageCreateInfo
@@ -10165,6 +11645,10 @@ function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPrope
     ccall((:vkGetPhysicalDeviceCooperativeMatrixPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
+end
+
 @cenum VkCoverageReductionModeNV::UInt32 begin
     VK_COVERAGE_REDUCTION_MODE_MERGE_NV = 0
     VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV = 1
@@ -10200,6 +11684,10 @@ const PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV = Pt
 
 function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations)
     ccall((:vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
+end
+
+function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
 end
 
 struct VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT
@@ -10257,6 +11745,10 @@ function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateHeadlessSurfaceEXT, libvulkan), VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 @cenum VkLineRasterizationModeEXT::UInt32 begin
     VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT = 0
     VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT = 1
@@ -10298,6 +11790,10 @@ function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePat
     ccall((:vkCmdSetLineStippleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
 end
 
+function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
+end
+
 struct VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10322,6 +11818,10 @@ const PFN_vkResetQueryPoolEXT = Ptr{Cvoid}
 
 function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPoolEXT, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
+function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
 struct VkPhysicalDeviceIndexTypeUint8FeaturesEXT
@@ -10376,48 +11876,96 @@ function vkCmdSetCullModeEXT(commandBuffer, cullMode)
     ccall((:vkCmdSetCullModeEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
 end
 
+function vkCmdSetCullModeEXT(commandBuffer, cullMode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
+end
+
 function vkCmdSetFrontFaceEXT(commandBuffer, frontFace)
     ccall((:vkCmdSetFrontFaceEXT, libvulkan), Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
+end
+
+function vkCmdSetFrontFaceEXT(commandBuffer, frontFace, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
 end
 
 function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology)
     ccall((:vkCmdSetPrimitiveTopologyEXT, libvulkan), Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
 end
 
+function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
+end
+
 function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports)
     ccall((:vkCmdSetViewportWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
+end
+
+function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
 end
 
 function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors)
     ccall((:vkCmdSetScissorWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
 end
 
+function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
+end
+
 function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
     ccall((:vkCmdBindVertexBuffers2EXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
+end
+
+function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
 end
 
 function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable)
     ccall((:vkCmdSetDepthTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
 end
 
+function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
+end
+
 function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable)
     ccall((:vkCmdSetDepthWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
+end
+
+function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
 end
 
 function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp)
     ccall((:vkCmdSetDepthCompareOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
 end
 
+function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
+end
+
 function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable)
     ccall((:vkCmdSetDepthBoundsTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
+end
+
+function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
 end
 
 function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable)
     ccall((:vkCmdSetStencilTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
 end
 
+function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
+end
+
 function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
     ccall((:vkCmdSetStencilOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
+end
+
+function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
 end
 
 struct VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT
@@ -10597,24 +12145,48 @@ function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequir
     ccall((:vkGetGeneratedCommandsMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo)
     ccall((:vkCmdPreprocessGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
+end
+
+function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
 end
 
 function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
     ccall((:vkCmdExecuteGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
 end
 
+function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
+end
+
 function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex)
     ccall((:vkCmdBindPipelineShaderGroupNV, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
+end
+
+function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
 end
 
 function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
     ccall((:vkCreateIndirectCommandsLayoutNV, libvulkan), VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
 end
 
+function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
+end
+
 function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator)
     ccall((:vkDestroyIndirectCommandsLayoutNV, libvulkan), Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
+end
+
+function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
 end
 
 struct VkPhysicalDeviceInheritedViewportScissorFeaturesNV
@@ -10776,16 +12348,32 @@ function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDat
     ccall((:vkCreatePrivateDataSlotEXT, libvulkan), VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
 end
 
+function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDataSlot, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
+end
+
 function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator)
     ccall((:vkDestroyPrivateDataSlotEXT, libvulkan), Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
+end
+
+function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
 end
 
 function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data)
     ccall((:vkSetPrivateDataEXT, libvulkan), VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
 end
 
+function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
+end
+
 function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData)
     ccall((:vkGetPrivateDataEXT, libvulkan), Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
+end
+
+function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
 end
 
 struct VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT
@@ -10866,6 +12454,10 @@ function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerO
     ccall((:vkCmdSetFragmentShadingRateEnumNV, libvulkan), Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
 end
 
+function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
+end
+
 struct VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10916,8 +12508,16 @@ function vkAcquireWinrtDisplayNV(physicalDevice, display)
     ccall((:vkAcquireWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
+function vkAcquireWinrtDisplayNV(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
 function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay)
     ccall((:vkGetWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
+end
+
+function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
 end
 
 struct VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE
@@ -10969,6 +12569,10 @@ function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pV
     ccall((:vkCmdSetVertexInputEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
 end
 
+function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
+end
+
 struct VkPhysicalDeviceExtendedDynamicState2FeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10996,20 +12600,40 @@ function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints)
     ccall((:vkCmdSetPatchControlPointsEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
 end
 
+function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
+end
+
 function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable)
     ccall((:vkCmdSetRasterizerDiscardEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
+end
+
+function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
 end
 
 function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable)
     ccall((:vkCmdSetDepthBiasEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
 end
 
+function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
+end
+
 function vkCmdSetLogicOpEXT(commandBuffer, logicOp)
     ccall((:vkCmdSetLogicOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
 end
 
+function vkCmdSetLogicOpEXT(commandBuffer, logicOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
+end
+
 function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable)
     ccall((:vkCmdSetPrimitiveRestartEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
+end
+
+function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
 end
 
 struct VkPhysicalDeviceColorWriteEnableFeaturesEXT
@@ -11030,6 +12654,10 @@ const PFN_vkCmdSetColorWriteEnableEXT = Ptr{Cvoid}
 
 function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables)
     ccall((:vkCmdSetColorWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
+end
+
+function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
 end
 
 const VkAccelerationStructureKHR = UInt64
@@ -11316,64 +12944,128 @@ function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAcce
     ccall((:vkCreateAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkCmdBuildAccelerationStructuresKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
     ccall((:vkCmdBuildAccelerationStructuresIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
+end
+
+function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
 end
 
 function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkBuildAccelerationStructuresKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureToMemoryKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
 end
 
+function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
+end
+
 function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyMemoryToAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
     ccall((:vkWriteAccelerationStructuresPropertiesKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
 end
 
+function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
+end
+
 function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureToMemoryKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
 end
 
+function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
+end
+
 function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyMemoryToAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo)
     ccall((:vkGetAccelerationStructureDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
 end
 
+function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
+function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
 function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility)
     ccall((:vkGetDeviceAccelerationStructureCompatibilityKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
 end
 
+function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
+end
+
 function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
     ccall((:vkGetAccelerationStructureBuildSizesKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
+end
+
+function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
 end
 
 @cenum VkShaderGroupShaderKHR::UInt32 begin
@@ -11476,24 +13168,48 @@ function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShader
     ccall((:vkCmdTraceRaysKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
 end
 
+function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingCaptureReplayShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
     ccall((:vkCmdTraceRaysIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
+end
+
+function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
 end
 
 function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader)
     ccall((:vkGetRayTracingShaderGroupStackSizeKHR, libvulkan), VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
 end
 
+function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader, fptr)
+    ccall(fptr, VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
+end
+
 function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize)
     ccall((:vkCmdSetRayTracingPipelineStackSizeKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
+end
+
+function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
 end
 
 struct VkPhysicalDeviceRayQueryFeaturesKHR
@@ -11526,8 +13242,16 @@ function vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateWaylandSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkWaylandSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkWaylandSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display)
     ccall((:vkGetPhysicalDeviceWaylandPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{wl_display}), physicalDevice, queueFamilyIndex, display)
+end
+
+function vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{wl_display}), physicalDevice, queueFamilyIndex, display)
 end
 
 const VkXcbSurfaceCreateFlagsKHR = VkFlags
@@ -11550,8 +13274,16 @@ function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXcbSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id)
     ccall((:vkGetPhysicalDeviceXcbPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
+end
+
+function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
 end
 
 const VkXlibSurfaceCreateFlagsKHR = VkFlags
@@ -11574,8 +13306,16 @@ function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXlibSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID)
     ccall((:vkGetPhysicalDeviceXlibPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
+end
+
+function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
 end
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkAcquireXlibDisplayEXT ) ( VkPhysicalDevice physicalDevice , Display * dpy , VkDisplayKHR display )
@@ -11588,8 +13328,16 @@ function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display)
     ccall((:vkAcquireXlibDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
 end
 
+function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
+end
+
 function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay)
     ccall((:vkGetRandROutputDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
+end
+
+function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
 end
 
 const VULKAN_H_ = 1

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -3162,24 +3162,16 @@ end
 
 const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
 
-function VkClearColorValue(float32::NTuple{4, Cfloat})
+function VkClearColorValue(val::__U_VkClearColorValue)
     ref = Ref{VkClearColorValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkClearColorValue(int32::NTuple{4, Int32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkClearColorValue(uint32::NTuple{4, UInt32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.uint32 = uint32
+    if val isa NTuple{4, Cfloat}
+        ptr.float32 = val
+    elseif val isa NTuple{4, Int32}
+        ptr.int32 = val
+    elseif val isa NTuple{4, UInt32}
+        ptr.uint32 = val
+    end
     ref[]
 end
 
@@ -3211,17 +3203,14 @@ end
 
 const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
 
-function VkClearValue(color::VkClearColorValue)
+function VkClearValue(val::__U_VkClearValue)
     ref = Ref{VkClearValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.color = color
-    ref[]
-end
-
-function VkClearValue(depthStencil::VkClearDepthStencilValue)
-    ref = Ref{VkClearValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.depthStencil = depthStencil
+    if val isa VkClearColorValue
+        ptr.color = val
+    elseif val isa VkClearDepthStencilValue
+        ptr.depthStencil = val
+    end
     ref[]
 end
 
@@ -7768,45 +7757,22 @@ end
 
 const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
 
-function VkPerformanceCounterResultKHR(int32::Int32)
+function VkPerformanceCounterResultKHR(val::__U_VkPerformanceCounterResultKHR)
     ref = Ref{VkPerformanceCounterResultKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(int64::Int64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int64 = int64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint32::UInt32)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint32 = uint32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint64::UInt64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint64 = uint64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float32::Cfloat)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float64::Cdouble)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float64 = float64
+    if val isa Int32
+        ptr.int32 = val
+    elseif val isa Int64
+        ptr.int64 = val
+    elseif val isa UInt32
+        ptr.uint32 = val
+    elseif val isa UInt64
+        ptr.uint64 = val
+    elseif val isa Cfloat
+        ptr.float32 = val
+    elseif val isa Cdouble
+        ptr.float64 = val
+    end
     ref[]
 end
 
@@ -8501,31 +8467,18 @@ end
 
 const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
 
-function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+function VkPipelineExecutableStatisticValueKHR(val::__U_VkPipelineExecutableStatisticValueKHR)
     ref = Ref{VkPipelineExecutableStatisticValueKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.b32 = b32
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(i64::Int64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.i64 = i64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.u64 = u64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.f64 = f64
+    if val isa VkBool32
+        ptr.b32 = val
+    elseif val isa Int64
+        ptr.i64 = val
+    elseif val isa UInt64
+        ptr.u64 = val
+    elseif val isa Cdouble
+        ptr.f64 = val
+    end
     ref[]
 end
 
@@ -11349,38 +11302,20 @@ end
 
 const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
 
-function VkPerformanceValueDataINTEL(value32::UInt32)
+function VkPerformanceValueDataINTEL(val::__U_VkPerformanceValueDataINTEL)
     ref = Ref{VkPerformanceValueDataINTEL}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value32 = value32
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(value64::UInt64)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value64 = value64
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueFloat = valueFloat
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueBool::VkBool32)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueBool = valueBool
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueString = valueString
+    if val isa UInt32
+        ptr.value32 = val
+    elseif val isa UInt64
+        ptr.value64 = val
+    elseif val isa Cfloat
+        ptr.valueFloat = val
+    elseif val isa VkBool32
+        ptr.valueBool = val
+    elseif val isa Ptr{Cchar}
+        ptr.valueString = val
+    end
     ref[]
 end
 
@@ -12873,17 +12808,14 @@ end
 
 const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressKHR(val::__U_VkDeviceOrHostAddressKHR)
     ref = Ref{VkDeviceOrHostAddressKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -12910,17 +12842,14 @@ end
 
 const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressConstKHR(val::__U_VkDeviceOrHostAddressConstKHR)
     ref = Ref{VkDeviceOrHostAddressConstKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressConstKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -12981,24 +12910,16 @@ end
 
 const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
 
-function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+function VkAccelerationStructureGeometryDataKHR(val::__U_VkAccelerationStructureGeometryDataKHR)
     ref = Ref{VkAccelerationStructureGeometryDataKHR}()
     ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.triangles = triangles
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.aabbs = aabbs
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.instances = instances
+    if val isa VkAccelerationStructureGeometryTrianglesDataKHR
+        ptr.triangles = val
+    elseif val isa VkAccelerationStructureGeometryAabbsDataKHR
+        ptr.aabbs = val
+    elseif val isa VkAccelerationStructureGeometryInstancesDataKHR
+        ptr.instances = val
+    end
     ref[]
 end
 

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -3160,6 +3160,29 @@ function Base.setproperty!(x::Ptr{VkClearColorValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
+
+function VkClearColorValue(float32::NTuple{4, Cfloat})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkClearColorValue(int32::NTuple{4, Int32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkClearColorValue(uint32::NTuple{4, UInt32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
 struct VkClearDepthStencilValue
     depth::Cfloat
     stencil::UInt32
@@ -3184,6 +3207,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkClearValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
+
+function VkClearValue(color::VkClearColorValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.color = color
+    ref[]
+end
+
+function VkClearValue(depthStencil::VkClearDepthStencilValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.depthStencil = depthStencil
+    ref[]
 end
 
 struct VkClearAttachment
@@ -7727,6 +7766,50 @@ function Base.setproperty!(x::Ptr{VkPerformanceCounterResultKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
+
+function VkPerformanceCounterResultKHR(int32::Int32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(int64::Int64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int64 = int64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint32::UInt32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint64::UInt64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint64 = uint64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float32::Cfloat)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float64::Cdouble)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float64 = float64
+    ref[]
+end
+
 struct VkAcquireProfilingLockInfoKHR
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8414,6 +8497,36 @@ end
 
 function Base.setproperty!(x::Ptr{VkPipelineExecutableStatisticValueKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
+
+function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.b32 = b32
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(i64::Int64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.i64 = i64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.u64 = u64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.f64 = f64
+    ref[]
 end
 
 struct VkPipelineExecutableStatisticKHR
@@ -10666,6 +10779,18 @@ function Base.setproperty!(x::Ptr{VkAccelerationStructureInstanceKHR}, f::Symbol
     unsafe_store!(getproperty(x, f), v)
 end
 
+function VkAccelerationStructureInstanceKHR(transform::VkTransformMatrixKHR, instanceCustomIndex::UInt32, mask::UInt32, instanceShaderBindingTableRecordOffset::UInt32, flags::VkGeometryInstanceFlagsKHR, accelerationStructureReference::UInt64)
+    ref = Ref{VkAccelerationStructureInstanceKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureInstanceKHR}, ref)
+    ptr.transform = transform
+    ptr.instanceCustomIndex = instanceCustomIndex
+    ptr.mask = mask
+    ptr.instanceShaderBindingTableRecordOffset = instanceShaderBindingTableRecordOffset
+    ptr.flags = flags
+    ptr.accelerationStructureReference = accelerationStructureReference
+    ref[]
+end
+
 const VkAccelerationStructureInstanceNV = VkAccelerationStructureInstanceKHR
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkCreateAccelerationStructureNV ) ( VkDevice device , const VkAccelerationStructureCreateInfoNV * pCreateInfo , const VkAllocationCallbacks * pAllocator , VkAccelerationStructureNV * pAccelerationStructure )
@@ -11220,6 +11345,43 @@ end
 
 function Base.setproperty!(x::Ptr{VkPerformanceValueDataINTEL}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
+
+function VkPerformanceValueDataINTEL(value32::UInt32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value32 = value32
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(value64::UInt64)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value64 = value64
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueFloat = valueFloat
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueBool::VkBool32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueBool = valueBool
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueString = valueString
+    ref[]
 end
 
 struct VkPerformanceValueINTEL
@@ -12709,6 +12871,22 @@ function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
+end
+
 struct VkDeviceOrHostAddressConstKHR
     data::NTuple{8, UInt8}
 end
@@ -12728,6 +12906,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressConstKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
 end
 
 struct VkAccelerationStructureBuildRangeInfoKHR
@@ -12783,6 +12977,29 @@ end
 
 function Base.setproperty!(x::Ptr{VkAccelerationStructureGeometryDataKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
+
+function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.triangles = triangles
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.aabbs = aabbs
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.instances = instances
+    ref[]
 end
 
 struct VkAccelerationStructureGeometryKHR

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -3646,548 +3646,1096 @@ function vkCreateInstance(pCreateInfo, pAllocator, pInstance)
     ccall((:vkCreateInstance, libvulkan), VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
 end
 
+function vkCreateInstance(pCreateInfo, pAllocator, pInstance, fptr)
+    ccall(fptr, VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
+end
+
 function vkDestroyInstance(instance, pAllocator)
     ccall((:vkDestroyInstance, libvulkan), Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
+end
+
+function vkDestroyInstance(instance, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
 end
 
 function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices)
     ccall((:vkEnumeratePhysicalDevices, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
 end
 
+function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
+end
+
 function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
+end
+
+function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
 end
 
 function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceProperties(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
 end
 
+function vkGetPhysicalDeviceProperties(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
+end
+
 function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
+function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
 function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetInstanceProcAddr(instance, pName)
     ccall((:vkGetInstanceProcAddr, libvulkan), PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
+end
+
+function vkGetInstanceProcAddr(instance, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
 end
 
 function vkGetDeviceProcAddr(device, pName)
     ccall((:vkGetDeviceProcAddr, libvulkan), PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
 end
 
+function vkGetDeviceProcAddr(device, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
+end
+
 function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice)
     ccall((:vkCreateDevice, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
+end
+
+function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
 end
 
 function vkDestroyDevice(device, pAllocator)
     ccall((:vkDestroyDevice, libvulkan), Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
 end
 
+function vkDestroyDevice(device, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
+end
+
 function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceExtensionProperties, libvulkan), VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceExtensionProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
+end
+
 function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceLayerProperties, libvulkan), VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceLayerProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue)
     ccall((:vkGetDeviceQueue, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
+end
+
+function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
 end
 
 function vkQueueSubmit(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
+function vkQueueSubmit(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
 function vkQueueWaitIdle(queue)
     ccall((:vkQueueWaitIdle, libvulkan), VkResult, (VkQueue,), queue)
+end
+
+function vkQueueWaitIdle(queue, fptr)
+    ccall(fptr, VkResult, (VkQueue,), queue)
 end
 
 function vkDeviceWaitIdle(device)
     ccall((:vkDeviceWaitIdle, libvulkan), VkResult, (VkDevice,), device)
 end
 
+function vkDeviceWaitIdle(device, fptr)
+    ccall(fptr, VkResult, (VkDevice,), device)
+end
+
 function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory)
     ccall((:vkAllocateMemory, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
+end
+
+function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
 end
 
 function vkFreeMemory(device, memory, pAllocator)
     ccall((:vkFreeMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
 end
 
+function vkFreeMemory(device, memory, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
+end
+
 function vkMapMemory(device, memory, offset, size, flags, ppData)
     ccall((:vkMapMemory, libvulkan), VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
+end
+
+function vkMapMemory(device, memory, offset, size, flags, ppData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
 end
 
 function vkUnmapMemory(device, memory)
     ccall((:vkUnmapMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory), device, memory)
 end
 
+function vkUnmapMemory(device, memory, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory), device, memory)
+end
+
 function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkFlushMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
+function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
 function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkInvalidateMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
+function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
 function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes)
     ccall((:vkGetDeviceMemoryCommitment, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
+end
+
+function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
 end
 
 function vkBindBufferMemory(device, buffer, memory, memoryOffset)
     ccall((:vkBindBufferMemory, libvulkan), VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
 end
 
+function vkBindBufferMemory(device, buffer, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
+end
+
 function vkBindImageMemory(device, image, memory, memoryOffset)
     ccall((:vkBindImageMemory, libvulkan), VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
+end
+
+function vkBindImageMemory(device, image, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
 end
 
 function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
+end
+
 function vkGetImageMemoryRequirements(device, image, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements(device, image, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
 end
 
 function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
+function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
 end
 
 function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence)
     ccall((:vkQueueBindSparse, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
 end
 
+function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
+end
+
 function vkCreateFence(device, pCreateInfo, pAllocator, pFence)
     ccall((:vkCreateFence, libvulkan), VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
+end
+
+function vkCreateFence(device, pCreateInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
 end
 
 function vkDestroyFence(device, fence, pAllocator)
     ccall((:vkDestroyFence, libvulkan), Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
 end
 
+function vkDestroyFence(device, fence, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
+end
+
 function vkResetFences(device, fenceCount, pFences)
     ccall((:vkResetFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
+end
+
+function vkResetFences(device, fenceCount, pFences, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
 end
 
 function vkGetFenceStatus(device, fence)
     ccall((:vkGetFenceStatus, libvulkan), VkResult, (VkDevice, VkFence), device, fence)
 end
 
+function vkGetFenceStatus(device, fence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkFence), device, fence)
+end
+
 function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout)
     ccall((:vkWaitForFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
+end
+
+function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
 end
 
 function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore)
     ccall((:vkCreateSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
 end
 
+function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
+end
+
 function vkDestroySemaphore(device, semaphore, pAllocator)
     ccall((:vkDestroySemaphore, libvulkan), Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
+end
+
+function vkDestroySemaphore(device, semaphore, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
 end
 
 function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent)
     ccall((:vkCreateEvent, libvulkan), VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
 end
 
+function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
+end
+
 function vkDestroyEvent(device, event, pAllocator)
     ccall((:vkDestroyEvent, libvulkan), Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
+end
+
+function vkDestroyEvent(device, event, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
 end
 
 function vkGetEventStatus(device, event)
     ccall((:vkGetEventStatus, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkGetEventStatus(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkSetEvent(device, event)
     ccall((:vkSetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
+end
+
+function vkSetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
 end
 
 function vkResetEvent(device, event)
     ccall((:vkResetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkResetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool)
     ccall((:vkCreateQueryPool, libvulkan), VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
+end
+
+function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
 end
 
 function vkDestroyQueryPool(device, queryPool, pAllocator)
     ccall((:vkDestroyQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
 end
 
+function vkDestroyQueryPool(device, queryPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
+end
+
 function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
     ccall((:vkGetQueryPoolResults, libvulkan), VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
+end
+
+function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
 end
 
 function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer)
     ccall((:vkCreateBuffer, libvulkan), VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
 end
 
+function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
+end
+
 function vkDestroyBuffer(device, buffer, pAllocator)
     ccall((:vkDestroyBuffer, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
+end
+
+function vkDestroyBuffer(device, buffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
 end
 
 function vkCreateBufferView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateBufferView, libvulkan), VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
 end
 
+function vkCreateBufferView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
+end
+
 function vkDestroyBufferView(device, bufferView, pAllocator)
     ccall((:vkDestroyBufferView, libvulkan), Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
+end
+
+function vkDestroyBufferView(device, bufferView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
 end
 
 function vkCreateImage(device, pCreateInfo, pAllocator, pImage)
     ccall((:vkCreateImage, libvulkan), VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
 end
 
+function vkCreateImage(device, pCreateInfo, pAllocator, pImage, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
+end
+
 function vkDestroyImage(device, image, pAllocator)
     ccall((:vkDestroyImage, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
+end
+
+function vkDestroyImage(device, image, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
 end
 
 function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout)
     ccall((:vkGetImageSubresourceLayout, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
 end
 
+function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
+end
+
 function vkCreateImageView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateImageView, libvulkan), VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
+end
+
+function vkCreateImageView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
 end
 
 function vkDestroyImageView(device, imageView, pAllocator)
     ccall((:vkDestroyImageView, libvulkan), Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
 end
 
+function vkDestroyImageView(device, imageView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
+end
+
 function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule)
     ccall((:vkCreateShaderModule, libvulkan), VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
+end
+
+function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
 end
 
 function vkDestroyShaderModule(device, shaderModule, pAllocator)
     ccall((:vkDestroyShaderModule, libvulkan), Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
 end
 
+function vkDestroyShaderModule(device, shaderModule, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
+end
+
 function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache)
     ccall((:vkCreatePipelineCache, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
+end
+
+function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
 end
 
 function vkDestroyPipelineCache(device, pipelineCache, pAllocator)
     ccall((:vkDestroyPipelineCache, libvulkan), Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
 end
 
+function vkDestroyPipelineCache(device, pipelineCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
+end
+
 function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData)
     ccall((:vkGetPipelineCacheData, libvulkan), VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
+end
+
+function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
 end
 
 function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergePipelineCaches, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateGraphicsPipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateComputePipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
+function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
 function vkDestroyPipeline(device, pipeline, pAllocator)
     ccall((:vkDestroyPipeline, libvulkan), Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
+end
+
+function vkDestroyPipeline(device, pipeline, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
 end
 
 function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout)
     ccall((:vkCreatePipelineLayout, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
 end
 
+function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
+end
+
 function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator)
     ccall((:vkDestroyPipelineLayout, libvulkan), Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
+end
+
+function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
 end
 
 function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler)
     ccall((:vkCreateSampler, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
 end
 
+function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
+end
+
 function vkDestroySampler(device, sampler, pAllocator)
     ccall((:vkDestroySampler, libvulkan), Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
+end
+
+function vkDestroySampler(device, sampler, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
 end
 
 function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout)
     ccall((:vkCreateDescriptorSetLayout, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
 end
 
+function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
+end
+
 function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator)
     ccall((:vkDestroyDescriptorSetLayout, libvulkan), Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
+end
+
+function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
 end
 
 function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool)
     ccall((:vkCreateDescriptorPool, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
 end
 
+function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
+end
+
 function vkDestroyDescriptorPool(device, descriptorPool, pAllocator)
     ccall((:vkDestroyDescriptorPool, libvulkan), Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
+end
+
+function vkDestroyDescriptorPool(device, descriptorPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
 end
 
 function vkResetDescriptorPool(device, descriptorPool, flags)
     ccall((:vkResetDescriptorPool, libvulkan), VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
 end
 
+function vkResetDescriptorPool(device, descriptorPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
+end
+
 function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets)
     ccall((:vkAllocateDescriptorSets, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
+end
+
+function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
 end
 
 function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets)
     ccall((:vkFreeDescriptorSets, libvulkan), VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
 end
 
+function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
+end
+
 function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
     ccall((:vkUpdateDescriptorSets, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
+end
+
+function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
 end
 
 function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer)
     ccall((:vkCreateFramebuffer, libvulkan), VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
 end
 
+function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
+end
+
 function vkDestroyFramebuffer(device, framebuffer, pAllocator)
     ccall((:vkDestroyFramebuffer, libvulkan), Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
+end
+
+function vkDestroyFramebuffer(device, framebuffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
 end
 
 function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkDestroyRenderPass(device, renderPass, pAllocator)
     ccall((:vkDestroyRenderPass, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
+end
+
+function vkDestroyRenderPass(device, renderPass, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
 end
 
 function vkGetRenderAreaGranularity(device, renderPass, pGranularity)
     ccall((:vkGetRenderAreaGranularity, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
 end
 
+function vkGetRenderAreaGranularity(device, renderPass, pGranularity, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
+end
+
 function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool)
     ccall((:vkCreateCommandPool, libvulkan), VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
+end
+
+function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
 end
 
 function vkDestroyCommandPool(device, commandPool, pAllocator)
     ccall((:vkDestroyCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
 end
 
+function vkDestroyCommandPool(device, commandPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
+end
+
 function vkResetCommandPool(device, commandPool, flags)
     ccall((:vkResetCommandPool, libvulkan), VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
+end
+
+function vkResetCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
 end
 
 function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers)
     ccall((:vkAllocateCommandBuffers, libvulkan), VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
 end
 
+function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
+end
+
 function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers)
     ccall((:vkFreeCommandBuffers, libvulkan), Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
+end
+
+function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
 end
 
 function vkBeginCommandBuffer(commandBuffer, pBeginInfo)
     ccall((:vkBeginCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
 end
 
+function vkBeginCommandBuffer(commandBuffer, pBeginInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
+end
+
 function vkEndCommandBuffer(commandBuffer)
     ccall((:vkEndCommandBuffer, libvulkan), VkResult, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkEndCommandBuffer(commandBuffer, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer,), commandBuffer)
 end
 
 function vkResetCommandBuffer(commandBuffer, flags)
     ccall((:vkResetCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
 end
 
+function vkResetCommandBuffer(commandBuffer, flags, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
+end
+
 function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline)
     ccall((:vkCmdBindPipeline, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
+end
+
+function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
 end
 
 function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports)
     ccall((:vkCmdSetViewport, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
 end
 
+function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
+end
+
 function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors)
     ccall((:vkCmdSetScissor, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
+end
+
+function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
 end
 
 function vkCmdSetLineWidth(commandBuffer, lineWidth)
     ccall((:vkCmdSetLineWidth, libvulkan), Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
 end
 
+function vkCmdSetLineWidth(commandBuffer, lineWidth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
+end
+
 function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
     ccall((:vkCmdSetDepthBias, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
+end
+
+function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
 end
 
 function vkCmdSetBlendConstants(commandBuffer, blendConstants)
     ccall((:vkCmdSetBlendConstants, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
 end
 
+function vkCmdSetBlendConstants(commandBuffer, blendConstants, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
+end
+
 function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds)
     ccall((:vkCmdSetDepthBounds, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
+end
+
+function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
 end
 
 function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask)
     ccall((:vkCmdSetStencilCompareMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
 end
 
+function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
+end
+
 function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask)
     ccall((:vkCmdSetStencilWriteMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
+end
+
+function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
 end
 
 function vkCmdSetStencilReference(commandBuffer, faceMask, reference)
     ccall((:vkCmdSetStencilReference, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
 end
 
+function vkCmdSetStencilReference(commandBuffer, faceMask, reference, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
+end
+
 function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
     ccall((:vkCmdBindDescriptorSets, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
+end
+
+function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
 end
 
 function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType)
     ccall((:vkCmdBindIndexBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
 end
 
+function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
+end
+
 function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
     ccall((:vkCmdBindVertexBuffers, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
+end
+
+function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
 end
 
 function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
     ccall((:vkCmdDraw, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
 end
 
+function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
+end
+
 function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
     ccall((:vkCmdDrawIndexed, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
+end
+
+function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
 end
 
 function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndexedIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
 function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatch, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
 end
 
+function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
+end
+
 function vkCmdDispatchIndirect(commandBuffer, buffer, offset)
     ccall((:vkCmdDispatchIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
+end
+
+function vkCmdDispatchIndirect(commandBuffer, buffer, offset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
 end
 
 function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
     ccall((:vkCmdBlitImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
 end
 
+function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
+end
+
 function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyBufferToImage, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyImageToBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData)
     ccall((:vkCmdUpdateBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
+end
+
+function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
 end
 
 function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data)
     ccall((:vkCmdFillBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
 end
 
+function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
+end
+
 function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
     ccall((:vkCmdClearColorImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
+end
+
+function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
 end
 
 function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
     ccall((:vkCmdClearDepthStencilImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
 end
 
+function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
+end
+
 function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
     ccall((:vkCmdClearAttachments, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
+end
+
+function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
 end
 
 function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdResolveImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
+function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
 function vkCmdSetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdSetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
+function vkCmdSetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
 function vkCmdResetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
+function vkCmdResetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
 function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdWaitEvents, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
+function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
 function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdPipelineBarrier, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
+function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
 function vkCmdBeginQuery(commandBuffer, queryPool, query, flags)
     ccall((:vkCmdBeginQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
+end
+
+function vkCmdBeginQuery(commandBuffer, queryPool, query, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
 end
 
 function vkCmdEndQuery(commandBuffer, queryPool, query)
     ccall((:vkCmdEndQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
 end
 
+function vkCmdEndQuery(commandBuffer, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
+end
+
 function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount)
     ccall((:vkCmdResetQueryPool, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
+end
+
+function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
 end
 
 function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query)
     ccall((:vkCmdWriteTimestamp, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
+end
+
 function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
     ccall((:vkCmdCopyQueryPoolResults, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
+end
+
+function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
 end
 
 function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues)
     ccall((:vkCmdPushConstants, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
 end
 
+function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
+end
+
 function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents)
     ccall((:vkCmdBeginRenderPass, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
+end
+
+function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
 end
 
 function vkCmdNextSubpass(commandBuffer, contents)
     ccall((:vkCmdNextSubpass, libvulkan), Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
 end
 
+function vkCmdNextSubpass(commandBuffer, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
+end
+
 function vkCmdEndRenderPass(commandBuffer)
     ccall((:vkCmdEndRenderPass, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndRenderPass(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers)
     ccall((:vkCmdExecuteCommands, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
+end
+
+function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
 end
 
 const VkSamplerYcbcrConversion = UInt64
@@ -4973,112 +5521,224 @@ function vkEnumerateInstanceVersion(pApiVersion)
     ccall((:vkEnumerateInstanceVersion, libvulkan), VkResult, (Ptr{UInt32},), pApiVersion)
 end
 
+function vkEnumerateInstanceVersion(pApiVersion, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32},), pApiVersion)
+end
+
 function vkBindBufferMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindBufferMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 function vkBindImageMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindImageMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
     ccall((:vkGetDeviceGroupPeerMemoryFeatures, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
+function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
 function vkCmdSetDeviceMask(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMask, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMask(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBase, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroups, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
+function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
 function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
 function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
+function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
 function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
 function vkTrimCommandPool(device, commandPool, flags)
     ccall((:vkTrimCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
+function vkTrimCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
 function vkGetDeviceQueue2(device, pQueueInfo, pQueue)
     ccall((:vkGetDeviceQueue2, libvulkan), Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
 end
 
+function vkGetDeviceQueue2(device, pQueueInfo, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
+end
+
 function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion)
     ccall((:vkCreateSamplerYcbcrConversion, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
+function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
 function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversion, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
+function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
 function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
     ccall((:vkCreateDescriptorUpdateTemplate, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
+function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
 function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
+function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
 function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFenceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphoreProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
+function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
 function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupport, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
+function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
 @cenum VkDriverId::UInt32 begin
@@ -5778,52 +6438,104 @@ function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, coun
     ccall((:vkCmdDrawIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 function vkResetQueryPool(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
+function vkResetQueryPool(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
 function vkGetSemaphoreCounterValue(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValue, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
+function vkGetSemaphoreCounterValue(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
 function vkWaitSemaphores(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphores, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphores(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphore(device, pSignalInfo)
     ccall((:vkSignalSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphore(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 function vkGetBufferDeviceAddress(device, pInfo)
     ccall((:vkGetBufferDeviceAddress, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddress(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkSurfaceKHR = UInt64
@@ -5922,20 +6634,40 @@ function vkDestroySurfaceKHR(instance, surface, pAllocator)
     ccall((:vkDestroySurfaceKHR, libvulkan), Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
 end
 
+function vkDestroySurfaceKHR(instance, surface, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
+end
+
 function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported)
     ccall((:vkGetPhysicalDeviceSurfaceSupportKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
+end
+
+function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
 end
 
 function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormatsKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
 end
 
+function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
+end
+
 function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes)
     ccall((:vkGetPhysicalDeviceSurfacePresentModesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
+end
+
+function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
 end
 
 const VkSwapchainKHR = UInt64
@@ -6066,36 +6798,72 @@ function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain)
     ccall((:vkCreateSwapchainKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
 end
 
+function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
+end
+
 function vkDestroySwapchainKHR(device, swapchain, pAllocator)
     ccall((:vkDestroySwapchainKHR, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
+end
+
+function vkDestroySwapchainKHR(device, swapchain, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
 end
 
 function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages)
     ccall((:vkGetSwapchainImagesKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
 end
 
+function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
+end
+
 function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex)
     ccall((:vkAcquireNextImageKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
+end
+
+function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
 end
 
 function vkQueuePresentKHR(queue, pPresentInfo)
     ccall((:vkQueuePresentKHR, libvulkan), VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
 end
 
+function vkQueuePresentKHR(queue, pPresentInfo, fptr)
+    ccall(fptr, VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
+end
+
 function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities)
     ccall((:vkGetDeviceGroupPresentCapabilitiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
+end
+
+function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
 end
 
 function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes)
     ccall((:vkGetDeviceGroupSurfacePresentModesKHR, libvulkan), VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
 end
 
+function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
+end
+
 function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects)
     ccall((:vkGetPhysicalDevicePresentRectanglesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
 end
 
+function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
+end
+
 function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex)
     ccall((:vkAcquireNextImage2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
+end
+
+function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
 end
 
 const VkDisplayKHR = UInt64
@@ -6198,28 +6966,56 @@ function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount,
     ccall((:vkGetPhysicalDeviceDisplayPropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlanePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays)
     ccall((:vkGetDisplayPlaneSupportedDisplaysKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
 end
 
+function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
+end
+
 function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
+function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
 function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode)
     ccall((:vkCreateDisplayModeKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
 end
 
+function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
+end
+
 function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
 end
 
+function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
+end
+
 function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateDisplayPlaneSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
+function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
 struct VkDisplayPresentInfoKHR
@@ -6235,6 +7031,10 @@ const PFN_vkCreateSharedSwapchainsKHR = Ptr{Cvoid}
 
 function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
     ccall((:vkCreateSharedSwapchainsKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
+end
+
+function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
 end
 
 const VkRenderPassMultiviewCreateInfoKHR = VkRenderPassMultiviewCreateInfo
@@ -6286,28 +7086,56 @@ function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
 const VkPeerMemoryFeatureFlagsKHR = VkPeerMemoryFeatureFlags
@@ -6345,12 +7173,24 @@ function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceInd
     ccall((:vkGetDeviceGroupPeerMemoryFeaturesKHR, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
+function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
 function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMaskKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBaseKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 const VkCommandPoolTrimFlagsKHR = VkCommandPoolTrimFlags
@@ -6362,6 +7202,10 @@ function vkTrimCommandPoolKHR(device, commandPool, flags)
     ccall((:vkTrimCommandPoolKHR, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
+function vkTrimCommandPoolKHR(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
 const VkPhysicalDeviceGroupPropertiesKHR = VkPhysicalDeviceGroupProperties
 
 const VkDeviceGroupDeviceCreateInfoKHR = VkDeviceGroupDeviceCreateInfo
@@ -6371,6 +7215,10 @@ const PFN_vkEnumeratePhysicalDeviceGroupsKHR = Ptr{Cvoid}
 
 function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroupsKHR, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
+function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
 const VkExternalMemoryHandleTypeFlagsKHR = VkExternalMemoryHandleTypeFlags
@@ -6398,6 +7246,10 @@ const PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferPropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
+function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
 const VkExternalMemoryImageCreateInfoKHR = VkExternalMemoryImageCreateInfo
@@ -6436,8 +7288,16 @@ function vkGetMemoryFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetMemoryFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
+function vkGetMemoryFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
 function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties)
     ccall((:vkGetMemoryFdPropertiesKHR, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
+end
+
+function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
 end
 
 const VkExternalSemaphoreHandleTypeFlagsKHR = VkExternalSemaphoreHandleTypeFlags
@@ -6457,6 +7317,10 @@ const PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphorePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
+function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
 const VkSemaphoreImportFlagsKHR = VkSemaphoreImportFlags
@@ -6491,8 +7355,16 @@ function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo)
     ccall((:vkImportSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
 end
 
+function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
+end
+
 function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 struct VkPhysicalDevicePushDescriptorPropertiesKHR
@@ -6511,8 +7383,16 @@ function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set
     ccall((:vkCmdPushDescriptorSetKHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
 end
 
+function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
+end
+
 function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData)
     ccall((:vkCmdPushDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
+end
+
+function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
 end
 
 const VkPhysicalDeviceShaderFloat16Int8FeaturesKHR = VkPhysicalDeviceShaderFloat16Int8Features
@@ -6562,12 +7442,24 @@ function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pD
     ccall((:vkCreateDescriptorUpdateTemplateKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
+function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
 function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 const VkPhysicalDeviceImagelessFramebufferFeaturesKHR = VkPhysicalDeviceImagelessFramebufferFeatures
@@ -6608,16 +7500,32 @@ function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 struct VkSharedPresentSurfaceCapabilitiesKHR
@@ -6631,6 +7539,10 @@ const PFN_vkGetSwapchainStatusKHR = Ptr{Cvoid}
 
 function vkGetSwapchainStatusKHR(device, swapchain)
     ccall((:vkGetSwapchainStatusKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
+end
+
+function vkGetSwapchainStatusKHR(device, swapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
 end
 
 const VkExternalFenceHandleTypeFlagsKHR = VkExternalFenceHandleTypeFlags
@@ -6650,6 +7562,10 @@ const PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFencePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 const VkFenceImportFlagsKHR = VkFenceImportFlags
@@ -6684,8 +7600,16 @@ function vkImportFenceFdKHR(device, pImportFenceFdInfo)
     ccall((:vkImportFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
 end
 
+function vkImportFenceFdKHR(device, pImportFenceFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
+end
+
 function vkGetFenceFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetFenceFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 @cenum VkPerformanceCounterUnitKHR::UInt32 begin
@@ -6832,16 +7756,32 @@ function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physica
     ccall((:vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
 end
 
+function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
+end
+
 function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
     ccall((:vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
+end
+
+function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
 end
 
 function vkAcquireProfilingLockKHR(device, pInfo)
     ccall((:vkAcquireProfilingLockKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
 end
 
+function vkAcquireProfilingLockKHR(device, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
+end
+
 function vkReleaseProfilingLockKHR(device)
     ccall((:vkReleaseProfilingLockKHR, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkReleaseProfilingLockKHR(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 const VkPointClippingBehaviorKHR = VkPointClippingBehavior
@@ -6886,8 +7826,16 @@ function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormats2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
+end
+
+function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
 end
 
 const VkPhysicalDeviceVariablePointerFeaturesKHR = VkPhysicalDeviceVariablePointersFeatures
@@ -6941,16 +7889,32 @@ function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount
     ccall((:vkGetPhysicalDeviceDisplayProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlaneProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModeProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
+function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
 function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
+end
+
+function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
 end
 
 const VkMemoryDedicatedRequirementsKHR = VkMemoryDedicatedRequirements
@@ -6980,12 +7944,24 @@ function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 const VkImageFormatListCreateInfoKHR = VkImageFormatListCreateInfo
@@ -7020,8 +7996,16 @@ function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcb
     ccall((:vkCreateSamplerYcbcrConversionKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
+function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
 function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversionKHR, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
+function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
 const VkBindBufferMemoryInfoKHR = VkBindBufferMemoryInfo
@@ -7038,8 +8022,16 @@ function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 const VkPhysicalDeviceMaintenance3PropertiesKHR = VkPhysicalDeviceMaintenance3Properties
@@ -7053,6 +8045,10 @@ function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupportKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
+function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountKHR ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
 const PFN_vkCmdDrawIndirectCountKHR = Ptr{Cvoid}
 
@@ -7063,8 +8059,16 @@ function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 const VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR = VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures
@@ -7129,12 +8133,24 @@ function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValueKHR, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
+function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
 function vkWaitSemaphoresKHR(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphoresKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphoresKHR(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphoreKHR(device, pSignalInfo)
     ccall((:vkSignalSemaphoreKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphoreKHR(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR = VkPhysicalDeviceVulkanMemoryModelFeatures
@@ -7215,8 +8231,16 @@ function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentSha
     ccall((:vkGetPhysicalDeviceFragmentShadingRatesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
 end
 
+function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
+end
+
 function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps)
     ccall((:vkCmdSetFragmentShadingRateKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
+end
+
+function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
 end
 
 struct VkSurfaceProtectedCapabilitiesKHR
@@ -7256,12 +8280,24 @@ function vkGetBufferDeviceAddressKHR(device, pInfo)
     ccall((:vkGetBufferDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkDeferredOperationKHR = UInt64
@@ -7285,20 +8321,40 @@ function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation)
     ccall((:vkCreateDeferredOperationKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
 end
 
+function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
+end
+
 function vkDestroyDeferredOperationKHR(device, operation, pAllocator)
     ccall((:vkDestroyDeferredOperationKHR, libvulkan), Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
+end
+
+function vkDestroyDeferredOperationKHR(device, operation, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
 end
 
 function vkGetDeferredOperationMaxConcurrencyKHR(device, operation)
     ccall((:vkGetDeferredOperationMaxConcurrencyKHR, libvulkan), UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationMaxConcurrencyKHR(device, operation, fptr)
+    ccall(fptr, UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkGetDeferredOperationResultKHR(device, operation)
     ccall((:vkGetDeferredOperationResultKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationResultKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkDeferredOperationJoinKHR(device, operation)
     ccall((:vkDeferredOperationJoinKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
+function vkDeferredOperationJoinKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
 @cenum VkPipelineExecutableStatisticFormatKHR::UInt32 begin
@@ -7392,12 +8448,24 @@ function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutable
     ccall((:vkGetPipelineExecutablePropertiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
 end
 
+function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutableCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
+end
+
 function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics)
     ccall((:vkGetPipelineExecutableStatisticsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
 end
 
+function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
+end
+
 function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
     ccall((:vkGetPipelineExecutableInternalRepresentationsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
+end
+
+function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
 end
 
 struct VkPipelineLibraryCreateInfoKHR
@@ -7549,32 +8617,64 @@ function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo)
     ccall((:vkCmdSetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
 end
 
+function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
+end
+
 function vkCmdResetEvent2KHR(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
+end
+
+function vkCmdResetEvent2KHR(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
 end
 
 function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos)
     ccall((:vkCmdWaitEvents2KHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
 end
 
+function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
+end
+
 function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo)
     ccall((:vkCmdPipelineBarrier2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
+end
+
+function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
 end
 
 function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query)
     ccall((:vkCmdWriteTimestamp2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
+end
+
 function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit2KHR, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
+function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
 function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarker2AMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
 end
 
+function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
+end
+
 function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointData2NV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR
@@ -7725,24 +8825,48 @@ function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo)
     ccall((:vkCmdCopyBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
 end
 
+function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
+end
+
 function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo)
     ccall((:vkCmdCopyImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
+end
+
+function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
 end
 
 function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo)
     ccall((:vkCmdCopyBufferToImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
 end
 
+function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
+end
+
 function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo)
     ccall((:vkCmdCopyImageToBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
+end
+
+function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
 end
 
 function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo)
     ccall((:vkCmdBlitImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
 end
 
+function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
+end
+
 function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo)
     ccall((:vkCmdResolveImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
+end
+
+function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
 end
 
 const VkDebugReportCallbackEXT = UInt64
@@ -7826,12 +8950,24 @@ function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCall
     ccall((:vkCreateDebugReportCallbackEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
 end
 
+function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
+end
+
 function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator)
     ccall((:vkDestroyDebugReportCallbackEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
 end
 
+function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
+end
+
 function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
     ccall((:vkDebugReportMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
+end
+
+function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
 end
 
 @cenum VkRasterizationOrderAMD::UInt32 begin
@@ -7890,20 +9026,40 @@ function vkDebugMarkerSetObjectTagEXT(device, pTagInfo)
     ccall((:vkDebugMarkerSetObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
 end
 
+function vkDebugMarkerSetObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
+end
+
 function vkDebugMarkerSetObjectNameEXT(device, pNameInfo)
     ccall((:vkDebugMarkerSetObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
+end
+
+function vkDebugMarkerSetObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
 end
 
 function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerBeginEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdDebugMarkerEndEXT(commandBuffer)
     ccall((:vkCmdDebugMarkerEndEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdDebugMarkerEndEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerInsertEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
 struct VkDedicatedAllocationImageCreateInfoNV
@@ -7978,24 +9134,48 @@ function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindi
     ccall((:vkCmdBindTransformFeedbackBuffersEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
 end
 
+function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
+end
+
 function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdBeginTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
+function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
 function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdEndTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
+function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
 function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index)
     ccall((:vkCmdBeginQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
+end
+
+function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
 end
 
 function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index)
     ccall((:vkCmdEndQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
 end
 
+function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
+end
+
 function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
     ccall((:vkCmdDrawIndirectByteCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
+end
+
+function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
 end
 
 struct VkImageViewHandleInfoNVX
@@ -8023,8 +9203,16 @@ function vkGetImageViewHandleNVX(device, pInfo)
     ccall((:vkGetImageViewHandleNVX, libvulkan), UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
 end
 
+function vkGetImageViewHandleNVX(device, pInfo, fptr)
+    ccall(fptr, UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
+end
+
 function vkGetImageViewAddressNVX(device, imageView, pProperties)
     ccall((:vkGetImageViewAddressNVX, libvulkan), VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
+end
+
+function vkGetImageViewAddressNVX(device, imageView, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
 end
 
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountAMD ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
@@ -8037,8 +9225,16 @@ function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkTextureLODGatherFormatPropertiesAMD
@@ -8079,6 +9275,10 @@ function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, 
     ccall((:vkGetShaderInfoAMD, libvulkan), VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
 end
 
+function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
+end
+
 struct VkPhysicalDeviceCornerSampledImageFeaturesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8116,6 +9316,10 @@ const PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
     ccall((:vkGetPhysicalDeviceExternalImageFormatPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
 end
 
 struct VkExternalMemoryImageCreateInfoNV
@@ -8199,8 +9403,16 @@ function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingB
     ccall((:vkCmdBeginConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
 end
 
+function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
+end
+
 function vkCmdEndConditionalRenderingEXT(commandBuffer)
     ccall((:vkCmdEndConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkCmdEndConditionalRenderingEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
 struct VkViewportWScalingNV
@@ -8223,11 +9435,19 @@ function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount,
     ccall((:vkCmdSetViewportWScalingNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
 end
 
+function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
+end
+
 # typedef VkResult ( VKAPI_PTR * PFN_vkReleaseDisplayEXT ) ( VkPhysicalDevice physicalDevice , VkDisplayKHR display )
 const PFN_vkReleaseDisplayEXT = Ptr{Cvoid}
 
 function vkReleaseDisplayEXT(physicalDevice, display)
     ccall((:vkReleaseDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
+function vkReleaseDisplayEXT(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
 @cenum VkSurfaceCounterFlagBitsEXT::UInt32 begin
@@ -8259,6 +9479,10 @@ const PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2EXT, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
+function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
 @cenum VkDisplayPowerStateEXT::UInt32 begin
@@ -8318,16 +9542,32 @@ function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo)
     ccall((:vkDisplayPowerControlEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
 end
 
+function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
+end
+
 function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDeviceEventEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
+end
+
+function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
 end
 
 function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDisplayEventEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
 end
 
+function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
+end
+
 function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue)
     ccall((:vkGetSwapchainCounterEXT, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
+end
+
+function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
 end
 
 struct VkRefreshCycleDurationGOOGLE
@@ -8364,8 +9604,16 @@ function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProper
     ccall((:vkGetRefreshCycleDurationGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
 end
 
+function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
+end
+
 function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings)
     ccall((:vkGetPastPresentationTimingGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
+end
+
+function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
 end
 
 struct VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX
@@ -8431,6 +9679,10 @@ const PFN_vkCmdSetDiscardRectangleEXT = Ptr{Cvoid}
 
 function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
     ccall((:vkCmdSetDiscardRectangleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
+end
+
+function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
 end
 
 @cenum VkConservativeRasterizationModeEXT::UInt32 begin
@@ -8502,6 +9754,10 @@ const PFN_vkSetHdrMetadataEXT = Ptr{Cvoid}
 
 function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata)
     ccall((:vkSetHdrMetadataEXT, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
+end
+
+function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
 end
 
 const VkDebugUtilsMessengerEXT = UInt64
@@ -8619,44 +9875,88 @@ function vkSetDebugUtilsObjectNameEXT(device, pNameInfo)
     ccall((:vkSetDebugUtilsObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
 end
 
+function vkSetDebugUtilsObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
+end
+
 function vkSetDebugUtilsObjectTagEXT(device, pTagInfo)
     ccall((:vkSetDebugUtilsObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
+end
+
+function vkSetDebugUtilsObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
 end
 
 function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkQueueEndDebugUtilsLabelEXT(queue)
     ccall((:vkQueueEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue,), queue)
+end
+
+function vkQueueEndDebugUtilsLabelEXT(queue, fptr)
+    ccall(fptr, Cvoid, (VkQueue,), queue)
 end
 
 function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCmdEndDebugUtilsLabelEXT(commandBuffer)
     ccall((:vkCmdEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndDebugUtilsLabelEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger)
     ccall((:vkCreateDebugUtilsMessengerEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
 end
 
+function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
+end
+
 function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator)
     ccall((:vkDestroyDebugUtilsMessengerEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
 end
 
+function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
+end
+
 function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData)
     ccall((:vkSubmitDebugUtilsMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
+end
+
+function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
 end
 
 const VkSamplerReductionModeEXT = VkSamplerReductionMode
@@ -8761,8 +10061,16 @@ function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo)
     ccall((:vkCmdSetSampleLocationsEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
 end
 
+function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
+end
+
 function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties)
     ccall((:vkGetPhysicalDeviceMultisamplePropertiesEXT, libvulkan), Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
+end
+
+function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
 end
 
 @cenum VkBlendOverlapEXT::UInt32 begin
@@ -8890,6 +10198,10 @@ function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties)
     ccall((:vkGetImageDrmFormatModifierPropertiesEXT, libvulkan), VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
 end
 
+function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
+end
+
 const VkValidationCacheEXT = UInt64
 
 @cenum VkValidationCacheHeaderVersionEXT::UInt32 begin
@@ -8929,16 +10241,32 @@ function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidation
     ccall((:vkCreateValidationCacheEXT, libvulkan), VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
 end
 
+function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
+end
+
 function vkDestroyValidationCacheEXT(device, validationCache, pAllocator)
     ccall((:vkDestroyValidationCacheEXT, libvulkan), Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
+end
+
+function vkDestroyValidationCacheEXT(device, validationCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
 end
 
 function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergeValidationCachesEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData)
     ccall((:vkGetValidationCacheDataEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
+end
+
+function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
 end
 
 const VkDescriptorBindingFlagBitsEXT = VkDescriptorBindingFlagBits
@@ -9041,12 +10369,24 @@ function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout)
     ccall((:vkCmdBindShadingRateImageNV, libvulkan), Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
 end
 
+function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
+end
+
 function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
     ccall((:vkCmdSetViewportShadingRatePaletteNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
 end
 
+function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
+end
+
 function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
     ccall((:vkCmdSetCoarseSampleOrderNV, libvulkan), Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
+end
+
+function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
 end
 
 const VkAccelerationStructureNV = UInt64
@@ -9371,52 +10711,104 @@ function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccel
     ccall((:vkCreateAccelerationStructureNV, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureNV, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements)
     ccall((:vkGetAccelerationStructureMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
+end
+
 function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos)
     ccall((:vkBindAccelerationStructureMemoryNV, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
 end
 
 function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
     ccall((:vkCmdBuildAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
 end
 
+function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
+end
+
 function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode)
     ccall((:vkCmdCopyAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
+end
+
+function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
 end
 
 function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
     ccall((:vkCmdTraceRaysNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
 end
 
+function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesNV, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
+function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
 function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData)
     ccall((:vkGetAccelerationStructureHandleNV, libvulkan), VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
 end
 
+function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
+function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
 function vkCompileDeferredNV(device, pipeline, shader)
     ccall((:vkCompileDeferredNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
+end
+
+function vkCompileDeferredNV(device, pipeline, shader, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
 end
 
 struct VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV
@@ -9484,11 +10876,19 @@ function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, p
     ccall((:vkGetMemoryHostPointerPropertiesEXT, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
 end
 
+function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, pMemoryHostPointerProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdWriteBufferMarkerAMD ) ( VkCommandBuffer commandBuffer , VkPipelineStageFlagBits pipelineStage , VkBuffer dstBuffer , VkDeviceSize dstOffset , uint32_t marker )
 const PFN_vkCmdWriteBufferMarkerAMD = Ptr{Cvoid}
 
 function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarkerAMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
+end
+
+function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
 end
 
 @cenum VkPipelineCompilerControlFlagBitsAMD::UInt32 begin
@@ -9527,8 +10927,16 @@ function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDom
     ccall((:vkGetPhysicalDeviceCalibrateableTimeDomainsEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
 end
 
+function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDomainCount, pTimeDomains, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
+end
+
 function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
     ccall((:vkGetCalibratedTimestampsEXT, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
+end
+
+function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
 end
 
 struct VkPhysicalDeviceShaderCorePropertiesAMD
@@ -9660,12 +11068,24 @@ function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask)
     ccall((:vkCmdDrawMeshTasksNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
 end
 
+function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
+end
+
 function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectCountNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV
@@ -9700,6 +11120,10 @@ function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclus
     ccall((:vkCmdSetExclusiveScissorNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
 end
 
+function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
+end
+
 struct VkQueueFamilyCheckpointPropertiesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -9723,8 +11147,16 @@ function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker)
     ccall((:vkCmdSetCheckpointNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
 end
 
+function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
+end
+
 function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointDataNV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL
@@ -9866,36 +11298,72 @@ function vkInitializePerformanceApiINTEL(device, pInitializeInfo)
     ccall((:vkInitializePerformanceApiINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
 end
 
+function vkInitializePerformanceApiINTEL(device, pInitializeInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
+end
+
 function vkUninitializePerformanceApiINTEL(device)
     ccall((:vkUninitializePerformanceApiINTEL, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkUninitializePerformanceApiINTEL(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceStreamMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
 function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo)
     ccall((:vkCmdSetPerformanceOverrideINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
 end
 
+function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
+end
+
 function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration)
     ccall((:vkAcquirePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
+end
+
+function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
 end
 
 function vkReleasePerformanceConfigurationINTEL(device, configuration)
     ccall((:vkReleasePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
 end
 
+function vkReleasePerformanceConfigurationINTEL(device, configuration, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
+end
+
 function vkQueueSetPerformanceConfigurationINTEL(queue, configuration)
     ccall((:vkQueueSetPerformanceConfigurationINTEL, libvulkan), VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
 end
 
+function vkQueueSetPerformanceConfigurationINTEL(queue, configuration, fptr)
+    ccall(fptr, VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
+end
+
 function vkGetPerformanceParameterINTEL(device, parameter, pValue)
     ccall((:vkGetPerformanceParameterINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
+end
+
+function vkGetPerformanceParameterINTEL(device, parameter, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
 end
 
 struct VkPhysicalDevicePCIBusInfoPropertiesEXT
@@ -9924,6 +11392,10 @@ const PFN_vkSetLocalDimmingAMD = Ptr{Cvoid}
 
 function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable)
     ccall((:vkSetLocalDimmingAMD, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
+end
+
+function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
 end
 
 struct VkPhysicalDeviceFragmentDensityMapFeaturesEXT
@@ -10048,6 +11520,10 @@ function vkGetBufferDeviceAddressEXT(device, pInfo)
     ccall((:vkGetBufferDeviceAddressEXT, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressEXT(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 @cenum VkToolPurposeFlagBitsEXT::UInt32 begin
     VK_TOOL_PURPOSE_VALIDATION_BIT_EXT = 1
     VK_TOOL_PURPOSE_PROFILING_BIT_EXT = 2
@@ -10076,6 +11552,10 @@ const PFN_vkGetPhysicalDeviceToolPropertiesEXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties)
     ccall((:vkGetPhysicalDeviceToolPropertiesEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
+end
+
+function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
 end
 
 const VkImageStencilUsageCreateInfoEXT = VkImageStencilUsageCreateInfo
@@ -10165,6 +11645,10 @@ function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPrope
     ccall((:vkGetPhysicalDeviceCooperativeMatrixPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
+end
+
 @cenum VkCoverageReductionModeNV::UInt32 begin
     VK_COVERAGE_REDUCTION_MODE_MERGE_NV = 0
     VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV = 1
@@ -10200,6 +11684,10 @@ const PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV = Pt
 
 function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations)
     ccall((:vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
+end
+
+function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
 end
 
 struct VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT
@@ -10257,6 +11745,10 @@ function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateHeadlessSurfaceEXT, libvulkan), VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 @cenum VkLineRasterizationModeEXT::UInt32 begin
     VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT = 0
     VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT = 1
@@ -10298,6 +11790,10 @@ function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePat
     ccall((:vkCmdSetLineStippleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
 end
 
+function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
+end
+
 struct VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10322,6 +11818,10 @@ const PFN_vkResetQueryPoolEXT = Ptr{Cvoid}
 
 function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPoolEXT, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
+function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
 struct VkPhysicalDeviceIndexTypeUint8FeaturesEXT
@@ -10376,48 +11876,96 @@ function vkCmdSetCullModeEXT(commandBuffer, cullMode)
     ccall((:vkCmdSetCullModeEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
 end
 
+function vkCmdSetCullModeEXT(commandBuffer, cullMode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
+end
+
 function vkCmdSetFrontFaceEXT(commandBuffer, frontFace)
     ccall((:vkCmdSetFrontFaceEXT, libvulkan), Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
+end
+
+function vkCmdSetFrontFaceEXT(commandBuffer, frontFace, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
 end
 
 function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology)
     ccall((:vkCmdSetPrimitiveTopologyEXT, libvulkan), Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
 end
 
+function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
+end
+
 function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports)
     ccall((:vkCmdSetViewportWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
+end
+
+function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
 end
 
 function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors)
     ccall((:vkCmdSetScissorWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
 end
 
+function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
+end
+
 function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
     ccall((:vkCmdBindVertexBuffers2EXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
+end
+
+function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
 end
 
 function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable)
     ccall((:vkCmdSetDepthTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
 end
 
+function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
+end
+
 function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable)
     ccall((:vkCmdSetDepthWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
+end
+
+function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
 end
 
 function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp)
     ccall((:vkCmdSetDepthCompareOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
 end
 
+function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
+end
+
 function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable)
     ccall((:vkCmdSetDepthBoundsTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
+end
+
+function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
 end
 
 function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable)
     ccall((:vkCmdSetStencilTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
 end
 
+function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
+end
+
 function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
     ccall((:vkCmdSetStencilOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
+end
+
+function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
 end
 
 struct VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT
@@ -10597,24 +12145,48 @@ function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequir
     ccall((:vkGetGeneratedCommandsMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo)
     ccall((:vkCmdPreprocessGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
+end
+
+function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
 end
 
 function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
     ccall((:vkCmdExecuteGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
 end
 
+function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
+end
+
 function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex)
     ccall((:vkCmdBindPipelineShaderGroupNV, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
+end
+
+function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
 end
 
 function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
     ccall((:vkCreateIndirectCommandsLayoutNV, libvulkan), VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
 end
 
+function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
+end
+
 function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator)
     ccall((:vkDestroyIndirectCommandsLayoutNV, libvulkan), Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
+end
+
+function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
 end
 
 struct VkPhysicalDeviceInheritedViewportScissorFeaturesNV
@@ -10776,16 +12348,32 @@ function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDat
     ccall((:vkCreatePrivateDataSlotEXT, libvulkan), VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
 end
 
+function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDataSlot, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
+end
+
 function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator)
     ccall((:vkDestroyPrivateDataSlotEXT, libvulkan), Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
+end
+
+function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
 end
 
 function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data)
     ccall((:vkSetPrivateDataEXT, libvulkan), VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
 end
 
+function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
+end
+
 function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData)
     ccall((:vkGetPrivateDataEXT, libvulkan), Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
+end
+
+function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
 end
 
 struct VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT
@@ -10866,6 +12454,10 @@ function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerO
     ccall((:vkCmdSetFragmentShadingRateEnumNV, libvulkan), Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
 end
 
+function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
+end
+
 struct VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10916,8 +12508,16 @@ function vkAcquireWinrtDisplayNV(physicalDevice, display)
     ccall((:vkAcquireWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
+function vkAcquireWinrtDisplayNV(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
 function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay)
     ccall((:vkGetWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
+end
+
+function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
 end
 
 struct VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE
@@ -10969,6 +12569,10 @@ function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pV
     ccall((:vkCmdSetVertexInputEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
 end
 
+function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
+end
+
 struct VkPhysicalDeviceExtendedDynamicState2FeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10996,20 +12600,40 @@ function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints)
     ccall((:vkCmdSetPatchControlPointsEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
 end
 
+function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
+end
+
 function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable)
     ccall((:vkCmdSetRasterizerDiscardEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
+end
+
+function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
 end
 
 function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable)
     ccall((:vkCmdSetDepthBiasEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
 end
 
+function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
+end
+
 function vkCmdSetLogicOpEXT(commandBuffer, logicOp)
     ccall((:vkCmdSetLogicOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
 end
 
+function vkCmdSetLogicOpEXT(commandBuffer, logicOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
+end
+
 function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable)
     ccall((:vkCmdSetPrimitiveRestartEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
+end
+
+function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
 end
 
 struct VkPhysicalDeviceColorWriteEnableFeaturesEXT
@@ -11030,6 +12654,10 @@ const PFN_vkCmdSetColorWriteEnableEXT = Ptr{Cvoid}
 
 function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables)
     ccall((:vkCmdSetColorWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
+end
+
+function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
 end
 
 const VkAccelerationStructureKHR = UInt64
@@ -11316,64 +12944,128 @@ function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAcce
     ccall((:vkCreateAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkCmdBuildAccelerationStructuresKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
     ccall((:vkCmdBuildAccelerationStructuresIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
+end
+
+function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
 end
 
 function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkBuildAccelerationStructuresKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureToMemoryKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
 end
 
+function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
+end
+
 function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyMemoryToAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
     ccall((:vkWriteAccelerationStructuresPropertiesKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
 end
 
+function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
+end
+
 function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureToMemoryKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
 end
 
+function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
+end
+
 function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyMemoryToAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo)
     ccall((:vkGetAccelerationStructureDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
 end
 
+function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
+function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
 function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility)
     ccall((:vkGetDeviceAccelerationStructureCompatibilityKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
 end
 
+function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
+end
+
 function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
     ccall((:vkGetAccelerationStructureBuildSizesKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
+end
+
+function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
 end
 
 @cenum VkShaderGroupShaderKHR::UInt32 begin
@@ -11476,24 +13168,48 @@ function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShader
     ccall((:vkCmdTraceRaysKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
 end
 
+function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingCaptureReplayShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
     ccall((:vkCmdTraceRaysIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
+end
+
+function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
 end
 
 function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader)
     ccall((:vkGetRayTracingShaderGroupStackSizeKHR, libvulkan), VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
 end
 
+function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader, fptr)
+    ccall(fptr, VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
+end
+
 function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize)
     ccall((:vkCmdSetRayTracingPipelineStackSizeKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
+end
+
+function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
 end
 
 struct VkPhysicalDeviceRayQueryFeaturesKHR
@@ -11526,8 +13242,16 @@ function vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateWaylandSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkWaylandSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkWaylandSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display)
     ccall((:vkGetPhysicalDeviceWaylandPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{wl_display}), physicalDevice, queueFamilyIndex, display)
+end
+
+function vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{wl_display}), physicalDevice, queueFamilyIndex, display)
 end
 
 const VkXcbSurfaceCreateFlagsKHR = VkFlags
@@ -11550,8 +13274,16 @@ function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXcbSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id)
     ccall((:vkGetPhysicalDeviceXcbPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
+end
+
+function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
 end
 
 const VkXlibSurfaceCreateFlagsKHR = VkFlags
@@ -11574,8 +13306,16 @@ function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXlibSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID)
     ccall((:vkGetPhysicalDeviceXlibPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
+end
+
+function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
 end
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkAcquireXlibDisplayEXT ) ( VkPhysicalDevice physicalDevice , Display * dpy , VkDisplayKHR display )
@@ -11588,8 +13328,16 @@ function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display)
     ccall((:vkAcquireXlibDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
 end
 
+function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
+end
+
 function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay)
     ccall((:vkGetRandROutputDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
+end
+
+function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
 end
 
 const VULKAN_H_ = 1

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -3162,24 +3162,16 @@ end
 
 const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
 
-function VkClearColorValue(float32::NTuple{4, Cfloat})
+function VkClearColorValue(val::__U_VkClearColorValue)
     ref = Ref{VkClearColorValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkClearColorValue(int32::NTuple{4, Int32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkClearColorValue(uint32::NTuple{4, UInt32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.uint32 = uint32
+    if val isa NTuple{4, Cfloat}
+        ptr.float32 = val
+    elseif val isa NTuple{4, Int32}
+        ptr.int32 = val
+    elseif val isa NTuple{4, UInt32}
+        ptr.uint32 = val
+    end
     ref[]
 end
 
@@ -3211,17 +3203,14 @@ end
 
 const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
 
-function VkClearValue(color::VkClearColorValue)
+function VkClearValue(val::__U_VkClearValue)
     ref = Ref{VkClearValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.color = color
-    ref[]
-end
-
-function VkClearValue(depthStencil::VkClearDepthStencilValue)
-    ref = Ref{VkClearValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.depthStencil = depthStencil
+    if val isa VkClearColorValue
+        ptr.color = val
+    elseif val isa VkClearDepthStencilValue
+        ptr.depthStencil = val
+    end
     ref[]
 end
 
@@ -7768,45 +7757,22 @@ end
 
 const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
 
-function VkPerformanceCounterResultKHR(int32::Int32)
+function VkPerformanceCounterResultKHR(val::__U_VkPerformanceCounterResultKHR)
     ref = Ref{VkPerformanceCounterResultKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(int64::Int64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int64 = int64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint32::UInt32)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint32 = uint32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint64::UInt64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint64 = uint64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float32::Cfloat)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float64::Cdouble)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float64 = float64
+    if val isa Int32
+        ptr.int32 = val
+    elseif val isa Int64
+        ptr.int64 = val
+    elseif val isa UInt32
+        ptr.uint32 = val
+    elseif val isa UInt64
+        ptr.uint64 = val
+    elseif val isa Cfloat
+        ptr.float32 = val
+    elseif val isa Cdouble
+        ptr.float64 = val
+    end
     ref[]
 end
 
@@ -8501,31 +8467,18 @@ end
 
 const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
 
-function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+function VkPipelineExecutableStatisticValueKHR(val::__U_VkPipelineExecutableStatisticValueKHR)
     ref = Ref{VkPipelineExecutableStatisticValueKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.b32 = b32
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(i64::Int64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.i64 = i64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.u64 = u64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.f64 = f64
+    if val isa VkBool32
+        ptr.b32 = val
+    elseif val isa Int64
+        ptr.i64 = val
+    elseif val isa UInt64
+        ptr.u64 = val
+    elseif val isa Cdouble
+        ptr.f64 = val
+    end
     ref[]
 end
 
@@ -11349,38 +11302,20 @@ end
 
 const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
 
-function VkPerformanceValueDataINTEL(value32::UInt32)
+function VkPerformanceValueDataINTEL(val::__U_VkPerformanceValueDataINTEL)
     ref = Ref{VkPerformanceValueDataINTEL}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value32 = value32
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(value64::UInt64)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value64 = value64
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueFloat = valueFloat
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueBool::VkBool32)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueBool = valueBool
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueString = valueString
+    if val isa UInt32
+        ptr.value32 = val
+    elseif val isa UInt64
+        ptr.value64 = val
+    elseif val isa Cfloat
+        ptr.valueFloat = val
+    elseif val isa VkBool32
+        ptr.valueBool = val
+    elseif val isa Ptr{Cchar}
+        ptr.valueString = val
+    end
     ref[]
 end
 
@@ -12873,17 +12808,14 @@ end
 
 const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressKHR(val::__U_VkDeviceOrHostAddressKHR)
     ref = Ref{VkDeviceOrHostAddressKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -12910,17 +12842,14 @@ end
 
 const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressConstKHR(val::__U_VkDeviceOrHostAddressConstKHR)
     ref = Ref{VkDeviceOrHostAddressConstKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressConstKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -12981,24 +12910,16 @@ end
 
 const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
 
-function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+function VkAccelerationStructureGeometryDataKHR(val::__U_VkAccelerationStructureGeometryDataKHR)
     ref = Ref{VkAccelerationStructureGeometryDataKHR}()
     ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.triangles = triangles
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.aabbs = aabbs
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.instances = instances
+    if val isa VkAccelerationStructureGeometryTrianglesDataKHR
+        ptr.triangles = val
+    elseif val isa VkAccelerationStructureGeometryAabbsDataKHR
+        ptr.aabbs = val
+    elseif val isa VkAccelerationStructureGeometryInstancesDataKHR
+        ptr.instances = val
+    end
     ref[]
 end
 

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -3160,6 +3160,29 @@ function Base.setproperty!(x::Ptr{VkClearColorValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
+
+function VkClearColorValue(float32::NTuple{4, Cfloat})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkClearColorValue(int32::NTuple{4, Int32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkClearColorValue(uint32::NTuple{4, UInt32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
 struct VkClearDepthStencilValue
     depth::Cfloat
     stencil::UInt32
@@ -3184,6 +3207,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkClearValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
+
+function VkClearValue(color::VkClearColorValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.color = color
+    ref[]
+end
+
+function VkClearValue(depthStencil::VkClearDepthStencilValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.depthStencil = depthStencil
+    ref[]
 end
 
 struct VkClearAttachment
@@ -7727,6 +7766,50 @@ function Base.setproperty!(x::Ptr{VkPerformanceCounterResultKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
+
+function VkPerformanceCounterResultKHR(int32::Int32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(int64::Int64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int64 = int64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint32::UInt32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint64::UInt64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint64 = uint64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float32::Cfloat)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float64::Cdouble)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float64 = float64
+    ref[]
+end
+
 struct VkAcquireProfilingLockInfoKHR
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8414,6 +8497,36 @@ end
 
 function Base.setproperty!(x::Ptr{VkPipelineExecutableStatisticValueKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
+
+function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.b32 = b32
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(i64::Int64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.i64 = i64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.u64 = u64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.f64 = f64
+    ref[]
 end
 
 struct VkPipelineExecutableStatisticKHR
@@ -10666,6 +10779,18 @@ function Base.setproperty!(x::Ptr{VkAccelerationStructureInstanceKHR}, f::Symbol
     unsafe_store!(getproperty(x, f), v)
 end
 
+function VkAccelerationStructureInstanceKHR(transform::VkTransformMatrixKHR, instanceCustomIndex::UInt32, mask::UInt32, instanceShaderBindingTableRecordOffset::UInt32, flags::VkGeometryInstanceFlagsKHR, accelerationStructureReference::UInt64)
+    ref = Ref{VkAccelerationStructureInstanceKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureInstanceKHR}, ref)
+    ptr.transform = transform
+    ptr.instanceCustomIndex = instanceCustomIndex
+    ptr.mask = mask
+    ptr.instanceShaderBindingTableRecordOffset = instanceShaderBindingTableRecordOffset
+    ptr.flags = flags
+    ptr.accelerationStructureReference = accelerationStructureReference
+    ref[]
+end
+
 const VkAccelerationStructureInstanceNV = VkAccelerationStructureInstanceKHR
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkCreateAccelerationStructureNV ) ( VkDevice device , const VkAccelerationStructureCreateInfoNV * pCreateInfo , const VkAllocationCallbacks * pAllocator , VkAccelerationStructureNV * pAccelerationStructure )
@@ -11220,6 +11345,43 @@ end
 
 function Base.setproperty!(x::Ptr{VkPerformanceValueDataINTEL}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
+
+function VkPerformanceValueDataINTEL(value32::UInt32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value32 = value32
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(value64::UInt64)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value64 = value64
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueFloat = valueFloat
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueBool::VkBool32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueBool = valueBool
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueString = valueString
+    ref[]
 end
 
 struct VkPerformanceValueINTEL
@@ -12709,6 +12871,22 @@ function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
+end
+
 struct VkDeviceOrHostAddressConstKHR
     data::NTuple{8, UInt8}
 end
@@ -12728,6 +12906,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressConstKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
 end
 
 struct VkAccelerationStructureBuildRangeInfoKHR
@@ -12783,6 +12977,29 @@ end
 
 function Base.setproperty!(x::Ptr{VkAccelerationStructureGeometryDataKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
+
+function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.triangles = triangles
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.aabbs = aabbs
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.instances = instances
+    ref[]
 end
 
 struct VkAccelerationStructureGeometryKHR

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -3646,548 +3646,1096 @@ function vkCreateInstance(pCreateInfo, pAllocator, pInstance)
     ccall((:vkCreateInstance, libvulkan), VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
 end
 
+function vkCreateInstance(pCreateInfo, pAllocator, pInstance, fptr)
+    ccall(fptr, VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
+end
+
 function vkDestroyInstance(instance, pAllocator)
     ccall((:vkDestroyInstance, libvulkan), Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
+end
+
+function vkDestroyInstance(instance, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
 end
 
 function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices)
     ccall((:vkEnumeratePhysicalDevices, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
 end
 
+function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
+end
+
 function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
+end
+
+function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
 end
 
 function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceProperties(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
 end
 
+function vkGetPhysicalDeviceProperties(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
+end
+
 function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
+function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
 function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetInstanceProcAddr(instance, pName)
     ccall((:vkGetInstanceProcAddr, libvulkan), PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
+end
+
+function vkGetInstanceProcAddr(instance, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
 end
 
 function vkGetDeviceProcAddr(device, pName)
     ccall((:vkGetDeviceProcAddr, libvulkan), PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
 end
 
+function vkGetDeviceProcAddr(device, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
+end
+
 function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice)
     ccall((:vkCreateDevice, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
+end
+
+function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
 end
 
 function vkDestroyDevice(device, pAllocator)
     ccall((:vkDestroyDevice, libvulkan), Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
 end
 
+function vkDestroyDevice(device, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
+end
+
 function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceExtensionProperties, libvulkan), VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceExtensionProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
+end
+
 function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceLayerProperties, libvulkan), VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceLayerProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue)
     ccall((:vkGetDeviceQueue, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
+end
+
+function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
 end
 
 function vkQueueSubmit(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
+function vkQueueSubmit(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
 function vkQueueWaitIdle(queue)
     ccall((:vkQueueWaitIdle, libvulkan), VkResult, (VkQueue,), queue)
+end
+
+function vkQueueWaitIdle(queue, fptr)
+    ccall(fptr, VkResult, (VkQueue,), queue)
 end
 
 function vkDeviceWaitIdle(device)
     ccall((:vkDeviceWaitIdle, libvulkan), VkResult, (VkDevice,), device)
 end
 
+function vkDeviceWaitIdle(device, fptr)
+    ccall(fptr, VkResult, (VkDevice,), device)
+end
+
 function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory)
     ccall((:vkAllocateMemory, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
+end
+
+function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
 end
 
 function vkFreeMemory(device, memory, pAllocator)
     ccall((:vkFreeMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
 end
 
+function vkFreeMemory(device, memory, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
+end
+
 function vkMapMemory(device, memory, offset, size, flags, ppData)
     ccall((:vkMapMemory, libvulkan), VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
+end
+
+function vkMapMemory(device, memory, offset, size, flags, ppData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
 end
 
 function vkUnmapMemory(device, memory)
     ccall((:vkUnmapMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory), device, memory)
 end
 
+function vkUnmapMemory(device, memory, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory), device, memory)
+end
+
 function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkFlushMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
+function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
 function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkInvalidateMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
+function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
 function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes)
     ccall((:vkGetDeviceMemoryCommitment, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
+end
+
+function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
 end
 
 function vkBindBufferMemory(device, buffer, memory, memoryOffset)
     ccall((:vkBindBufferMemory, libvulkan), VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
 end
 
+function vkBindBufferMemory(device, buffer, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
+end
+
 function vkBindImageMemory(device, image, memory, memoryOffset)
     ccall((:vkBindImageMemory, libvulkan), VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
+end
+
+function vkBindImageMemory(device, image, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
 end
 
 function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
+end
+
 function vkGetImageMemoryRequirements(device, image, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements(device, image, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
 end
 
 function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
+function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
 end
 
 function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence)
     ccall((:vkQueueBindSparse, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
 end
 
+function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
+end
+
 function vkCreateFence(device, pCreateInfo, pAllocator, pFence)
     ccall((:vkCreateFence, libvulkan), VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
+end
+
+function vkCreateFence(device, pCreateInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
 end
 
 function vkDestroyFence(device, fence, pAllocator)
     ccall((:vkDestroyFence, libvulkan), Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
 end
 
+function vkDestroyFence(device, fence, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
+end
+
 function vkResetFences(device, fenceCount, pFences)
     ccall((:vkResetFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
+end
+
+function vkResetFences(device, fenceCount, pFences, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
 end
 
 function vkGetFenceStatus(device, fence)
     ccall((:vkGetFenceStatus, libvulkan), VkResult, (VkDevice, VkFence), device, fence)
 end
 
+function vkGetFenceStatus(device, fence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkFence), device, fence)
+end
+
 function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout)
     ccall((:vkWaitForFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
+end
+
+function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
 end
 
 function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore)
     ccall((:vkCreateSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
 end
 
+function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
+end
+
 function vkDestroySemaphore(device, semaphore, pAllocator)
     ccall((:vkDestroySemaphore, libvulkan), Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
+end
+
+function vkDestroySemaphore(device, semaphore, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
 end
 
 function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent)
     ccall((:vkCreateEvent, libvulkan), VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
 end
 
+function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
+end
+
 function vkDestroyEvent(device, event, pAllocator)
     ccall((:vkDestroyEvent, libvulkan), Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
+end
+
+function vkDestroyEvent(device, event, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
 end
 
 function vkGetEventStatus(device, event)
     ccall((:vkGetEventStatus, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkGetEventStatus(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkSetEvent(device, event)
     ccall((:vkSetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
+end
+
+function vkSetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
 end
 
 function vkResetEvent(device, event)
     ccall((:vkResetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkResetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool)
     ccall((:vkCreateQueryPool, libvulkan), VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
+end
+
+function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
 end
 
 function vkDestroyQueryPool(device, queryPool, pAllocator)
     ccall((:vkDestroyQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
 end
 
+function vkDestroyQueryPool(device, queryPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
+end
+
 function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
     ccall((:vkGetQueryPoolResults, libvulkan), VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
+end
+
+function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
 end
 
 function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer)
     ccall((:vkCreateBuffer, libvulkan), VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
 end
 
+function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
+end
+
 function vkDestroyBuffer(device, buffer, pAllocator)
     ccall((:vkDestroyBuffer, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
+end
+
+function vkDestroyBuffer(device, buffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
 end
 
 function vkCreateBufferView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateBufferView, libvulkan), VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
 end
 
+function vkCreateBufferView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
+end
+
 function vkDestroyBufferView(device, bufferView, pAllocator)
     ccall((:vkDestroyBufferView, libvulkan), Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
+end
+
+function vkDestroyBufferView(device, bufferView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
 end
 
 function vkCreateImage(device, pCreateInfo, pAllocator, pImage)
     ccall((:vkCreateImage, libvulkan), VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
 end
 
+function vkCreateImage(device, pCreateInfo, pAllocator, pImage, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
+end
+
 function vkDestroyImage(device, image, pAllocator)
     ccall((:vkDestroyImage, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
+end
+
+function vkDestroyImage(device, image, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
 end
 
 function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout)
     ccall((:vkGetImageSubresourceLayout, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
 end
 
+function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
+end
+
 function vkCreateImageView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateImageView, libvulkan), VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
+end
+
+function vkCreateImageView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
 end
 
 function vkDestroyImageView(device, imageView, pAllocator)
     ccall((:vkDestroyImageView, libvulkan), Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
 end
 
+function vkDestroyImageView(device, imageView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
+end
+
 function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule)
     ccall((:vkCreateShaderModule, libvulkan), VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
+end
+
+function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
 end
 
 function vkDestroyShaderModule(device, shaderModule, pAllocator)
     ccall((:vkDestroyShaderModule, libvulkan), Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
 end
 
+function vkDestroyShaderModule(device, shaderModule, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
+end
+
 function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache)
     ccall((:vkCreatePipelineCache, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
+end
+
+function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
 end
 
 function vkDestroyPipelineCache(device, pipelineCache, pAllocator)
     ccall((:vkDestroyPipelineCache, libvulkan), Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
 end
 
+function vkDestroyPipelineCache(device, pipelineCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
+end
+
 function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData)
     ccall((:vkGetPipelineCacheData, libvulkan), VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
+end
+
+function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
 end
 
 function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergePipelineCaches, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateGraphicsPipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateComputePipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
+function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
 function vkDestroyPipeline(device, pipeline, pAllocator)
     ccall((:vkDestroyPipeline, libvulkan), Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
+end
+
+function vkDestroyPipeline(device, pipeline, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
 end
 
 function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout)
     ccall((:vkCreatePipelineLayout, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
 end
 
+function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
+end
+
 function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator)
     ccall((:vkDestroyPipelineLayout, libvulkan), Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
+end
+
+function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
 end
 
 function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler)
     ccall((:vkCreateSampler, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
 end
 
+function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
+end
+
 function vkDestroySampler(device, sampler, pAllocator)
     ccall((:vkDestroySampler, libvulkan), Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
+end
+
+function vkDestroySampler(device, sampler, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
 end
 
 function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout)
     ccall((:vkCreateDescriptorSetLayout, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
 end
 
+function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
+end
+
 function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator)
     ccall((:vkDestroyDescriptorSetLayout, libvulkan), Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
+end
+
+function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
 end
 
 function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool)
     ccall((:vkCreateDescriptorPool, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
 end
 
+function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
+end
+
 function vkDestroyDescriptorPool(device, descriptorPool, pAllocator)
     ccall((:vkDestroyDescriptorPool, libvulkan), Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
+end
+
+function vkDestroyDescriptorPool(device, descriptorPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
 end
 
 function vkResetDescriptorPool(device, descriptorPool, flags)
     ccall((:vkResetDescriptorPool, libvulkan), VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
 end
 
+function vkResetDescriptorPool(device, descriptorPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
+end
+
 function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets)
     ccall((:vkAllocateDescriptorSets, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
+end
+
+function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
 end
 
 function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets)
     ccall((:vkFreeDescriptorSets, libvulkan), VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
 end
 
+function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
+end
+
 function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
     ccall((:vkUpdateDescriptorSets, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
+end
+
+function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
 end
 
 function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer)
     ccall((:vkCreateFramebuffer, libvulkan), VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
 end
 
+function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
+end
+
 function vkDestroyFramebuffer(device, framebuffer, pAllocator)
     ccall((:vkDestroyFramebuffer, libvulkan), Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
+end
+
+function vkDestroyFramebuffer(device, framebuffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
 end
 
 function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkDestroyRenderPass(device, renderPass, pAllocator)
     ccall((:vkDestroyRenderPass, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
+end
+
+function vkDestroyRenderPass(device, renderPass, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
 end
 
 function vkGetRenderAreaGranularity(device, renderPass, pGranularity)
     ccall((:vkGetRenderAreaGranularity, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
 end
 
+function vkGetRenderAreaGranularity(device, renderPass, pGranularity, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
+end
+
 function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool)
     ccall((:vkCreateCommandPool, libvulkan), VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
+end
+
+function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
 end
 
 function vkDestroyCommandPool(device, commandPool, pAllocator)
     ccall((:vkDestroyCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
 end
 
+function vkDestroyCommandPool(device, commandPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
+end
+
 function vkResetCommandPool(device, commandPool, flags)
     ccall((:vkResetCommandPool, libvulkan), VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
+end
+
+function vkResetCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
 end
 
 function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers)
     ccall((:vkAllocateCommandBuffers, libvulkan), VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
 end
 
+function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
+end
+
 function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers)
     ccall((:vkFreeCommandBuffers, libvulkan), Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
+end
+
+function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
 end
 
 function vkBeginCommandBuffer(commandBuffer, pBeginInfo)
     ccall((:vkBeginCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
 end
 
+function vkBeginCommandBuffer(commandBuffer, pBeginInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
+end
+
 function vkEndCommandBuffer(commandBuffer)
     ccall((:vkEndCommandBuffer, libvulkan), VkResult, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkEndCommandBuffer(commandBuffer, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer,), commandBuffer)
 end
 
 function vkResetCommandBuffer(commandBuffer, flags)
     ccall((:vkResetCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
 end
 
+function vkResetCommandBuffer(commandBuffer, flags, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
+end
+
 function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline)
     ccall((:vkCmdBindPipeline, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
+end
+
+function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
 end
 
 function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports)
     ccall((:vkCmdSetViewport, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
 end
 
+function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
+end
+
 function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors)
     ccall((:vkCmdSetScissor, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
+end
+
+function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
 end
 
 function vkCmdSetLineWidth(commandBuffer, lineWidth)
     ccall((:vkCmdSetLineWidth, libvulkan), Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
 end
 
+function vkCmdSetLineWidth(commandBuffer, lineWidth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
+end
+
 function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
     ccall((:vkCmdSetDepthBias, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
+end
+
+function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
 end
 
 function vkCmdSetBlendConstants(commandBuffer, blendConstants)
     ccall((:vkCmdSetBlendConstants, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
 end
 
+function vkCmdSetBlendConstants(commandBuffer, blendConstants, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
+end
+
 function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds)
     ccall((:vkCmdSetDepthBounds, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
+end
+
+function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
 end
 
 function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask)
     ccall((:vkCmdSetStencilCompareMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
 end
 
+function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
+end
+
 function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask)
     ccall((:vkCmdSetStencilWriteMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
+end
+
+function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
 end
 
 function vkCmdSetStencilReference(commandBuffer, faceMask, reference)
     ccall((:vkCmdSetStencilReference, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
 end
 
+function vkCmdSetStencilReference(commandBuffer, faceMask, reference, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
+end
+
 function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
     ccall((:vkCmdBindDescriptorSets, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
+end
+
+function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
 end
 
 function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType)
     ccall((:vkCmdBindIndexBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
 end
 
+function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
+end
+
 function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
     ccall((:vkCmdBindVertexBuffers, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
+end
+
+function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
 end
 
 function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
     ccall((:vkCmdDraw, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
 end
 
+function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
+end
+
 function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
     ccall((:vkCmdDrawIndexed, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
+end
+
+function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
 end
 
 function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndexedIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
 function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatch, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
 end
 
+function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
+end
+
 function vkCmdDispatchIndirect(commandBuffer, buffer, offset)
     ccall((:vkCmdDispatchIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
+end
+
+function vkCmdDispatchIndirect(commandBuffer, buffer, offset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
 end
 
 function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
     ccall((:vkCmdBlitImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
 end
 
+function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
+end
+
 function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyBufferToImage, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyImageToBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData)
     ccall((:vkCmdUpdateBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
+end
+
+function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
 end
 
 function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data)
     ccall((:vkCmdFillBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
 end
 
+function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
+end
+
 function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
     ccall((:vkCmdClearColorImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
+end
+
+function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
 end
 
 function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
     ccall((:vkCmdClearDepthStencilImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
 end
 
+function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
+end
+
 function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
     ccall((:vkCmdClearAttachments, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
+end
+
+function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
 end
 
 function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdResolveImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
+function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
 function vkCmdSetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdSetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
+function vkCmdSetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
 function vkCmdResetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
+function vkCmdResetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
 function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdWaitEvents, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
+function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
 function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdPipelineBarrier, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
+function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
 function vkCmdBeginQuery(commandBuffer, queryPool, query, flags)
     ccall((:vkCmdBeginQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
+end
+
+function vkCmdBeginQuery(commandBuffer, queryPool, query, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
 end
 
 function vkCmdEndQuery(commandBuffer, queryPool, query)
     ccall((:vkCmdEndQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
 end
 
+function vkCmdEndQuery(commandBuffer, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
+end
+
 function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount)
     ccall((:vkCmdResetQueryPool, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
+end
+
+function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
 end
 
 function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query)
     ccall((:vkCmdWriteTimestamp, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
+end
+
 function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
     ccall((:vkCmdCopyQueryPoolResults, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
+end
+
+function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
 end
 
 function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues)
     ccall((:vkCmdPushConstants, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
 end
 
+function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
+end
+
 function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents)
     ccall((:vkCmdBeginRenderPass, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
+end
+
+function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
 end
 
 function vkCmdNextSubpass(commandBuffer, contents)
     ccall((:vkCmdNextSubpass, libvulkan), Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
 end
 
+function vkCmdNextSubpass(commandBuffer, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
+end
+
 function vkCmdEndRenderPass(commandBuffer)
     ccall((:vkCmdEndRenderPass, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndRenderPass(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers)
     ccall((:vkCmdExecuteCommands, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
+end
+
+function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
 end
 
 const VkSamplerYcbcrConversion = UInt64
@@ -4973,112 +5521,224 @@ function vkEnumerateInstanceVersion(pApiVersion)
     ccall((:vkEnumerateInstanceVersion, libvulkan), VkResult, (Ptr{UInt32},), pApiVersion)
 end
 
+function vkEnumerateInstanceVersion(pApiVersion, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32},), pApiVersion)
+end
+
 function vkBindBufferMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindBufferMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 function vkBindImageMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindImageMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
     ccall((:vkGetDeviceGroupPeerMemoryFeatures, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
+function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
 function vkCmdSetDeviceMask(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMask, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMask(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBase, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroups, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
+function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
 function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
 function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
+function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
 function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
 function vkTrimCommandPool(device, commandPool, flags)
     ccall((:vkTrimCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
+function vkTrimCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
 function vkGetDeviceQueue2(device, pQueueInfo, pQueue)
     ccall((:vkGetDeviceQueue2, libvulkan), Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
 end
 
+function vkGetDeviceQueue2(device, pQueueInfo, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
+end
+
 function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion)
     ccall((:vkCreateSamplerYcbcrConversion, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
+function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
 function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversion, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
+function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
 function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
     ccall((:vkCreateDescriptorUpdateTemplate, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
+function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
 function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
+function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
 function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFenceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphoreProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
+function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
 function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupport, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
+function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
 @cenum VkDriverId::UInt32 begin
@@ -5778,52 +6438,104 @@ function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, coun
     ccall((:vkCmdDrawIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 function vkResetQueryPool(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
+function vkResetQueryPool(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
 function vkGetSemaphoreCounterValue(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValue, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
+function vkGetSemaphoreCounterValue(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
 function vkWaitSemaphores(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphores, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphores(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphore(device, pSignalInfo)
     ccall((:vkSignalSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphore(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 function vkGetBufferDeviceAddress(device, pInfo)
     ccall((:vkGetBufferDeviceAddress, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddress(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkSurfaceKHR = UInt64
@@ -5922,20 +6634,40 @@ function vkDestroySurfaceKHR(instance, surface, pAllocator)
     ccall((:vkDestroySurfaceKHR, libvulkan), Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
 end
 
+function vkDestroySurfaceKHR(instance, surface, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
+end
+
 function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported)
     ccall((:vkGetPhysicalDeviceSurfaceSupportKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
+end
+
+function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
 end
 
 function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormatsKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
 end
 
+function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
+end
+
 function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes)
     ccall((:vkGetPhysicalDeviceSurfacePresentModesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
+end
+
+function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
 end
 
 const VkSwapchainKHR = UInt64
@@ -6066,36 +6798,72 @@ function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain)
     ccall((:vkCreateSwapchainKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
 end
 
+function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
+end
+
 function vkDestroySwapchainKHR(device, swapchain, pAllocator)
     ccall((:vkDestroySwapchainKHR, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
+end
+
+function vkDestroySwapchainKHR(device, swapchain, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
 end
 
 function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages)
     ccall((:vkGetSwapchainImagesKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
 end
 
+function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
+end
+
 function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex)
     ccall((:vkAcquireNextImageKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
+end
+
+function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
 end
 
 function vkQueuePresentKHR(queue, pPresentInfo)
     ccall((:vkQueuePresentKHR, libvulkan), VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
 end
 
+function vkQueuePresentKHR(queue, pPresentInfo, fptr)
+    ccall(fptr, VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
+end
+
 function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities)
     ccall((:vkGetDeviceGroupPresentCapabilitiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
+end
+
+function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
 end
 
 function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes)
     ccall((:vkGetDeviceGroupSurfacePresentModesKHR, libvulkan), VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
 end
 
+function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
+end
+
 function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects)
     ccall((:vkGetPhysicalDevicePresentRectanglesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
 end
 
+function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
+end
+
 function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex)
     ccall((:vkAcquireNextImage2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
+end
+
+function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
 end
 
 const VkDisplayKHR = UInt64
@@ -6198,28 +6966,56 @@ function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount,
     ccall((:vkGetPhysicalDeviceDisplayPropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlanePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays)
     ccall((:vkGetDisplayPlaneSupportedDisplaysKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
 end
 
+function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
+end
+
 function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
+function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
 function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode)
     ccall((:vkCreateDisplayModeKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
 end
 
+function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
+end
+
 function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
 end
 
+function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
+end
+
 function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateDisplayPlaneSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
+function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
 struct VkDisplayPresentInfoKHR
@@ -6235,6 +7031,10 @@ const PFN_vkCreateSharedSwapchainsKHR = Ptr{Cvoid}
 
 function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
     ccall((:vkCreateSharedSwapchainsKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
+end
+
+function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
 end
 
 const VkRenderPassMultiviewCreateInfoKHR = VkRenderPassMultiviewCreateInfo
@@ -6286,28 +7086,56 @@ function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
 const VkPeerMemoryFeatureFlagsKHR = VkPeerMemoryFeatureFlags
@@ -6345,12 +7173,24 @@ function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceInd
     ccall((:vkGetDeviceGroupPeerMemoryFeaturesKHR, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
+function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
 function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMaskKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBaseKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 const VkCommandPoolTrimFlagsKHR = VkCommandPoolTrimFlags
@@ -6362,6 +7202,10 @@ function vkTrimCommandPoolKHR(device, commandPool, flags)
     ccall((:vkTrimCommandPoolKHR, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
+function vkTrimCommandPoolKHR(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
 const VkPhysicalDeviceGroupPropertiesKHR = VkPhysicalDeviceGroupProperties
 
 const VkDeviceGroupDeviceCreateInfoKHR = VkDeviceGroupDeviceCreateInfo
@@ -6371,6 +7215,10 @@ const PFN_vkEnumeratePhysicalDeviceGroupsKHR = Ptr{Cvoid}
 
 function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroupsKHR, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
+function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
 const VkExternalMemoryHandleTypeFlagsKHR = VkExternalMemoryHandleTypeFlags
@@ -6398,6 +7246,10 @@ const PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferPropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
+function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
 const VkExternalMemoryImageCreateInfoKHR = VkExternalMemoryImageCreateInfo
@@ -6436,8 +7288,16 @@ function vkGetMemoryFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetMemoryFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
+function vkGetMemoryFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
 function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties)
     ccall((:vkGetMemoryFdPropertiesKHR, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
+end
+
+function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
 end
 
 const VkExternalSemaphoreHandleTypeFlagsKHR = VkExternalSemaphoreHandleTypeFlags
@@ -6457,6 +7317,10 @@ const PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphorePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
+function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
 const VkSemaphoreImportFlagsKHR = VkSemaphoreImportFlags
@@ -6491,8 +7355,16 @@ function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo)
     ccall((:vkImportSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
 end
 
+function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
+end
+
 function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 struct VkPhysicalDevicePushDescriptorPropertiesKHR
@@ -6511,8 +7383,16 @@ function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set
     ccall((:vkCmdPushDescriptorSetKHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
 end
 
+function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
+end
+
 function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData)
     ccall((:vkCmdPushDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
+end
+
+function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
 end
 
 const VkPhysicalDeviceShaderFloat16Int8FeaturesKHR = VkPhysicalDeviceShaderFloat16Int8Features
@@ -6562,12 +7442,24 @@ function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pD
     ccall((:vkCreateDescriptorUpdateTemplateKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
+function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
 function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 const VkPhysicalDeviceImagelessFramebufferFeaturesKHR = VkPhysicalDeviceImagelessFramebufferFeatures
@@ -6608,16 +7500,32 @@ function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 struct VkSharedPresentSurfaceCapabilitiesKHR
@@ -6631,6 +7539,10 @@ const PFN_vkGetSwapchainStatusKHR = Ptr{Cvoid}
 
 function vkGetSwapchainStatusKHR(device, swapchain)
     ccall((:vkGetSwapchainStatusKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
+end
+
+function vkGetSwapchainStatusKHR(device, swapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
 end
 
 const VkExternalFenceHandleTypeFlagsKHR = VkExternalFenceHandleTypeFlags
@@ -6650,6 +7562,10 @@ const PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFencePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 const VkFenceImportFlagsKHR = VkFenceImportFlags
@@ -6684,8 +7600,16 @@ function vkImportFenceFdKHR(device, pImportFenceFdInfo)
     ccall((:vkImportFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
 end
 
+function vkImportFenceFdKHR(device, pImportFenceFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
+end
+
 function vkGetFenceFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetFenceFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 @cenum VkPerformanceCounterUnitKHR::UInt32 begin
@@ -6832,16 +7756,32 @@ function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physica
     ccall((:vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
 end
 
+function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
+end
+
 function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
     ccall((:vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
+end
+
+function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
 end
 
 function vkAcquireProfilingLockKHR(device, pInfo)
     ccall((:vkAcquireProfilingLockKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
 end
 
+function vkAcquireProfilingLockKHR(device, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
+end
+
 function vkReleaseProfilingLockKHR(device)
     ccall((:vkReleaseProfilingLockKHR, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkReleaseProfilingLockKHR(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 const VkPointClippingBehaviorKHR = VkPointClippingBehavior
@@ -6886,8 +7826,16 @@ function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormats2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
+end
+
+function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
 end
 
 const VkPhysicalDeviceVariablePointerFeaturesKHR = VkPhysicalDeviceVariablePointersFeatures
@@ -6941,16 +7889,32 @@ function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount
     ccall((:vkGetPhysicalDeviceDisplayProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlaneProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModeProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
+function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
 function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
+end
+
+function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
 end
 
 const VkMemoryDedicatedRequirementsKHR = VkMemoryDedicatedRequirements
@@ -6980,12 +7944,24 @@ function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 const VkImageFormatListCreateInfoKHR = VkImageFormatListCreateInfo
@@ -7020,8 +7996,16 @@ function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcb
     ccall((:vkCreateSamplerYcbcrConversionKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
+function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
 function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversionKHR, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
+function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
 const VkBindBufferMemoryInfoKHR = VkBindBufferMemoryInfo
@@ -7038,8 +8022,16 @@ function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 const VkPhysicalDeviceMaintenance3PropertiesKHR = VkPhysicalDeviceMaintenance3Properties
@@ -7053,6 +8045,10 @@ function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupportKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
+function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountKHR ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
 const PFN_vkCmdDrawIndirectCountKHR = Ptr{Cvoid}
 
@@ -7063,8 +8059,16 @@ function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 const VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR = VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures
@@ -7129,12 +8133,24 @@ function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValueKHR, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
+function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
 function vkWaitSemaphoresKHR(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphoresKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphoresKHR(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphoreKHR(device, pSignalInfo)
     ccall((:vkSignalSemaphoreKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphoreKHR(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR = VkPhysicalDeviceVulkanMemoryModelFeatures
@@ -7215,8 +8231,16 @@ function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentSha
     ccall((:vkGetPhysicalDeviceFragmentShadingRatesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
 end
 
+function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
+end
+
 function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps)
     ccall((:vkCmdSetFragmentShadingRateKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
+end
+
+function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
 end
 
 struct VkSurfaceProtectedCapabilitiesKHR
@@ -7256,12 +8280,24 @@ function vkGetBufferDeviceAddressKHR(device, pInfo)
     ccall((:vkGetBufferDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkDeferredOperationKHR = UInt64
@@ -7285,20 +8321,40 @@ function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation)
     ccall((:vkCreateDeferredOperationKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
 end
 
+function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
+end
+
 function vkDestroyDeferredOperationKHR(device, operation, pAllocator)
     ccall((:vkDestroyDeferredOperationKHR, libvulkan), Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
+end
+
+function vkDestroyDeferredOperationKHR(device, operation, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
 end
 
 function vkGetDeferredOperationMaxConcurrencyKHR(device, operation)
     ccall((:vkGetDeferredOperationMaxConcurrencyKHR, libvulkan), UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationMaxConcurrencyKHR(device, operation, fptr)
+    ccall(fptr, UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkGetDeferredOperationResultKHR(device, operation)
     ccall((:vkGetDeferredOperationResultKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationResultKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkDeferredOperationJoinKHR(device, operation)
     ccall((:vkDeferredOperationJoinKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
+function vkDeferredOperationJoinKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
 @cenum VkPipelineExecutableStatisticFormatKHR::UInt32 begin
@@ -7392,12 +8448,24 @@ function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutable
     ccall((:vkGetPipelineExecutablePropertiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
 end
 
+function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutableCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
+end
+
 function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics)
     ccall((:vkGetPipelineExecutableStatisticsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
 end
 
+function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
+end
+
 function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
     ccall((:vkGetPipelineExecutableInternalRepresentationsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
+end
+
+function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
 end
 
 struct VkPipelineLibraryCreateInfoKHR
@@ -7549,32 +8617,64 @@ function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo)
     ccall((:vkCmdSetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
 end
 
+function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
+end
+
 function vkCmdResetEvent2KHR(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
+end
+
+function vkCmdResetEvent2KHR(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
 end
 
 function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos)
     ccall((:vkCmdWaitEvents2KHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
 end
 
+function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
+end
+
 function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo)
     ccall((:vkCmdPipelineBarrier2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
+end
+
+function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
 end
 
 function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query)
     ccall((:vkCmdWriteTimestamp2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
+end
+
 function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit2KHR, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
+function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
 function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarker2AMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
 end
 
+function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
+end
+
 function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointData2NV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR
@@ -7725,24 +8825,48 @@ function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo)
     ccall((:vkCmdCopyBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
 end
 
+function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
+end
+
 function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo)
     ccall((:vkCmdCopyImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
+end
+
+function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
 end
 
 function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo)
     ccall((:vkCmdCopyBufferToImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
 end
 
+function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
+end
+
 function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo)
     ccall((:vkCmdCopyImageToBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
+end
+
+function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
 end
 
 function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo)
     ccall((:vkCmdBlitImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
 end
 
+function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
+end
+
 function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo)
     ccall((:vkCmdResolveImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
+end
+
+function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
 end
 
 const VkDebugReportCallbackEXT = UInt64
@@ -7826,12 +8950,24 @@ function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCall
     ccall((:vkCreateDebugReportCallbackEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
 end
 
+function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
+end
+
 function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator)
     ccall((:vkDestroyDebugReportCallbackEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
 end
 
+function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
+end
+
 function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
     ccall((:vkDebugReportMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
+end
+
+function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
 end
 
 @cenum VkRasterizationOrderAMD::UInt32 begin
@@ -7890,20 +9026,40 @@ function vkDebugMarkerSetObjectTagEXT(device, pTagInfo)
     ccall((:vkDebugMarkerSetObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
 end
 
+function vkDebugMarkerSetObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
+end
+
 function vkDebugMarkerSetObjectNameEXT(device, pNameInfo)
     ccall((:vkDebugMarkerSetObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
+end
+
+function vkDebugMarkerSetObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
 end
 
 function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerBeginEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdDebugMarkerEndEXT(commandBuffer)
     ccall((:vkCmdDebugMarkerEndEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdDebugMarkerEndEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerInsertEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
 struct VkDedicatedAllocationImageCreateInfoNV
@@ -7978,24 +9134,48 @@ function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindi
     ccall((:vkCmdBindTransformFeedbackBuffersEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
 end
 
+function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
+end
+
 function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdBeginTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
+function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
 function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdEndTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
+function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
 function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index)
     ccall((:vkCmdBeginQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
+end
+
+function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
 end
 
 function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index)
     ccall((:vkCmdEndQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
 end
 
+function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
+end
+
 function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
     ccall((:vkCmdDrawIndirectByteCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
+end
+
+function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
 end
 
 struct VkImageViewHandleInfoNVX
@@ -8023,8 +9203,16 @@ function vkGetImageViewHandleNVX(device, pInfo)
     ccall((:vkGetImageViewHandleNVX, libvulkan), UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
 end
 
+function vkGetImageViewHandleNVX(device, pInfo, fptr)
+    ccall(fptr, UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
+end
+
 function vkGetImageViewAddressNVX(device, imageView, pProperties)
     ccall((:vkGetImageViewAddressNVX, libvulkan), VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
+end
+
+function vkGetImageViewAddressNVX(device, imageView, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
 end
 
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountAMD ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
@@ -8037,8 +9225,16 @@ function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkTextureLODGatherFormatPropertiesAMD
@@ -8079,6 +9275,10 @@ function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, 
     ccall((:vkGetShaderInfoAMD, libvulkan), VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
 end
 
+function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
+end
+
 struct VkPhysicalDeviceCornerSampledImageFeaturesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8116,6 +9316,10 @@ const PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
     ccall((:vkGetPhysicalDeviceExternalImageFormatPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
 end
 
 struct VkExternalMemoryImageCreateInfoNV
@@ -8199,8 +9403,16 @@ function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingB
     ccall((:vkCmdBeginConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
 end
 
+function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
+end
+
 function vkCmdEndConditionalRenderingEXT(commandBuffer)
     ccall((:vkCmdEndConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkCmdEndConditionalRenderingEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
 struct VkViewportWScalingNV
@@ -8223,11 +9435,19 @@ function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount,
     ccall((:vkCmdSetViewportWScalingNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
 end
 
+function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
+end
+
 # typedef VkResult ( VKAPI_PTR * PFN_vkReleaseDisplayEXT ) ( VkPhysicalDevice physicalDevice , VkDisplayKHR display )
 const PFN_vkReleaseDisplayEXT = Ptr{Cvoid}
 
 function vkReleaseDisplayEXT(physicalDevice, display)
     ccall((:vkReleaseDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
+function vkReleaseDisplayEXT(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
 @cenum VkSurfaceCounterFlagBitsEXT::UInt32 begin
@@ -8259,6 +9479,10 @@ const PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2EXT, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
+function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
 @cenum VkDisplayPowerStateEXT::UInt32 begin
@@ -8318,16 +9542,32 @@ function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo)
     ccall((:vkDisplayPowerControlEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
 end
 
+function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
+end
+
 function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDeviceEventEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
+end
+
+function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
 end
 
 function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDisplayEventEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
 end
 
+function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
+end
+
 function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue)
     ccall((:vkGetSwapchainCounterEXT, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
+end
+
+function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
 end
 
 struct VkRefreshCycleDurationGOOGLE
@@ -8364,8 +9604,16 @@ function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProper
     ccall((:vkGetRefreshCycleDurationGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
 end
 
+function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
+end
+
 function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings)
     ccall((:vkGetPastPresentationTimingGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
+end
+
+function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
 end
 
 struct VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX
@@ -8431,6 +9679,10 @@ const PFN_vkCmdSetDiscardRectangleEXT = Ptr{Cvoid}
 
 function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
     ccall((:vkCmdSetDiscardRectangleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
+end
+
+function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
 end
 
 @cenum VkConservativeRasterizationModeEXT::UInt32 begin
@@ -8502,6 +9754,10 @@ const PFN_vkSetHdrMetadataEXT = Ptr{Cvoid}
 
 function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata)
     ccall((:vkSetHdrMetadataEXT, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
+end
+
+function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
 end
 
 const VkDebugUtilsMessengerEXT = UInt64
@@ -8619,44 +9875,88 @@ function vkSetDebugUtilsObjectNameEXT(device, pNameInfo)
     ccall((:vkSetDebugUtilsObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
 end
 
+function vkSetDebugUtilsObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
+end
+
 function vkSetDebugUtilsObjectTagEXT(device, pTagInfo)
     ccall((:vkSetDebugUtilsObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
+end
+
+function vkSetDebugUtilsObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
 end
 
 function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkQueueEndDebugUtilsLabelEXT(queue)
     ccall((:vkQueueEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue,), queue)
+end
+
+function vkQueueEndDebugUtilsLabelEXT(queue, fptr)
+    ccall(fptr, Cvoid, (VkQueue,), queue)
 end
 
 function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCmdEndDebugUtilsLabelEXT(commandBuffer)
     ccall((:vkCmdEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndDebugUtilsLabelEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger)
     ccall((:vkCreateDebugUtilsMessengerEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
 end
 
+function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
+end
+
 function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator)
     ccall((:vkDestroyDebugUtilsMessengerEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
 end
 
+function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
+end
+
 function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData)
     ccall((:vkSubmitDebugUtilsMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
+end
+
+function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
 end
 
 const VkSamplerReductionModeEXT = VkSamplerReductionMode
@@ -8761,8 +10061,16 @@ function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo)
     ccall((:vkCmdSetSampleLocationsEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
 end
 
+function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
+end
+
 function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties)
     ccall((:vkGetPhysicalDeviceMultisamplePropertiesEXT, libvulkan), Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
+end
+
+function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
 end
 
 @cenum VkBlendOverlapEXT::UInt32 begin
@@ -8890,6 +10198,10 @@ function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties)
     ccall((:vkGetImageDrmFormatModifierPropertiesEXT, libvulkan), VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
 end
 
+function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
+end
+
 const VkValidationCacheEXT = UInt64
 
 @cenum VkValidationCacheHeaderVersionEXT::UInt32 begin
@@ -8929,16 +10241,32 @@ function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidation
     ccall((:vkCreateValidationCacheEXT, libvulkan), VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
 end
 
+function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
+end
+
 function vkDestroyValidationCacheEXT(device, validationCache, pAllocator)
     ccall((:vkDestroyValidationCacheEXT, libvulkan), Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
+end
+
+function vkDestroyValidationCacheEXT(device, validationCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
 end
 
 function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergeValidationCachesEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData)
     ccall((:vkGetValidationCacheDataEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
+end
+
+function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
 end
 
 const VkDescriptorBindingFlagBitsEXT = VkDescriptorBindingFlagBits
@@ -9041,12 +10369,24 @@ function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout)
     ccall((:vkCmdBindShadingRateImageNV, libvulkan), Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
 end
 
+function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
+end
+
 function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
     ccall((:vkCmdSetViewportShadingRatePaletteNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
 end
 
+function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
+end
+
 function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
     ccall((:vkCmdSetCoarseSampleOrderNV, libvulkan), Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
+end
+
+function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
 end
 
 const VkAccelerationStructureNV = UInt64
@@ -9371,52 +10711,104 @@ function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccel
     ccall((:vkCreateAccelerationStructureNV, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureNV, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements)
     ccall((:vkGetAccelerationStructureMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
+end
+
 function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos)
     ccall((:vkBindAccelerationStructureMemoryNV, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
 end
 
 function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
     ccall((:vkCmdBuildAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
 end
 
+function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
+end
+
 function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode)
     ccall((:vkCmdCopyAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
+end
+
+function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
 end
 
 function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
     ccall((:vkCmdTraceRaysNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
 end
 
+function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesNV, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
+function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
 function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData)
     ccall((:vkGetAccelerationStructureHandleNV, libvulkan), VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
 end
 
+function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
+function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
 function vkCompileDeferredNV(device, pipeline, shader)
     ccall((:vkCompileDeferredNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
+end
+
+function vkCompileDeferredNV(device, pipeline, shader, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
 end
 
 struct VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV
@@ -9484,11 +10876,19 @@ function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, p
     ccall((:vkGetMemoryHostPointerPropertiesEXT, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
 end
 
+function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, pMemoryHostPointerProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdWriteBufferMarkerAMD ) ( VkCommandBuffer commandBuffer , VkPipelineStageFlagBits pipelineStage , VkBuffer dstBuffer , VkDeviceSize dstOffset , uint32_t marker )
 const PFN_vkCmdWriteBufferMarkerAMD = Ptr{Cvoid}
 
 function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarkerAMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
+end
+
+function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
 end
 
 @cenum VkPipelineCompilerControlFlagBitsAMD::UInt32 begin
@@ -9527,8 +10927,16 @@ function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDom
     ccall((:vkGetPhysicalDeviceCalibrateableTimeDomainsEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
 end
 
+function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDomainCount, pTimeDomains, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
+end
+
 function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
     ccall((:vkGetCalibratedTimestampsEXT, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
+end
+
+function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
 end
 
 struct VkPhysicalDeviceShaderCorePropertiesAMD
@@ -9660,12 +11068,24 @@ function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask)
     ccall((:vkCmdDrawMeshTasksNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
 end
 
+function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
+end
+
 function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectCountNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV
@@ -9700,6 +11120,10 @@ function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclus
     ccall((:vkCmdSetExclusiveScissorNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
 end
 
+function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
+end
+
 struct VkQueueFamilyCheckpointPropertiesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -9723,8 +11147,16 @@ function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker)
     ccall((:vkCmdSetCheckpointNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
 end
 
+function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
+end
+
 function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointDataNV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL
@@ -9866,36 +11298,72 @@ function vkInitializePerformanceApiINTEL(device, pInitializeInfo)
     ccall((:vkInitializePerformanceApiINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
 end
 
+function vkInitializePerformanceApiINTEL(device, pInitializeInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
+end
+
 function vkUninitializePerformanceApiINTEL(device)
     ccall((:vkUninitializePerformanceApiINTEL, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkUninitializePerformanceApiINTEL(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceStreamMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
 function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo)
     ccall((:vkCmdSetPerformanceOverrideINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
 end
 
+function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
+end
+
 function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration)
     ccall((:vkAcquirePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
+end
+
+function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
 end
 
 function vkReleasePerformanceConfigurationINTEL(device, configuration)
     ccall((:vkReleasePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
 end
 
+function vkReleasePerformanceConfigurationINTEL(device, configuration, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
+end
+
 function vkQueueSetPerformanceConfigurationINTEL(queue, configuration)
     ccall((:vkQueueSetPerformanceConfigurationINTEL, libvulkan), VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
 end
 
+function vkQueueSetPerformanceConfigurationINTEL(queue, configuration, fptr)
+    ccall(fptr, VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
+end
+
 function vkGetPerformanceParameterINTEL(device, parameter, pValue)
     ccall((:vkGetPerformanceParameterINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
+end
+
+function vkGetPerformanceParameterINTEL(device, parameter, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
 end
 
 struct VkPhysicalDevicePCIBusInfoPropertiesEXT
@@ -9924,6 +11392,10 @@ const PFN_vkSetLocalDimmingAMD = Ptr{Cvoid}
 
 function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable)
     ccall((:vkSetLocalDimmingAMD, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
+end
+
+function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
 end
 
 struct VkPhysicalDeviceFragmentDensityMapFeaturesEXT
@@ -10048,6 +11520,10 @@ function vkGetBufferDeviceAddressEXT(device, pInfo)
     ccall((:vkGetBufferDeviceAddressEXT, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressEXT(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 @cenum VkToolPurposeFlagBitsEXT::UInt32 begin
     VK_TOOL_PURPOSE_VALIDATION_BIT_EXT = 1
     VK_TOOL_PURPOSE_PROFILING_BIT_EXT = 2
@@ -10076,6 +11552,10 @@ const PFN_vkGetPhysicalDeviceToolPropertiesEXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties)
     ccall((:vkGetPhysicalDeviceToolPropertiesEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
+end
+
+function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
 end
 
 const VkImageStencilUsageCreateInfoEXT = VkImageStencilUsageCreateInfo
@@ -10165,6 +11645,10 @@ function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPrope
     ccall((:vkGetPhysicalDeviceCooperativeMatrixPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
+end
+
 @cenum VkCoverageReductionModeNV::UInt32 begin
     VK_COVERAGE_REDUCTION_MODE_MERGE_NV = 0
     VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV = 1
@@ -10200,6 +11684,10 @@ const PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV = Pt
 
 function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations)
     ccall((:vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
+end
+
+function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
 end
 
 struct VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT
@@ -10257,6 +11745,10 @@ function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateHeadlessSurfaceEXT, libvulkan), VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 @cenum VkLineRasterizationModeEXT::UInt32 begin
     VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT = 0
     VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT = 1
@@ -10298,6 +11790,10 @@ function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePat
     ccall((:vkCmdSetLineStippleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
 end
 
+function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
+end
+
 struct VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10322,6 +11818,10 @@ const PFN_vkResetQueryPoolEXT = Ptr{Cvoid}
 
 function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPoolEXT, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
+function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
 struct VkPhysicalDeviceIndexTypeUint8FeaturesEXT
@@ -10376,48 +11876,96 @@ function vkCmdSetCullModeEXT(commandBuffer, cullMode)
     ccall((:vkCmdSetCullModeEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
 end
 
+function vkCmdSetCullModeEXT(commandBuffer, cullMode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
+end
+
 function vkCmdSetFrontFaceEXT(commandBuffer, frontFace)
     ccall((:vkCmdSetFrontFaceEXT, libvulkan), Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
+end
+
+function vkCmdSetFrontFaceEXT(commandBuffer, frontFace, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
 end
 
 function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology)
     ccall((:vkCmdSetPrimitiveTopologyEXT, libvulkan), Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
 end
 
+function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
+end
+
 function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports)
     ccall((:vkCmdSetViewportWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
+end
+
+function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
 end
 
 function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors)
     ccall((:vkCmdSetScissorWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
 end
 
+function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
+end
+
 function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
     ccall((:vkCmdBindVertexBuffers2EXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
+end
+
+function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
 end
 
 function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable)
     ccall((:vkCmdSetDepthTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
 end
 
+function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
+end
+
 function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable)
     ccall((:vkCmdSetDepthWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
+end
+
+function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
 end
 
 function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp)
     ccall((:vkCmdSetDepthCompareOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
 end
 
+function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
+end
+
 function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable)
     ccall((:vkCmdSetDepthBoundsTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
+end
+
+function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
 end
 
 function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable)
     ccall((:vkCmdSetStencilTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
 end
 
+function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
+end
+
 function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
     ccall((:vkCmdSetStencilOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
+end
+
+function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
 end
 
 struct VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT
@@ -10597,24 +12145,48 @@ function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequir
     ccall((:vkGetGeneratedCommandsMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo)
     ccall((:vkCmdPreprocessGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
+end
+
+function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
 end
 
 function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
     ccall((:vkCmdExecuteGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
 end
 
+function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
+end
+
 function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex)
     ccall((:vkCmdBindPipelineShaderGroupNV, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
+end
+
+function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
 end
 
 function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
     ccall((:vkCreateIndirectCommandsLayoutNV, libvulkan), VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
 end
 
+function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
+end
+
 function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator)
     ccall((:vkDestroyIndirectCommandsLayoutNV, libvulkan), Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
+end
+
+function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
 end
 
 struct VkPhysicalDeviceInheritedViewportScissorFeaturesNV
@@ -10776,16 +12348,32 @@ function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDat
     ccall((:vkCreatePrivateDataSlotEXT, libvulkan), VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
 end
 
+function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDataSlot, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
+end
+
 function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator)
     ccall((:vkDestroyPrivateDataSlotEXT, libvulkan), Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
+end
+
+function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
 end
 
 function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data)
     ccall((:vkSetPrivateDataEXT, libvulkan), VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
 end
 
+function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
+end
+
 function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData)
     ccall((:vkGetPrivateDataEXT, libvulkan), Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
+end
+
+function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
 end
 
 struct VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT
@@ -10866,6 +12454,10 @@ function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerO
     ccall((:vkCmdSetFragmentShadingRateEnumNV, libvulkan), Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
 end
 
+function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
+end
+
 struct VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10916,8 +12508,16 @@ function vkAcquireWinrtDisplayNV(physicalDevice, display)
     ccall((:vkAcquireWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
+function vkAcquireWinrtDisplayNV(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
 function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay)
     ccall((:vkGetWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
+end
+
+function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
 end
 
 struct VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE
@@ -10969,6 +12569,10 @@ function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pV
     ccall((:vkCmdSetVertexInputEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
 end
 
+function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
+end
+
 struct VkPhysicalDeviceExtendedDynamicState2FeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10996,20 +12600,40 @@ function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints)
     ccall((:vkCmdSetPatchControlPointsEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
 end
 
+function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
+end
+
 function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable)
     ccall((:vkCmdSetRasterizerDiscardEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
+end
+
+function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
 end
 
 function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable)
     ccall((:vkCmdSetDepthBiasEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
 end
 
+function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
+end
+
 function vkCmdSetLogicOpEXT(commandBuffer, logicOp)
     ccall((:vkCmdSetLogicOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
 end
 
+function vkCmdSetLogicOpEXT(commandBuffer, logicOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
+end
+
 function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable)
     ccall((:vkCmdSetPrimitiveRestartEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
+end
+
+function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
 end
 
 struct VkPhysicalDeviceColorWriteEnableFeaturesEXT
@@ -11030,6 +12654,10 @@ const PFN_vkCmdSetColorWriteEnableEXT = Ptr{Cvoid}
 
 function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables)
     ccall((:vkCmdSetColorWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
+end
+
+function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
 end
 
 const VkAccelerationStructureKHR = UInt64
@@ -11316,64 +12944,128 @@ function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAcce
     ccall((:vkCreateAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkCmdBuildAccelerationStructuresKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
     ccall((:vkCmdBuildAccelerationStructuresIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
+end
+
+function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
 end
 
 function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkBuildAccelerationStructuresKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureToMemoryKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
 end
 
+function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
+end
+
 function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyMemoryToAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
     ccall((:vkWriteAccelerationStructuresPropertiesKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
 end
 
+function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
+end
+
 function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureToMemoryKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
 end
 
+function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
+end
+
 function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyMemoryToAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo)
     ccall((:vkGetAccelerationStructureDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
 end
 
+function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
+function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
 function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility)
     ccall((:vkGetDeviceAccelerationStructureCompatibilityKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
 end
 
+function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
+end
+
 function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
     ccall((:vkGetAccelerationStructureBuildSizesKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
+end
+
+function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
 end
 
 @cenum VkShaderGroupShaderKHR::UInt32 begin
@@ -11476,24 +13168,48 @@ function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShader
     ccall((:vkCmdTraceRaysKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
 end
 
+function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingCaptureReplayShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
     ccall((:vkCmdTraceRaysIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
+end
+
+function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
 end
 
 function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader)
     ccall((:vkGetRayTracingShaderGroupStackSizeKHR, libvulkan), VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
 end
 
+function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader, fptr)
+    ccall(fptr, VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
+end
+
 function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize)
     ccall((:vkCmdSetRayTracingPipelineStackSizeKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
+end
+
+function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
 end
 
 struct VkPhysicalDeviceRayQueryFeaturesKHR
@@ -11526,8 +13242,16 @@ function vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateWaylandSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkWaylandSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkWaylandSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display)
     ccall((:vkGetPhysicalDeviceWaylandPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{wl_display}), physicalDevice, queueFamilyIndex, display)
+end
+
+function vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{wl_display}), physicalDevice, queueFamilyIndex, display)
 end
 
 const VkXcbSurfaceCreateFlagsKHR = VkFlags
@@ -11550,8 +13274,16 @@ function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXcbSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id)
     ccall((:vkGetPhysicalDeviceXcbPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
+end
+
+function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
 end
 
 const VkXlibSurfaceCreateFlagsKHR = VkFlags
@@ -11574,8 +13306,16 @@ function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXlibSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID)
     ccall((:vkGetPhysicalDeviceXlibPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
+end
+
+function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
 end
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkAcquireXlibDisplayEXT ) ( VkPhysicalDevice physicalDevice , Display * dpy , VkDisplayKHR display )
@@ -11588,8 +13328,16 @@ function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display)
     ccall((:vkAcquireXlibDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
 end
 
+function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
+end
+
 function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay)
     ccall((:vkGetRandROutputDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
+end
+
+function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
 end
 
 const VULKAN_H_ = 1

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -3162,24 +3162,16 @@ end
 
 const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
 
-function VkClearColorValue(float32::NTuple{4, Cfloat})
+function VkClearColorValue(val::__U_VkClearColorValue)
     ref = Ref{VkClearColorValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkClearColorValue(int32::NTuple{4, Int32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkClearColorValue(uint32::NTuple{4, UInt32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.uint32 = uint32
+    if val isa NTuple{4, Cfloat}
+        ptr.float32 = val
+    elseif val isa NTuple{4, Int32}
+        ptr.int32 = val
+    elseif val isa NTuple{4, UInt32}
+        ptr.uint32 = val
+    end
     ref[]
 end
 
@@ -3211,17 +3203,14 @@ end
 
 const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
 
-function VkClearValue(color::VkClearColorValue)
+function VkClearValue(val::__U_VkClearValue)
     ref = Ref{VkClearValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.color = color
-    ref[]
-end
-
-function VkClearValue(depthStencil::VkClearDepthStencilValue)
-    ref = Ref{VkClearValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.depthStencil = depthStencil
+    if val isa VkClearColorValue
+        ptr.color = val
+    elseif val isa VkClearDepthStencilValue
+        ptr.depthStencil = val
+    end
     ref[]
 end
 
@@ -7768,45 +7757,22 @@ end
 
 const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
 
-function VkPerformanceCounterResultKHR(int32::Int32)
+function VkPerformanceCounterResultKHR(val::__U_VkPerformanceCounterResultKHR)
     ref = Ref{VkPerformanceCounterResultKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(int64::Int64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int64 = int64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint32::UInt32)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint32 = uint32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint64::UInt64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint64 = uint64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float32::Cfloat)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float64::Cdouble)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float64 = float64
+    if val isa Int32
+        ptr.int32 = val
+    elseif val isa Int64
+        ptr.int64 = val
+    elseif val isa UInt32
+        ptr.uint32 = val
+    elseif val isa UInt64
+        ptr.uint64 = val
+    elseif val isa Cfloat
+        ptr.float32 = val
+    elseif val isa Cdouble
+        ptr.float64 = val
+    end
     ref[]
 end
 
@@ -8501,31 +8467,18 @@ end
 
 const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
 
-function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+function VkPipelineExecutableStatisticValueKHR(val::__U_VkPipelineExecutableStatisticValueKHR)
     ref = Ref{VkPipelineExecutableStatisticValueKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.b32 = b32
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(i64::Int64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.i64 = i64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.u64 = u64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.f64 = f64
+    if val isa VkBool32
+        ptr.b32 = val
+    elseif val isa Int64
+        ptr.i64 = val
+    elseif val isa UInt64
+        ptr.u64 = val
+    elseif val isa Cdouble
+        ptr.f64 = val
+    end
     ref[]
 end
 
@@ -11349,38 +11302,20 @@ end
 
 const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
 
-function VkPerformanceValueDataINTEL(value32::UInt32)
+function VkPerformanceValueDataINTEL(val::__U_VkPerformanceValueDataINTEL)
     ref = Ref{VkPerformanceValueDataINTEL}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value32 = value32
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(value64::UInt64)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value64 = value64
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueFloat = valueFloat
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueBool::VkBool32)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueBool = valueBool
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueString = valueString
+    if val isa UInt32
+        ptr.value32 = val
+    elseif val isa UInt64
+        ptr.value64 = val
+    elseif val isa Cfloat
+        ptr.valueFloat = val
+    elseif val isa VkBool32
+        ptr.valueBool = val
+    elseif val isa Ptr{Cchar}
+        ptr.valueString = val
+    end
     ref[]
 end
 
@@ -12873,17 +12808,14 @@ end
 
 const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressKHR(val::__U_VkDeviceOrHostAddressKHR)
     ref = Ref{VkDeviceOrHostAddressKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -12910,17 +12842,14 @@ end
 
 const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressConstKHR(val::__U_VkDeviceOrHostAddressConstKHR)
     ref = Ref{VkDeviceOrHostAddressConstKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressConstKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -12981,24 +12910,16 @@ end
 
 const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
 
-function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+function VkAccelerationStructureGeometryDataKHR(val::__U_VkAccelerationStructureGeometryDataKHR)
     ref = Ref{VkAccelerationStructureGeometryDataKHR}()
     ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.triangles = triangles
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.aabbs = aabbs
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.instances = instances
+    if val isa VkAccelerationStructureGeometryTrianglesDataKHR
+        ptr.triangles = val
+    elseif val isa VkAccelerationStructureGeometryAabbsDataKHR
+        ptr.aabbs = val
+    elseif val isa VkAccelerationStructureGeometryInstancesDataKHR
+        ptr.instances = val
+    end
     ref[]
 end
 

--- a/lib/i686-w64-mingw32.jl
+++ b/lib/i686-w64-mingw32.jl
@@ -3180,6 +3180,29 @@ function Base.setproperty!(x::Ptr{VkClearColorValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
+
+function VkClearColorValue(float32::NTuple{4, Cfloat})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkClearColorValue(int32::NTuple{4, Int32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkClearColorValue(uint32::NTuple{4, UInt32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
 struct VkClearDepthStencilValue
     depth::Cfloat
     stencil::UInt32
@@ -3204,6 +3227,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkClearValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
+
+function VkClearValue(color::VkClearColorValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.color = color
+    ref[]
+end
+
+function VkClearValue(depthStencil::VkClearDepthStencilValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.depthStencil = depthStencil
+    ref[]
 end
 
 struct VkClearAttachment
@@ -7747,6 +7786,50 @@ function Base.setproperty!(x::Ptr{VkPerformanceCounterResultKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
+
+function VkPerformanceCounterResultKHR(int32::Int32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(int64::Int64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int64 = int64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint32::UInt32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint64::UInt64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint64 = uint64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float32::Cfloat)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float64::Cdouble)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float64 = float64
+    ref[]
+end
+
 struct VkAcquireProfilingLockInfoKHR
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8434,6 +8517,36 @@ end
 
 function Base.setproperty!(x::Ptr{VkPipelineExecutableStatisticValueKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
+
+function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.b32 = b32
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(i64::Int64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.i64 = i64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.u64 = u64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.f64 = f64
+    ref[]
 end
 
 struct VkPipelineExecutableStatisticKHR
@@ -10686,6 +10799,18 @@ function Base.setproperty!(x::Ptr{VkAccelerationStructureInstanceKHR}, f::Symbol
     unsafe_store!(getproperty(x, f), v)
 end
 
+function VkAccelerationStructureInstanceKHR(transform::VkTransformMatrixKHR, instanceCustomIndex::UInt32, mask::UInt32, instanceShaderBindingTableRecordOffset::UInt32, flags::VkGeometryInstanceFlagsKHR, accelerationStructureReference::UInt64)
+    ref = Ref{VkAccelerationStructureInstanceKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureInstanceKHR}, ref)
+    ptr.transform = transform
+    ptr.instanceCustomIndex = instanceCustomIndex
+    ptr.mask = mask
+    ptr.instanceShaderBindingTableRecordOffset = instanceShaderBindingTableRecordOffset
+    ptr.flags = flags
+    ptr.accelerationStructureReference = accelerationStructureReference
+    ref[]
+end
+
 const VkAccelerationStructureInstanceNV = VkAccelerationStructureInstanceKHR
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkCreateAccelerationStructureNV
@@ -11240,6 +11365,43 @@ end
 
 function Base.setproperty!(x::Ptr{VkPerformanceValueDataINTEL}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
+
+function VkPerformanceValueDataINTEL(value32::UInt32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value32 = value32
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(value64::UInt64)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value64 = value64
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueFloat = valueFloat
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueBool::VkBool32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueBool = valueBool
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueString = valueString
+    ref[]
 end
 
 struct VkPerformanceValueINTEL
@@ -12729,6 +12891,22 @@ function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
+end
+
 struct VkDeviceOrHostAddressConstKHR
     data::NTuple{8, UInt8}
 end
@@ -12748,6 +12926,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressConstKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
 end
 
 struct VkAccelerationStructureBuildRangeInfoKHR
@@ -12803,6 +12997,29 @@ end
 
 function Base.setproperty!(x::Ptr{VkAccelerationStructureGeometryDataKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
+
+function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.triangles = triangles
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.aabbs = aabbs
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.instances = instances
+    ref[]
 end
 
 struct VkAccelerationStructureGeometryKHR

--- a/lib/i686-w64-mingw32.jl
+++ b/lib/i686-w64-mingw32.jl
@@ -3666,548 +3666,1096 @@ function vkCreateInstance(pCreateInfo, pAllocator, pInstance)
     ccall((:vkCreateInstance, libvulkan), VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
 end
 
+function vkCreateInstance(pCreateInfo, pAllocator, pInstance, fptr)
+    ccall(fptr, VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
+end
+
 function vkDestroyInstance(instance, pAllocator)
     ccall((:vkDestroyInstance, libvulkan), Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
+end
+
+function vkDestroyInstance(instance, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
 end
 
 function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices)
     ccall((:vkEnumeratePhysicalDevices, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
 end
 
+function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
+end
+
 function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
+end
+
+function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
 end
 
 function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceProperties(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
 end
 
+function vkGetPhysicalDeviceProperties(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
+end
+
 function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
+function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
 function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetInstanceProcAddr(instance, pName)
     ccall((:vkGetInstanceProcAddr, libvulkan), PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
+end
+
+function vkGetInstanceProcAddr(instance, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
 end
 
 function vkGetDeviceProcAddr(device, pName)
     ccall((:vkGetDeviceProcAddr, libvulkan), PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
 end
 
+function vkGetDeviceProcAddr(device, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
+end
+
 function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice)
     ccall((:vkCreateDevice, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
+end
+
+function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
 end
 
 function vkDestroyDevice(device, pAllocator)
     ccall((:vkDestroyDevice, libvulkan), Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
 end
 
+function vkDestroyDevice(device, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
+end
+
 function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceExtensionProperties, libvulkan), VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceExtensionProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
+end
+
 function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceLayerProperties, libvulkan), VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceLayerProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue)
     ccall((:vkGetDeviceQueue, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
+end
+
+function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
 end
 
 function vkQueueSubmit(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
+function vkQueueSubmit(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
 function vkQueueWaitIdle(queue)
     ccall((:vkQueueWaitIdle, libvulkan), VkResult, (VkQueue,), queue)
+end
+
+function vkQueueWaitIdle(queue, fptr)
+    ccall(fptr, VkResult, (VkQueue,), queue)
 end
 
 function vkDeviceWaitIdle(device)
     ccall((:vkDeviceWaitIdle, libvulkan), VkResult, (VkDevice,), device)
 end
 
+function vkDeviceWaitIdle(device, fptr)
+    ccall(fptr, VkResult, (VkDevice,), device)
+end
+
 function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory)
     ccall((:vkAllocateMemory, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
+end
+
+function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
 end
 
 function vkFreeMemory(device, memory, pAllocator)
     ccall((:vkFreeMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
 end
 
+function vkFreeMemory(device, memory, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
+end
+
 function vkMapMemory(device, memory, offset, size, flags, ppData)
     ccall((:vkMapMemory, libvulkan), VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
+end
+
+function vkMapMemory(device, memory, offset, size, flags, ppData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
 end
 
 function vkUnmapMemory(device, memory)
     ccall((:vkUnmapMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory), device, memory)
 end
 
+function vkUnmapMemory(device, memory, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory), device, memory)
+end
+
 function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkFlushMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
+function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
 function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkInvalidateMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
+function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
 function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes)
     ccall((:vkGetDeviceMemoryCommitment, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
+end
+
+function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
 end
 
 function vkBindBufferMemory(device, buffer, memory, memoryOffset)
     ccall((:vkBindBufferMemory, libvulkan), VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
 end
 
+function vkBindBufferMemory(device, buffer, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
+end
+
 function vkBindImageMemory(device, image, memory, memoryOffset)
     ccall((:vkBindImageMemory, libvulkan), VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
+end
+
+function vkBindImageMemory(device, image, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
 end
 
 function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
+end
+
 function vkGetImageMemoryRequirements(device, image, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements(device, image, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
 end
 
 function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
+function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
 end
 
 function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence)
     ccall((:vkQueueBindSparse, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
 end
 
+function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
+end
+
 function vkCreateFence(device, pCreateInfo, pAllocator, pFence)
     ccall((:vkCreateFence, libvulkan), VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
+end
+
+function vkCreateFence(device, pCreateInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
 end
 
 function vkDestroyFence(device, fence, pAllocator)
     ccall((:vkDestroyFence, libvulkan), Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
 end
 
+function vkDestroyFence(device, fence, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
+end
+
 function vkResetFences(device, fenceCount, pFences)
     ccall((:vkResetFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
+end
+
+function vkResetFences(device, fenceCount, pFences, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
 end
 
 function vkGetFenceStatus(device, fence)
     ccall((:vkGetFenceStatus, libvulkan), VkResult, (VkDevice, VkFence), device, fence)
 end
 
+function vkGetFenceStatus(device, fence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkFence), device, fence)
+end
+
 function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout)
     ccall((:vkWaitForFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
+end
+
+function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
 end
 
 function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore)
     ccall((:vkCreateSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
 end
 
+function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
+end
+
 function vkDestroySemaphore(device, semaphore, pAllocator)
     ccall((:vkDestroySemaphore, libvulkan), Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
+end
+
+function vkDestroySemaphore(device, semaphore, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
 end
 
 function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent)
     ccall((:vkCreateEvent, libvulkan), VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
 end
 
+function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
+end
+
 function vkDestroyEvent(device, event, pAllocator)
     ccall((:vkDestroyEvent, libvulkan), Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
+end
+
+function vkDestroyEvent(device, event, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
 end
 
 function vkGetEventStatus(device, event)
     ccall((:vkGetEventStatus, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkGetEventStatus(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkSetEvent(device, event)
     ccall((:vkSetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
+end
+
+function vkSetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
 end
 
 function vkResetEvent(device, event)
     ccall((:vkResetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkResetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool)
     ccall((:vkCreateQueryPool, libvulkan), VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
+end
+
+function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
 end
 
 function vkDestroyQueryPool(device, queryPool, pAllocator)
     ccall((:vkDestroyQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
 end
 
+function vkDestroyQueryPool(device, queryPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
+end
+
 function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
     ccall((:vkGetQueryPoolResults, libvulkan), VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
+end
+
+function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
 end
 
 function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer)
     ccall((:vkCreateBuffer, libvulkan), VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
 end
 
+function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
+end
+
 function vkDestroyBuffer(device, buffer, pAllocator)
     ccall((:vkDestroyBuffer, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
+end
+
+function vkDestroyBuffer(device, buffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
 end
 
 function vkCreateBufferView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateBufferView, libvulkan), VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
 end
 
+function vkCreateBufferView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
+end
+
 function vkDestroyBufferView(device, bufferView, pAllocator)
     ccall((:vkDestroyBufferView, libvulkan), Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
+end
+
+function vkDestroyBufferView(device, bufferView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
 end
 
 function vkCreateImage(device, pCreateInfo, pAllocator, pImage)
     ccall((:vkCreateImage, libvulkan), VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
 end
 
+function vkCreateImage(device, pCreateInfo, pAllocator, pImage, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
+end
+
 function vkDestroyImage(device, image, pAllocator)
     ccall((:vkDestroyImage, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
+end
+
+function vkDestroyImage(device, image, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
 end
 
 function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout)
     ccall((:vkGetImageSubresourceLayout, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
 end
 
+function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
+end
+
 function vkCreateImageView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateImageView, libvulkan), VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
+end
+
+function vkCreateImageView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
 end
 
 function vkDestroyImageView(device, imageView, pAllocator)
     ccall((:vkDestroyImageView, libvulkan), Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
 end
 
+function vkDestroyImageView(device, imageView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
+end
+
 function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule)
     ccall((:vkCreateShaderModule, libvulkan), VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
+end
+
+function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
 end
 
 function vkDestroyShaderModule(device, shaderModule, pAllocator)
     ccall((:vkDestroyShaderModule, libvulkan), Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
 end
 
+function vkDestroyShaderModule(device, shaderModule, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
+end
+
 function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache)
     ccall((:vkCreatePipelineCache, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
+end
+
+function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
 end
 
 function vkDestroyPipelineCache(device, pipelineCache, pAllocator)
     ccall((:vkDestroyPipelineCache, libvulkan), Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
 end
 
+function vkDestroyPipelineCache(device, pipelineCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
+end
+
 function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData)
     ccall((:vkGetPipelineCacheData, libvulkan), VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
+end
+
+function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
 end
 
 function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergePipelineCaches, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateGraphicsPipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateComputePipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
+function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
 function vkDestroyPipeline(device, pipeline, pAllocator)
     ccall((:vkDestroyPipeline, libvulkan), Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
+end
+
+function vkDestroyPipeline(device, pipeline, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
 end
 
 function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout)
     ccall((:vkCreatePipelineLayout, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
 end
 
+function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
+end
+
 function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator)
     ccall((:vkDestroyPipelineLayout, libvulkan), Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
+end
+
+function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
 end
 
 function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler)
     ccall((:vkCreateSampler, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
 end
 
+function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
+end
+
 function vkDestroySampler(device, sampler, pAllocator)
     ccall((:vkDestroySampler, libvulkan), Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
+end
+
+function vkDestroySampler(device, sampler, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
 end
 
 function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout)
     ccall((:vkCreateDescriptorSetLayout, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
 end
 
+function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
+end
+
 function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator)
     ccall((:vkDestroyDescriptorSetLayout, libvulkan), Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
+end
+
+function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
 end
 
 function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool)
     ccall((:vkCreateDescriptorPool, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
 end
 
+function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
+end
+
 function vkDestroyDescriptorPool(device, descriptorPool, pAllocator)
     ccall((:vkDestroyDescriptorPool, libvulkan), Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
+end
+
+function vkDestroyDescriptorPool(device, descriptorPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
 end
 
 function vkResetDescriptorPool(device, descriptorPool, flags)
     ccall((:vkResetDescriptorPool, libvulkan), VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
 end
 
+function vkResetDescriptorPool(device, descriptorPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
+end
+
 function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets)
     ccall((:vkAllocateDescriptorSets, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
+end
+
+function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
 end
 
 function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets)
     ccall((:vkFreeDescriptorSets, libvulkan), VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
 end
 
+function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
+end
+
 function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
     ccall((:vkUpdateDescriptorSets, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
+end
+
+function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
 end
 
 function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer)
     ccall((:vkCreateFramebuffer, libvulkan), VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
 end
 
+function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
+end
+
 function vkDestroyFramebuffer(device, framebuffer, pAllocator)
     ccall((:vkDestroyFramebuffer, libvulkan), Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
+end
+
+function vkDestroyFramebuffer(device, framebuffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
 end
 
 function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkDestroyRenderPass(device, renderPass, pAllocator)
     ccall((:vkDestroyRenderPass, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
+end
+
+function vkDestroyRenderPass(device, renderPass, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
 end
 
 function vkGetRenderAreaGranularity(device, renderPass, pGranularity)
     ccall((:vkGetRenderAreaGranularity, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
 end
 
+function vkGetRenderAreaGranularity(device, renderPass, pGranularity, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
+end
+
 function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool)
     ccall((:vkCreateCommandPool, libvulkan), VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
+end
+
+function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
 end
 
 function vkDestroyCommandPool(device, commandPool, pAllocator)
     ccall((:vkDestroyCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
 end
 
+function vkDestroyCommandPool(device, commandPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
+end
+
 function vkResetCommandPool(device, commandPool, flags)
     ccall((:vkResetCommandPool, libvulkan), VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
+end
+
+function vkResetCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
 end
 
 function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers)
     ccall((:vkAllocateCommandBuffers, libvulkan), VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
 end
 
+function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
+end
+
 function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers)
     ccall((:vkFreeCommandBuffers, libvulkan), Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
+end
+
+function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
 end
 
 function vkBeginCommandBuffer(commandBuffer, pBeginInfo)
     ccall((:vkBeginCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
 end
 
+function vkBeginCommandBuffer(commandBuffer, pBeginInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
+end
+
 function vkEndCommandBuffer(commandBuffer)
     ccall((:vkEndCommandBuffer, libvulkan), VkResult, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkEndCommandBuffer(commandBuffer, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer,), commandBuffer)
 end
 
 function vkResetCommandBuffer(commandBuffer, flags)
     ccall((:vkResetCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
 end
 
+function vkResetCommandBuffer(commandBuffer, flags, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
+end
+
 function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline)
     ccall((:vkCmdBindPipeline, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
+end
+
+function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
 end
 
 function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports)
     ccall((:vkCmdSetViewport, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
 end
 
+function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
+end
+
 function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors)
     ccall((:vkCmdSetScissor, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
+end
+
+function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
 end
 
 function vkCmdSetLineWidth(commandBuffer, lineWidth)
     ccall((:vkCmdSetLineWidth, libvulkan), Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
 end
 
+function vkCmdSetLineWidth(commandBuffer, lineWidth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
+end
+
 function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
     ccall((:vkCmdSetDepthBias, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
+end
+
+function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
 end
 
 function vkCmdSetBlendConstants(commandBuffer, blendConstants)
     ccall((:vkCmdSetBlendConstants, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
 end
 
+function vkCmdSetBlendConstants(commandBuffer, blendConstants, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
+end
+
 function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds)
     ccall((:vkCmdSetDepthBounds, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
+end
+
+function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
 end
 
 function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask)
     ccall((:vkCmdSetStencilCompareMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
 end
 
+function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
+end
+
 function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask)
     ccall((:vkCmdSetStencilWriteMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
+end
+
+function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
 end
 
 function vkCmdSetStencilReference(commandBuffer, faceMask, reference)
     ccall((:vkCmdSetStencilReference, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
 end
 
+function vkCmdSetStencilReference(commandBuffer, faceMask, reference, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
+end
+
 function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
     ccall((:vkCmdBindDescriptorSets, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
+end
+
+function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
 end
 
 function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType)
     ccall((:vkCmdBindIndexBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
 end
 
+function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
+end
+
 function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
     ccall((:vkCmdBindVertexBuffers, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
+end
+
+function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
 end
 
 function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
     ccall((:vkCmdDraw, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
 end
 
+function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
+end
+
 function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
     ccall((:vkCmdDrawIndexed, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
+end
+
+function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
 end
 
 function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndexedIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
 function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatch, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
 end
 
+function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
+end
+
 function vkCmdDispatchIndirect(commandBuffer, buffer, offset)
     ccall((:vkCmdDispatchIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
+end
+
+function vkCmdDispatchIndirect(commandBuffer, buffer, offset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
 end
 
 function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
     ccall((:vkCmdBlitImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
 end
 
+function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
+end
+
 function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyBufferToImage, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyImageToBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData)
     ccall((:vkCmdUpdateBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
+end
+
+function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
 end
 
 function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data)
     ccall((:vkCmdFillBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
 end
 
+function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
+end
+
 function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
     ccall((:vkCmdClearColorImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
+end
+
+function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
 end
 
 function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
     ccall((:vkCmdClearDepthStencilImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
 end
 
+function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
+end
+
 function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
     ccall((:vkCmdClearAttachments, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
+end
+
+function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
 end
 
 function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdResolveImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
+function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
 function vkCmdSetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdSetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
+function vkCmdSetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
 function vkCmdResetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
+function vkCmdResetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
 function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdWaitEvents, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
+function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
 function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdPipelineBarrier, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
+function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
 function vkCmdBeginQuery(commandBuffer, queryPool, query, flags)
     ccall((:vkCmdBeginQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
+end
+
+function vkCmdBeginQuery(commandBuffer, queryPool, query, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
 end
 
 function vkCmdEndQuery(commandBuffer, queryPool, query)
     ccall((:vkCmdEndQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
 end
 
+function vkCmdEndQuery(commandBuffer, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
+end
+
 function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount)
     ccall((:vkCmdResetQueryPool, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
+end
+
+function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
 end
 
 function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query)
     ccall((:vkCmdWriteTimestamp, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
+end
+
 function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
     ccall((:vkCmdCopyQueryPoolResults, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
+end
+
+function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
 end
 
 function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues)
     ccall((:vkCmdPushConstants, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
 end
 
+function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
+end
+
 function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents)
     ccall((:vkCmdBeginRenderPass, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
+end
+
+function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
 end
 
 function vkCmdNextSubpass(commandBuffer, contents)
     ccall((:vkCmdNextSubpass, libvulkan), Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
 end
 
+function vkCmdNextSubpass(commandBuffer, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
+end
+
 function vkCmdEndRenderPass(commandBuffer)
     ccall((:vkCmdEndRenderPass, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndRenderPass(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers)
     ccall((:vkCmdExecuteCommands, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
+end
+
+function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
 end
 
 const VkSamplerYcbcrConversion = UInt64
@@ -4993,112 +5541,224 @@ function vkEnumerateInstanceVersion(pApiVersion)
     ccall((:vkEnumerateInstanceVersion, libvulkan), VkResult, (Ptr{UInt32},), pApiVersion)
 end
 
+function vkEnumerateInstanceVersion(pApiVersion, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32},), pApiVersion)
+end
+
 function vkBindBufferMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindBufferMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 function vkBindImageMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindImageMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
     ccall((:vkGetDeviceGroupPeerMemoryFeatures, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
+function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
 function vkCmdSetDeviceMask(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMask, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMask(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBase, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroups, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
+function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
 function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
 function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
+function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
 function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
 function vkTrimCommandPool(device, commandPool, flags)
     ccall((:vkTrimCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
+function vkTrimCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
 function vkGetDeviceQueue2(device, pQueueInfo, pQueue)
     ccall((:vkGetDeviceQueue2, libvulkan), Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
 end
 
+function vkGetDeviceQueue2(device, pQueueInfo, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
+end
+
 function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion)
     ccall((:vkCreateSamplerYcbcrConversion, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
+function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
 function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversion, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
+function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
 function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
     ccall((:vkCreateDescriptorUpdateTemplate, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
+function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
 function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
+function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
 function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFenceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphoreProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
+function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
 function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupport, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
+function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
 @cenum VkDriverId::UInt32 begin
@@ -5798,52 +6458,104 @@ function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, coun
     ccall((:vkCmdDrawIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 function vkResetQueryPool(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
+function vkResetQueryPool(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
 function vkGetSemaphoreCounterValue(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValue, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
+function vkGetSemaphoreCounterValue(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
 function vkWaitSemaphores(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphores, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphores(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphore(device, pSignalInfo)
     ccall((:vkSignalSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphore(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 function vkGetBufferDeviceAddress(device, pInfo)
     ccall((:vkGetBufferDeviceAddress, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddress(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkSurfaceKHR = UInt64
@@ -5942,20 +6654,40 @@ function vkDestroySurfaceKHR(instance, surface, pAllocator)
     ccall((:vkDestroySurfaceKHR, libvulkan), Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
 end
 
+function vkDestroySurfaceKHR(instance, surface, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
+end
+
 function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported)
     ccall((:vkGetPhysicalDeviceSurfaceSupportKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
+end
+
+function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
 end
 
 function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormatsKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
 end
 
+function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
+end
+
 function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes)
     ccall((:vkGetPhysicalDeviceSurfacePresentModesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
+end
+
+function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
 end
 
 const VkSwapchainKHR = UInt64
@@ -6086,36 +6818,72 @@ function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain)
     ccall((:vkCreateSwapchainKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
 end
 
+function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
+end
+
 function vkDestroySwapchainKHR(device, swapchain, pAllocator)
     ccall((:vkDestroySwapchainKHR, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
+end
+
+function vkDestroySwapchainKHR(device, swapchain, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
 end
 
 function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages)
     ccall((:vkGetSwapchainImagesKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
 end
 
+function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
+end
+
 function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex)
     ccall((:vkAcquireNextImageKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
+end
+
+function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
 end
 
 function vkQueuePresentKHR(queue, pPresentInfo)
     ccall((:vkQueuePresentKHR, libvulkan), VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
 end
 
+function vkQueuePresentKHR(queue, pPresentInfo, fptr)
+    ccall(fptr, VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
+end
+
 function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities)
     ccall((:vkGetDeviceGroupPresentCapabilitiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
+end
+
+function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
 end
 
 function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes)
     ccall((:vkGetDeviceGroupSurfacePresentModesKHR, libvulkan), VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
 end
 
+function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
+end
+
 function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects)
     ccall((:vkGetPhysicalDevicePresentRectanglesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
 end
 
+function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
+end
+
 function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex)
     ccall((:vkAcquireNextImage2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
+end
+
+function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
 end
 
 const VkDisplayKHR = UInt64
@@ -6218,28 +6986,56 @@ function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount,
     ccall((:vkGetPhysicalDeviceDisplayPropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlanePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays)
     ccall((:vkGetDisplayPlaneSupportedDisplaysKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
 end
 
+function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
+end
+
 function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
+function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
 function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode)
     ccall((:vkCreateDisplayModeKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
 end
 
+function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
+end
+
 function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
 end
 
+function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
+end
+
 function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateDisplayPlaneSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
+function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
 struct VkDisplayPresentInfoKHR
@@ -6255,6 +7051,10 @@ const PFN_vkCreateSharedSwapchainsKHR = Ptr{Cvoid}
 
 function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
     ccall((:vkCreateSharedSwapchainsKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
+end
+
+function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
 end
 
 const VkRenderPassMultiviewCreateInfoKHR = VkRenderPassMultiviewCreateInfo
@@ -6306,28 +7106,56 @@ function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
 const VkPeerMemoryFeatureFlagsKHR = VkPeerMemoryFeatureFlags
@@ -6365,12 +7193,24 @@ function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceInd
     ccall((:vkGetDeviceGroupPeerMemoryFeaturesKHR, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
+function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
 function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMaskKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBaseKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 const VkCommandPoolTrimFlagsKHR = VkCommandPoolTrimFlags
@@ -6382,6 +7222,10 @@ function vkTrimCommandPoolKHR(device, commandPool, flags)
     ccall((:vkTrimCommandPoolKHR, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
+function vkTrimCommandPoolKHR(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
 const VkPhysicalDeviceGroupPropertiesKHR = VkPhysicalDeviceGroupProperties
 
 const VkDeviceGroupDeviceCreateInfoKHR = VkDeviceGroupDeviceCreateInfo
@@ -6391,6 +7235,10 @@ const PFN_vkEnumeratePhysicalDeviceGroupsKHR = Ptr{Cvoid}
 
 function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroupsKHR, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
+function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
 const VkExternalMemoryHandleTypeFlagsKHR = VkExternalMemoryHandleTypeFlags
@@ -6418,6 +7266,10 @@ const PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferPropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
+function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
 const VkExternalMemoryImageCreateInfoKHR = VkExternalMemoryImageCreateInfo
@@ -6456,8 +7308,16 @@ function vkGetMemoryFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetMemoryFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
+function vkGetMemoryFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
 function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties)
     ccall((:vkGetMemoryFdPropertiesKHR, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
+end
+
+function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
 end
 
 const VkExternalSemaphoreHandleTypeFlagsKHR = VkExternalSemaphoreHandleTypeFlags
@@ -6477,6 +7337,10 @@ const PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphorePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
+function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
 const VkSemaphoreImportFlagsKHR = VkSemaphoreImportFlags
@@ -6511,8 +7375,16 @@ function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo)
     ccall((:vkImportSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
 end
 
+function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
+end
+
 function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 struct VkPhysicalDevicePushDescriptorPropertiesKHR
@@ -6531,8 +7403,16 @@ function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set
     ccall((:vkCmdPushDescriptorSetKHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
 end
 
+function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
+end
+
 function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData)
     ccall((:vkCmdPushDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
+end
+
+function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
 end
 
 const VkPhysicalDeviceShaderFloat16Int8FeaturesKHR = VkPhysicalDeviceShaderFloat16Int8Features
@@ -6582,12 +7462,24 @@ function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pD
     ccall((:vkCreateDescriptorUpdateTemplateKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
+function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
 function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 const VkPhysicalDeviceImagelessFramebufferFeaturesKHR = VkPhysicalDeviceImagelessFramebufferFeatures
@@ -6628,16 +7520,32 @@ function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 struct VkSharedPresentSurfaceCapabilitiesKHR
@@ -6651,6 +7559,10 @@ const PFN_vkGetSwapchainStatusKHR = Ptr{Cvoid}
 
 function vkGetSwapchainStatusKHR(device, swapchain)
     ccall((:vkGetSwapchainStatusKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
+end
+
+function vkGetSwapchainStatusKHR(device, swapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
 end
 
 const VkExternalFenceHandleTypeFlagsKHR = VkExternalFenceHandleTypeFlags
@@ -6670,6 +7582,10 @@ const PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFencePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 const VkFenceImportFlagsKHR = VkFenceImportFlags
@@ -6704,8 +7620,16 @@ function vkImportFenceFdKHR(device, pImportFenceFdInfo)
     ccall((:vkImportFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
 end
 
+function vkImportFenceFdKHR(device, pImportFenceFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
+end
+
 function vkGetFenceFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetFenceFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 @cenum VkPerformanceCounterUnitKHR::UInt32 begin
@@ -6852,16 +7776,32 @@ function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physica
     ccall((:vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
 end
 
+function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
+end
+
 function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
     ccall((:vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
+end
+
+function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
 end
 
 function vkAcquireProfilingLockKHR(device, pInfo)
     ccall((:vkAcquireProfilingLockKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
 end
 
+function vkAcquireProfilingLockKHR(device, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
+end
+
 function vkReleaseProfilingLockKHR(device)
     ccall((:vkReleaseProfilingLockKHR, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkReleaseProfilingLockKHR(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 const VkPointClippingBehaviorKHR = VkPointClippingBehavior
@@ -6906,8 +7846,16 @@ function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormats2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
+end
+
+function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
 end
 
 const VkPhysicalDeviceVariablePointerFeaturesKHR = VkPhysicalDeviceVariablePointersFeatures
@@ -6961,16 +7909,32 @@ function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount
     ccall((:vkGetPhysicalDeviceDisplayProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlaneProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModeProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
+function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
 function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
+end
+
+function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
 end
 
 const VkMemoryDedicatedRequirementsKHR = VkMemoryDedicatedRequirements
@@ -7000,12 +7964,24 @@ function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 const VkImageFormatListCreateInfoKHR = VkImageFormatListCreateInfo
@@ -7040,8 +8016,16 @@ function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcb
     ccall((:vkCreateSamplerYcbcrConversionKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
+function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
 function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversionKHR, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
+function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
 const VkBindBufferMemoryInfoKHR = VkBindBufferMemoryInfo
@@ -7058,8 +8042,16 @@ function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 const VkPhysicalDeviceMaintenance3PropertiesKHR = VkPhysicalDeviceMaintenance3Properties
@@ -7073,6 +8065,10 @@ function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupportKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
+function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountKHR
 const PFN_vkCmdDrawIndirectCountKHR = Ptr{Cvoid}
 
@@ -7083,8 +8079,16 @@ function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 const VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR = VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures
@@ -7149,12 +8153,24 @@ function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValueKHR, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
+function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
 function vkWaitSemaphoresKHR(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphoresKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphoresKHR(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphoreKHR(device, pSignalInfo)
     ccall((:vkSignalSemaphoreKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphoreKHR(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR = VkPhysicalDeviceVulkanMemoryModelFeatures
@@ -7235,8 +8251,16 @@ function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentSha
     ccall((:vkGetPhysicalDeviceFragmentShadingRatesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
 end
 
+function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
+end
+
 function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps)
     ccall((:vkCmdSetFragmentShadingRateKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
+end
+
+function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
 end
 
 struct VkSurfaceProtectedCapabilitiesKHR
@@ -7276,12 +8300,24 @@ function vkGetBufferDeviceAddressKHR(device, pInfo)
     ccall((:vkGetBufferDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkDeferredOperationKHR = UInt64
@@ -7305,20 +8341,40 @@ function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation)
     ccall((:vkCreateDeferredOperationKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
 end
 
+function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
+end
+
 function vkDestroyDeferredOperationKHR(device, operation, pAllocator)
     ccall((:vkDestroyDeferredOperationKHR, libvulkan), Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
+end
+
+function vkDestroyDeferredOperationKHR(device, operation, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
 end
 
 function vkGetDeferredOperationMaxConcurrencyKHR(device, operation)
     ccall((:vkGetDeferredOperationMaxConcurrencyKHR, libvulkan), UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationMaxConcurrencyKHR(device, operation, fptr)
+    ccall(fptr, UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkGetDeferredOperationResultKHR(device, operation)
     ccall((:vkGetDeferredOperationResultKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationResultKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkDeferredOperationJoinKHR(device, operation)
     ccall((:vkDeferredOperationJoinKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
+function vkDeferredOperationJoinKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
 @cenum VkPipelineExecutableStatisticFormatKHR::UInt32 begin
@@ -7412,12 +8468,24 @@ function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutable
     ccall((:vkGetPipelineExecutablePropertiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
 end
 
+function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutableCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
+end
+
 function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics)
     ccall((:vkGetPipelineExecutableStatisticsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
 end
 
+function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
+end
+
 function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
     ccall((:vkGetPipelineExecutableInternalRepresentationsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
+end
+
+function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
 end
 
 struct VkPipelineLibraryCreateInfoKHR
@@ -7569,32 +8637,64 @@ function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo)
     ccall((:vkCmdSetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
 end
 
+function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
+end
+
 function vkCmdResetEvent2KHR(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
+end
+
+function vkCmdResetEvent2KHR(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
 end
 
 function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos)
     ccall((:vkCmdWaitEvents2KHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
 end
 
+function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
+end
+
 function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo)
     ccall((:vkCmdPipelineBarrier2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
+end
+
+function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
 end
 
 function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query)
     ccall((:vkCmdWriteTimestamp2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
+end
+
 function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit2KHR, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
+function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
 function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarker2AMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
 end
 
+function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
+end
+
 function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointData2NV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR
@@ -7745,24 +8845,48 @@ function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo)
     ccall((:vkCmdCopyBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
 end
 
+function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
+end
+
 function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo)
     ccall((:vkCmdCopyImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
+end
+
+function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
 end
 
 function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo)
     ccall((:vkCmdCopyBufferToImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
 end
 
+function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
+end
+
 function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo)
     ccall((:vkCmdCopyImageToBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
+end
+
+function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
 end
 
 function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo)
     ccall((:vkCmdBlitImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
 end
 
+function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
+end
+
 function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo)
     ccall((:vkCmdResolveImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
+end
+
+function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
 end
 
 const VkDebugReportCallbackEXT = UInt64
@@ -7846,12 +8970,24 @@ function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCall
     ccall((:vkCreateDebugReportCallbackEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
 end
 
+function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
+end
+
 function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator)
     ccall((:vkDestroyDebugReportCallbackEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
 end
 
+function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
+end
+
 function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
     ccall((:vkDebugReportMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
+end
+
+function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
 end
 
 @cenum VkRasterizationOrderAMD::UInt32 begin
@@ -7910,20 +9046,40 @@ function vkDebugMarkerSetObjectTagEXT(device, pTagInfo)
     ccall((:vkDebugMarkerSetObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
 end
 
+function vkDebugMarkerSetObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
+end
+
 function vkDebugMarkerSetObjectNameEXT(device, pNameInfo)
     ccall((:vkDebugMarkerSetObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
+end
+
+function vkDebugMarkerSetObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
 end
 
 function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerBeginEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdDebugMarkerEndEXT(commandBuffer)
     ccall((:vkCmdDebugMarkerEndEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdDebugMarkerEndEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerInsertEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
 struct VkDedicatedAllocationImageCreateInfoNV
@@ -7998,24 +9154,48 @@ function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindi
     ccall((:vkCmdBindTransformFeedbackBuffersEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
 end
 
+function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
+end
+
 function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdBeginTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
+function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
 function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdEndTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
+function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
 function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index)
     ccall((:vkCmdBeginQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
+end
+
+function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
 end
 
 function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index)
     ccall((:vkCmdEndQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
 end
 
+function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
+end
+
 function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
     ccall((:vkCmdDrawIndirectByteCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
+end
+
+function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
 end
 
 struct VkImageViewHandleInfoNVX
@@ -8043,8 +9223,16 @@ function vkGetImageViewHandleNVX(device, pInfo)
     ccall((:vkGetImageViewHandleNVX, libvulkan), UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
 end
 
+function vkGetImageViewHandleNVX(device, pInfo, fptr)
+    ccall(fptr, UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
+end
+
 function vkGetImageViewAddressNVX(device, imageView, pProperties)
     ccall((:vkGetImageViewAddressNVX, libvulkan), VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
+end
+
+function vkGetImageViewAddressNVX(device, imageView, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
 end
 
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountAMD
@@ -8057,8 +9245,16 @@ function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkTextureLODGatherFormatPropertiesAMD
@@ -8099,6 +9295,10 @@ function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, 
     ccall((:vkGetShaderInfoAMD, libvulkan), VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
 end
 
+function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
+end
+
 struct VkPhysicalDeviceCornerSampledImageFeaturesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8136,6 +9336,10 @@ const PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
     ccall((:vkGetPhysicalDeviceExternalImageFormatPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
 end
 
 struct VkExternalMemoryImageCreateInfoNV
@@ -8219,8 +9423,16 @@ function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingB
     ccall((:vkCmdBeginConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
 end
 
+function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
+end
+
 function vkCmdEndConditionalRenderingEXT(commandBuffer)
     ccall((:vkCmdEndConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkCmdEndConditionalRenderingEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
 struct VkViewportWScalingNV
@@ -8243,11 +9455,19 @@ function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount,
     ccall((:vkCmdSetViewportWScalingNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
 end
 
+function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
+end
+
 # typedef VkResult ( VKAPI_PTR * PFN_vkReleaseDisplayEXT
 const PFN_vkReleaseDisplayEXT = Ptr{Cvoid}
 
 function vkReleaseDisplayEXT(physicalDevice, display)
     ccall((:vkReleaseDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
+function vkReleaseDisplayEXT(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
 @cenum VkSurfaceCounterFlagBitsEXT::UInt32 begin
@@ -8279,6 +9499,10 @@ const PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2EXT, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
+function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
 @cenum VkDisplayPowerStateEXT::UInt32 begin
@@ -8338,16 +9562,32 @@ function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo)
     ccall((:vkDisplayPowerControlEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
 end
 
+function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
+end
+
 function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDeviceEventEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
+end
+
+function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
 end
 
 function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDisplayEventEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
 end
 
+function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
+end
+
 function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue)
     ccall((:vkGetSwapchainCounterEXT, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
+end
+
+function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
 end
 
 struct VkRefreshCycleDurationGOOGLE
@@ -8384,8 +9624,16 @@ function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProper
     ccall((:vkGetRefreshCycleDurationGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
 end
 
+function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
+end
+
 function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings)
     ccall((:vkGetPastPresentationTimingGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
+end
+
+function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
 end
 
 struct VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX
@@ -8451,6 +9699,10 @@ const PFN_vkCmdSetDiscardRectangleEXT = Ptr{Cvoid}
 
 function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
     ccall((:vkCmdSetDiscardRectangleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
+end
+
+function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
 end
 
 @cenum VkConservativeRasterizationModeEXT::UInt32 begin
@@ -8522,6 +9774,10 @@ const PFN_vkSetHdrMetadataEXT = Ptr{Cvoid}
 
 function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata)
     ccall((:vkSetHdrMetadataEXT, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
+end
+
+function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
 end
 
 const VkDebugUtilsMessengerEXT = UInt64
@@ -8639,44 +9895,88 @@ function vkSetDebugUtilsObjectNameEXT(device, pNameInfo)
     ccall((:vkSetDebugUtilsObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
 end
 
+function vkSetDebugUtilsObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
+end
+
 function vkSetDebugUtilsObjectTagEXT(device, pTagInfo)
     ccall((:vkSetDebugUtilsObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
+end
+
+function vkSetDebugUtilsObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
 end
 
 function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkQueueEndDebugUtilsLabelEXT(queue)
     ccall((:vkQueueEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue,), queue)
+end
+
+function vkQueueEndDebugUtilsLabelEXT(queue, fptr)
+    ccall(fptr, Cvoid, (VkQueue,), queue)
 end
 
 function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCmdEndDebugUtilsLabelEXT(commandBuffer)
     ccall((:vkCmdEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndDebugUtilsLabelEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger)
     ccall((:vkCreateDebugUtilsMessengerEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
 end
 
+function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
+end
+
 function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator)
     ccall((:vkDestroyDebugUtilsMessengerEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
 end
 
+function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
+end
+
 function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData)
     ccall((:vkSubmitDebugUtilsMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
+end
+
+function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
 end
 
 const VkSamplerReductionModeEXT = VkSamplerReductionMode
@@ -8781,8 +10081,16 @@ function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo)
     ccall((:vkCmdSetSampleLocationsEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
 end
 
+function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
+end
+
 function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties)
     ccall((:vkGetPhysicalDeviceMultisamplePropertiesEXT, libvulkan), Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
+end
+
+function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
 end
 
 @cenum VkBlendOverlapEXT::UInt32 begin
@@ -8910,6 +10218,10 @@ function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties)
     ccall((:vkGetImageDrmFormatModifierPropertiesEXT, libvulkan), VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
 end
 
+function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
+end
+
 const VkValidationCacheEXT = UInt64
 
 @cenum VkValidationCacheHeaderVersionEXT::UInt32 begin
@@ -8949,16 +10261,32 @@ function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidation
     ccall((:vkCreateValidationCacheEXT, libvulkan), VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
 end
 
+function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
+end
+
 function vkDestroyValidationCacheEXT(device, validationCache, pAllocator)
     ccall((:vkDestroyValidationCacheEXT, libvulkan), Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
+end
+
+function vkDestroyValidationCacheEXT(device, validationCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
 end
 
 function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergeValidationCachesEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData)
     ccall((:vkGetValidationCacheDataEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
+end
+
+function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
 end
 
 const VkDescriptorBindingFlagBitsEXT = VkDescriptorBindingFlagBits
@@ -9061,12 +10389,24 @@ function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout)
     ccall((:vkCmdBindShadingRateImageNV, libvulkan), Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
 end
 
+function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
+end
+
 function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
     ccall((:vkCmdSetViewportShadingRatePaletteNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
 end
 
+function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
+end
+
 function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
     ccall((:vkCmdSetCoarseSampleOrderNV, libvulkan), Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
+end
+
+function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
 end
 
 const VkAccelerationStructureNV = UInt64
@@ -9391,52 +10731,104 @@ function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccel
     ccall((:vkCreateAccelerationStructureNV, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureNV, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements)
     ccall((:vkGetAccelerationStructureMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
+end
+
 function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos)
     ccall((:vkBindAccelerationStructureMemoryNV, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
 end
 
 function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
     ccall((:vkCmdBuildAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
 end
 
+function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
+end
+
 function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode)
     ccall((:vkCmdCopyAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
+end
+
+function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
 end
 
 function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
     ccall((:vkCmdTraceRaysNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
 end
 
+function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesNV, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
+function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
 function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData)
     ccall((:vkGetAccelerationStructureHandleNV, libvulkan), VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
 end
 
+function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
+function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
 function vkCompileDeferredNV(device, pipeline, shader)
     ccall((:vkCompileDeferredNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
+end
+
+function vkCompileDeferredNV(device, pipeline, shader, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
 end
 
 struct VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV
@@ -9504,11 +10896,19 @@ function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, p
     ccall((:vkGetMemoryHostPointerPropertiesEXT, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
 end
 
+function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, pMemoryHostPointerProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdWriteBufferMarkerAMD
 const PFN_vkCmdWriteBufferMarkerAMD = Ptr{Cvoid}
 
 function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarkerAMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
+end
+
+function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
 end
 
 @cenum VkPipelineCompilerControlFlagBitsAMD::UInt32 begin
@@ -9547,8 +10947,16 @@ function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDom
     ccall((:vkGetPhysicalDeviceCalibrateableTimeDomainsEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
 end
 
+function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDomainCount, pTimeDomains, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
+end
+
 function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
     ccall((:vkGetCalibratedTimestampsEXT, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
+end
+
+function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
 end
 
 struct VkPhysicalDeviceShaderCorePropertiesAMD
@@ -9680,12 +11088,24 @@ function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask)
     ccall((:vkCmdDrawMeshTasksNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
 end
 
+function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
+end
+
 function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectCountNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV
@@ -9720,6 +11140,10 @@ function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclus
     ccall((:vkCmdSetExclusiveScissorNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
 end
 
+function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
+end
+
 struct VkQueueFamilyCheckpointPropertiesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -9743,8 +11167,16 @@ function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker)
     ccall((:vkCmdSetCheckpointNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
 end
 
+function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
+end
+
 function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointDataNV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL
@@ -9886,36 +11318,72 @@ function vkInitializePerformanceApiINTEL(device, pInitializeInfo)
     ccall((:vkInitializePerformanceApiINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
 end
 
+function vkInitializePerformanceApiINTEL(device, pInitializeInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
+end
+
 function vkUninitializePerformanceApiINTEL(device)
     ccall((:vkUninitializePerformanceApiINTEL, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkUninitializePerformanceApiINTEL(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceStreamMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
 function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo)
     ccall((:vkCmdSetPerformanceOverrideINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
 end
 
+function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
+end
+
 function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration)
     ccall((:vkAcquirePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
+end
+
+function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
 end
 
 function vkReleasePerformanceConfigurationINTEL(device, configuration)
     ccall((:vkReleasePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
 end
 
+function vkReleasePerformanceConfigurationINTEL(device, configuration, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
+end
+
 function vkQueueSetPerformanceConfigurationINTEL(queue, configuration)
     ccall((:vkQueueSetPerformanceConfigurationINTEL, libvulkan), VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
 end
 
+function vkQueueSetPerformanceConfigurationINTEL(queue, configuration, fptr)
+    ccall(fptr, VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
+end
+
 function vkGetPerformanceParameterINTEL(device, parameter, pValue)
     ccall((:vkGetPerformanceParameterINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
+end
+
+function vkGetPerformanceParameterINTEL(device, parameter, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
 end
 
 struct VkPhysicalDevicePCIBusInfoPropertiesEXT
@@ -9944,6 +11412,10 @@ const PFN_vkSetLocalDimmingAMD = Ptr{Cvoid}
 
 function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable)
     ccall((:vkSetLocalDimmingAMD, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
+end
+
+function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
 end
 
 struct VkPhysicalDeviceFragmentDensityMapFeaturesEXT
@@ -10068,6 +11540,10 @@ function vkGetBufferDeviceAddressEXT(device, pInfo)
     ccall((:vkGetBufferDeviceAddressEXT, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressEXT(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 @cenum VkToolPurposeFlagBitsEXT::UInt32 begin
     VK_TOOL_PURPOSE_VALIDATION_BIT_EXT = 1
     VK_TOOL_PURPOSE_PROFILING_BIT_EXT = 2
@@ -10096,6 +11572,10 @@ const PFN_vkGetPhysicalDeviceToolPropertiesEXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties)
     ccall((:vkGetPhysicalDeviceToolPropertiesEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
+end
+
+function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
 end
 
 const VkImageStencilUsageCreateInfoEXT = VkImageStencilUsageCreateInfo
@@ -10185,6 +11665,10 @@ function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPrope
     ccall((:vkGetPhysicalDeviceCooperativeMatrixPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
+end
+
 @cenum VkCoverageReductionModeNV::UInt32 begin
     VK_COVERAGE_REDUCTION_MODE_MERGE_NV = 0
     VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV = 1
@@ -10220,6 +11704,10 @@ const PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV = Pt
 
 function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations)
     ccall((:vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
+end
+
+function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
 end
 
 struct VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT
@@ -10277,6 +11765,10 @@ function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateHeadlessSurfaceEXT, libvulkan), VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 @cenum VkLineRasterizationModeEXT::UInt32 begin
     VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT = 0
     VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT = 1
@@ -10318,6 +11810,10 @@ function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePat
     ccall((:vkCmdSetLineStippleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
 end
 
+function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
+end
+
 struct VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10342,6 +11838,10 @@ const PFN_vkResetQueryPoolEXT = Ptr{Cvoid}
 
 function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPoolEXT, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
+function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
 struct VkPhysicalDeviceIndexTypeUint8FeaturesEXT
@@ -10396,48 +11896,96 @@ function vkCmdSetCullModeEXT(commandBuffer, cullMode)
     ccall((:vkCmdSetCullModeEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
 end
 
+function vkCmdSetCullModeEXT(commandBuffer, cullMode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
+end
+
 function vkCmdSetFrontFaceEXT(commandBuffer, frontFace)
     ccall((:vkCmdSetFrontFaceEXT, libvulkan), Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
+end
+
+function vkCmdSetFrontFaceEXT(commandBuffer, frontFace, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
 end
 
 function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology)
     ccall((:vkCmdSetPrimitiveTopologyEXT, libvulkan), Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
 end
 
+function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
+end
+
 function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports)
     ccall((:vkCmdSetViewportWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
+end
+
+function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
 end
 
 function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors)
     ccall((:vkCmdSetScissorWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
 end
 
+function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
+end
+
 function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
     ccall((:vkCmdBindVertexBuffers2EXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
+end
+
+function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
 end
 
 function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable)
     ccall((:vkCmdSetDepthTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
 end
 
+function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
+end
+
 function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable)
     ccall((:vkCmdSetDepthWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
+end
+
+function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
 end
 
 function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp)
     ccall((:vkCmdSetDepthCompareOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
 end
 
+function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
+end
+
 function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable)
     ccall((:vkCmdSetDepthBoundsTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
+end
+
+function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
 end
 
 function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable)
     ccall((:vkCmdSetStencilTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
 end
 
+function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
+end
+
 function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
     ccall((:vkCmdSetStencilOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
+end
+
+function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
 end
 
 struct VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT
@@ -10617,24 +12165,48 @@ function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequir
     ccall((:vkGetGeneratedCommandsMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo)
     ccall((:vkCmdPreprocessGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
+end
+
+function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
 end
 
 function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
     ccall((:vkCmdExecuteGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
 end
 
+function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
+end
+
 function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex)
     ccall((:vkCmdBindPipelineShaderGroupNV, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
+end
+
+function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
 end
 
 function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
     ccall((:vkCreateIndirectCommandsLayoutNV, libvulkan), VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
 end
 
+function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
+end
+
 function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator)
     ccall((:vkDestroyIndirectCommandsLayoutNV, libvulkan), Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
+end
+
+function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
 end
 
 struct VkPhysicalDeviceInheritedViewportScissorFeaturesNV
@@ -10796,16 +12368,32 @@ function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDat
     ccall((:vkCreatePrivateDataSlotEXT, libvulkan), VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
 end
 
+function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDataSlot, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
+end
+
 function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator)
     ccall((:vkDestroyPrivateDataSlotEXT, libvulkan), Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
+end
+
+function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
 end
 
 function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data)
     ccall((:vkSetPrivateDataEXT, libvulkan), VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
 end
 
+function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
+end
+
 function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData)
     ccall((:vkGetPrivateDataEXT, libvulkan), Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
+end
+
+function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
 end
 
 struct VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT
@@ -10886,6 +12474,10 @@ function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerO
     ccall((:vkCmdSetFragmentShadingRateEnumNV, libvulkan), Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
 end
 
+function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
+end
+
 struct VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10936,8 +12528,16 @@ function vkAcquireWinrtDisplayNV(physicalDevice, display)
     ccall((:vkAcquireWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
+function vkAcquireWinrtDisplayNV(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
 function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay)
     ccall((:vkGetWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
+end
+
+function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
 end
 
 struct VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE
@@ -10989,6 +12589,10 @@ function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pV
     ccall((:vkCmdSetVertexInputEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
 end
 
+function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
+end
+
 struct VkPhysicalDeviceExtendedDynamicState2FeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -11016,20 +12620,40 @@ function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints)
     ccall((:vkCmdSetPatchControlPointsEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
 end
 
+function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
+end
+
 function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable)
     ccall((:vkCmdSetRasterizerDiscardEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
+end
+
+function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
 end
 
 function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable)
     ccall((:vkCmdSetDepthBiasEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
 end
 
+function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
+end
+
 function vkCmdSetLogicOpEXT(commandBuffer, logicOp)
     ccall((:vkCmdSetLogicOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
 end
 
+function vkCmdSetLogicOpEXT(commandBuffer, logicOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
+end
+
 function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable)
     ccall((:vkCmdSetPrimitiveRestartEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
+end
+
+function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
 end
 
 struct VkPhysicalDeviceColorWriteEnableFeaturesEXT
@@ -11050,6 +12674,10 @@ const PFN_vkCmdSetColorWriteEnableEXT = Ptr{Cvoid}
 
 function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables)
     ccall((:vkCmdSetColorWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
+end
+
+function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
 end
 
 const VkAccelerationStructureKHR = UInt64
@@ -11336,64 +12964,128 @@ function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAcce
     ccall((:vkCreateAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkCmdBuildAccelerationStructuresKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
     ccall((:vkCmdBuildAccelerationStructuresIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
+end
+
+function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
 end
 
 function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkBuildAccelerationStructuresKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureToMemoryKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
 end
 
+function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
+end
+
 function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyMemoryToAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
     ccall((:vkWriteAccelerationStructuresPropertiesKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
 end
 
+function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
+end
+
 function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureToMemoryKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
 end
 
+function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
+end
+
 function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyMemoryToAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo)
     ccall((:vkGetAccelerationStructureDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
 end
 
+function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
+function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
 function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility)
     ccall((:vkGetDeviceAccelerationStructureCompatibilityKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
 end
 
+function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
+end
+
 function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
     ccall((:vkGetAccelerationStructureBuildSizesKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
+end
+
+function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
 end
 
 @cenum VkShaderGroupShaderKHR::UInt32 begin
@@ -11496,24 +13188,48 @@ function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShader
     ccall((:vkCmdTraceRaysKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
 end
 
+function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingCaptureReplayShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
     ccall((:vkCmdTraceRaysIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
+end
+
+function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
 end
 
 function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader)
     ccall((:vkGetRayTracingShaderGroupStackSizeKHR, libvulkan), VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
 end
 
+function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader, fptr)
+    ccall(fptr, VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
+end
+
 function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize)
     ccall((:vkCmdSetRayTracingPipelineStackSizeKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
+end
+
+function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
 end
 
 struct VkPhysicalDeviceRayQueryFeaturesKHR
@@ -11542,8 +13258,16 @@ function vkCreateWin32SurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateWin32SurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkWin32SurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateWin32SurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkWin32SurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceWin32PresentationSupportKHR(physicalDevice, queueFamilyIndex)
     ccall((:vkGetPhysicalDeviceWin32PresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32), physicalDevice, queueFamilyIndex)
+end
+
+function vkGetPhysicalDeviceWin32PresentationSupportKHR(physicalDevice, queueFamilyIndex, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32), physicalDevice, queueFamilyIndex)
 end
 
 struct VkImportMemoryWin32HandleInfoKHR
@@ -11585,8 +13309,16 @@ function vkGetMemoryWin32HandleKHR(device, pGetWin32HandleInfo, pHandle)
     ccall((:vkGetMemoryWin32HandleKHR, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryGetWin32HandleInfoKHR}, Ptr{HANDLE}), device, pGetWin32HandleInfo, pHandle)
 end
 
+function vkGetMemoryWin32HandleKHR(device, pGetWin32HandleInfo, pHandle, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryGetWin32HandleInfoKHR}, Ptr{HANDLE}), device, pGetWin32HandleInfo, pHandle)
+end
+
 function vkGetMemoryWin32HandlePropertiesKHR(device, handleType, handle, pMemoryWin32HandleProperties)
     ccall((:vkGetMemoryWin32HandlePropertiesKHR, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, HANDLE, Ptr{VkMemoryWin32HandlePropertiesKHR}), device, handleType, handle, pMemoryWin32HandleProperties)
+end
+
+function vkGetMemoryWin32HandlePropertiesKHR(device, handleType, handle, pMemoryWin32HandleProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, HANDLE, Ptr{VkMemoryWin32HandlePropertiesKHR}), device, handleType, handle, pMemoryWin32HandleProperties)
 end
 
 struct VkWin32KeyedMutexAcquireReleaseInfoKHR
@@ -11645,8 +13377,16 @@ function vkImportSemaphoreWin32HandleKHR(device, pImportSemaphoreWin32HandleInfo
     ccall((:vkImportSemaphoreWin32HandleKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportSemaphoreWin32HandleInfoKHR}), device, pImportSemaphoreWin32HandleInfo)
 end
 
+function vkImportSemaphoreWin32HandleKHR(device, pImportSemaphoreWin32HandleInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportSemaphoreWin32HandleInfoKHR}), device, pImportSemaphoreWin32HandleInfo)
+end
+
 function vkGetSemaphoreWin32HandleKHR(device, pGetWin32HandleInfo, pHandle)
     ccall((:vkGetSemaphoreWin32HandleKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreGetWin32HandleInfoKHR}, Ptr{HANDLE}), device, pGetWin32HandleInfo, pHandle)
+end
+
+function vkGetSemaphoreWin32HandleKHR(device, pGetWin32HandleInfo, pHandle, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreGetWin32HandleInfoKHR}, Ptr{HANDLE}), device, pGetWin32HandleInfo, pHandle)
 end
 
 struct VkImportFenceWin32HandleInfoKHR
@@ -11684,8 +13424,16 @@ function vkImportFenceWin32HandleKHR(device, pImportFenceWin32HandleInfo)
     ccall((:vkImportFenceWin32HandleKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportFenceWin32HandleInfoKHR}), device, pImportFenceWin32HandleInfo)
 end
 
+function vkImportFenceWin32HandleKHR(device, pImportFenceWin32HandleInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportFenceWin32HandleInfoKHR}), device, pImportFenceWin32HandleInfo)
+end
+
 function vkGetFenceWin32HandleKHR(device, pGetWin32HandleInfo, pHandle)
     ccall((:vkGetFenceWin32HandleKHR, libvulkan), VkResult, (VkDevice, Ptr{VkFenceGetWin32HandleInfoKHR}, Ptr{HANDLE}), device, pGetWin32HandleInfo, pHandle)
+end
+
+function vkGetFenceWin32HandleKHR(device, pGetWin32HandleInfo, pHandle, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceGetWin32HandleInfoKHR}, Ptr{HANDLE}), device, pGetWin32HandleInfo, pHandle)
 end
 
 struct VkImportMemoryWin32HandleInfoNV
@@ -11707,6 +13455,10 @@ const PFN_vkGetMemoryWin32HandleNV = Ptr{Cvoid}
 
 function vkGetMemoryWin32HandleNV(device, memory, handleType, pHandle)
     ccall((:vkGetMemoryWin32HandleNV, libvulkan), VkResult, (VkDevice, VkDeviceMemory, VkExternalMemoryHandleTypeFlagsNV, Ptr{HANDLE}), device, memory, handleType, pHandle)
+end
+
+function vkGetMemoryWin32HandleNV(device, memory, handleType, pHandle, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeviceMemory, VkExternalMemoryHandleTypeFlagsNV, Ptr{HANDLE}), device, memory, handleType, pHandle)
 end
 
 struct VkWin32KeyedMutexAcquireReleaseInfoNV
@@ -11763,16 +13515,32 @@ function vkGetPhysicalDeviceSurfacePresentModes2EXT(physicalDevice, pSurfaceInfo
     ccall((:vkGetPhysicalDeviceSurfacePresentModes2EXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, pSurfaceInfo, pPresentModeCount, pPresentModes)
 end
 
+function vkGetPhysicalDeviceSurfacePresentModes2EXT(physicalDevice, pSurfaceInfo, pPresentModeCount, pPresentModes, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, pSurfaceInfo, pPresentModeCount, pPresentModes)
+end
+
 function vkAcquireFullScreenExclusiveModeEXT(device, swapchain)
     ccall((:vkAcquireFullScreenExclusiveModeEXT, libvulkan), VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
+end
+
+function vkAcquireFullScreenExclusiveModeEXT(device, swapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
 end
 
 function vkReleaseFullScreenExclusiveModeEXT(device, swapchain)
     ccall((:vkReleaseFullScreenExclusiveModeEXT, libvulkan), VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
 end
 
+function vkReleaseFullScreenExclusiveModeEXT(device, swapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
+end
+
 function vkGetDeviceGroupSurfacePresentModes2EXT(device, pSurfaceInfo, pModes)
     ccall((:vkGetDeviceGroupSurfacePresentModes2EXT, libvulkan), VkResult, (VkDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, pSurfaceInfo, pModes)
+end
+
+function vkGetDeviceGroupSurfacePresentModes2EXT(device, pSurfaceInfo, pModes, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, pSurfaceInfo, pModes)
 end
 
 const VULKAN_H_ = 1

--- a/lib/i686-w64-mingw32.jl
+++ b/lib/i686-w64-mingw32.jl
@@ -3182,24 +3182,16 @@ end
 
 const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
 
-function VkClearColorValue(float32::NTuple{4, Cfloat})
+function VkClearColorValue(val::__U_VkClearColorValue)
     ref = Ref{VkClearColorValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkClearColorValue(int32::NTuple{4, Int32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkClearColorValue(uint32::NTuple{4, UInt32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.uint32 = uint32
+    if val isa NTuple{4, Cfloat}
+        ptr.float32 = val
+    elseif val isa NTuple{4, Int32}
+        ptr.int32 = val
+    elseif val isa NTuple{4, UInt32}
+        ptr.uint32 = val
+    end
     ref[]
 end
 
@@ -3231,17 +3223,14 @@ end
 
 const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
 
-function VkClearValue(color::VkClearColorValue)
+function VkClearValue(val::__U_VkClearValue)
     ref = Ref{VkClearValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.color = color
-    ref[]
-end
-
-function VkClearValue(depthStencil::VkClearDepthStencilValue)
-    ref = Ref{VkClearValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.depthStencil = depthStencil
+    if val isa VkClearColorValue
+        ptr.color = val
+    elseif val isa VkClearDepthStencilValue
+        ptr.depthStencil = val
+    end
     ref[]
 end
 
@@ -7788,45 +7777,22 @@ end
 
 const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
 
-function VkPerformanceCounterResultKHR(int32::Int32)
+function VkPerformanceCounterResultKHR(val::__U_VkPerformanceCounterResultKHR)
     ref = Ref{VkPerformanceCounterResultKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(int64::Int64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int64 = int64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint32::UInt32)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint32 = uint32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint64::UInt64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint64 = uint64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float32::Cfloat)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float64::Cdouble)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float64 = float64
+    if val isa Int32
+        ptr.int32 = val
+    elseif val isa Int64
+        ptr.int64 = val
+    elseif val isa UInt32
+        ptr.uint32 = val
+    elseif val isa UInt64
+        ptr.uint64 = val
+    elseif val isa Cfloat
+        ptr.float32 = val
+    elseif val isa Cdouble
+        ptr.float64 = val
+    end
     ref[]
 end
 
@@ -8521,31 +8487,18 @@ end
 
 const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
 
-function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+function VkPipelineExecutableStatisticValueKHR(val::__U_VkPipelineExecutableStatisticValueKHR)
     ref = Ref{VkPipelineExecutableStatisticValueKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.b32 = b32
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(i64::Int64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.i64 = i64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.u64 = u64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.f64 = f64
+    if val isa VkBool32
+        ptr.b32 = val
+    elseif val isa Int64
+        ptr.i64 = val
+    elseif val isa UInt64
+        ptr.u64 = val
+    elseif val isa Cdouble
+        ptr.f64 = val
+    end
     ref[]
 end
 
@@ -11369,38 +11322,20 @@ end
 
 const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
 
-function VkPerformanceValueDataINTEL(value32::UInt32)
+function VkPerformanceValueDataINTEL(val::__U_VkPerformanceValueDataINTEL)
     ref = Ref{VkPerformanceValueDataINTEL}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value32 = value32
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(value64::UInt64)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value64 = value64
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueFloat = valueFloat
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueBool::VkBool32)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueBool = valueBool
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueString = valueString
+    if val isa UInt32
+        ptr.value32 = val
+    elseif val isa UInt64
+        ptr.value64 = val
+    elseif val isa Cfloat
+        ptr.valueFloat = val
+    elseif val isa VkBool32
+        ptr.valueBool = val
+    elseif val isa Ptr{Cchar}
+        ptr.valueString = val
+    end
     ref[]
 end
 
@@ -12893,17 +12828,14 @@ end
 
 const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressKHR(val::__U_VkDeviceOrHostAddressKHR)
     ref = Ref{VkDeviceOrHostAddressKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -12930,17 +12862,14 @@ end
 
 const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressConstKHR(val::__U_VkDeviceOrHostAddressConstKHR)
     ref = Ref{VkDeviceOrHostAddressConstKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressConstKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -13001,24 +12930,16 @@ end
 
 const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
 
-function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+function VkAccelerationStructureGeometryDataKHR(val::__U_VkAccelerationStructureGeometryDataKHR)
     ref = Ref{VkAccelerationStructureGeometryDataKHR}()
     ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.triangles = triangles
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.aabbs = aabbs
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.instances = instances
+    if val isa VkAccelerationStructureGeometryTrianglesDataKHR
+        ptr.triangles = val
+    elseif val isa VkAccelerationStructureGeometryAabbsDataKHR
+        ptr.aabbs = val
+    elseif val isa VkAccelerationStructureGeometryInstancesDataKHR
+        ptr.instances = val
+    end
     ref[]
 end
 

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -3686,548 +3686,1096 @@ function vkCreateInstance(pCreateInfo, pAllocator, pInstance)
     ccall((:vkCreateInstance, libvulkan), VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
 end
 
+function vkCreateInstance(pCreateInfo, pAllocator, pInstance, fptr)
+    ccall(fptr, VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
+end
+
 function vkDestroyInstance(instance, pAllocator)
     ccall((:vkDestroyInstance, libvulkan), Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
+end
+
+function vkDestroyInstance(instance, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
 end
 
 function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices)
     ccall((:vkEnumeratePhysicalDevices, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
 end
 
+function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
+end
+
 function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
+end
+
+function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
 end
 
 function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceProperties(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
 end
 
+function vkGetPhysicalDeviceProperties(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
+end
+
 function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
+function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
 function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetInstanceProcAddr(instance, pName)
     ccall((:vkGetInstanceProcAddr, libvulkan), PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
+end
+
+function vkGetInstanceProcAddr(instance, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
 end
 
 function vkGetDeviceProcAddr(device, pName)
     ccall((:vkGetDeviceProcAddr, libvulkan), PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
 end
 
+function vkGetDeviceProcAddr(device, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
+end
+
 function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice)
     ccall((:vkCreateDevice, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
+end
+
+function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
 end
 
 function vkDestroyDevice(device, pAllocator)
     ccall((:vkDestroyDevice, libvulkan), Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
 end
 
+function vkDestroyDevice(device, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
+end
+
 function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceExtensionProperties, libvulkan), VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceExtensionProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
+end
+
 function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceLayerProperties, libvulkan), VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceLayerProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue)
     ccall((:vkGetDeviceQueue, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
+end
+
+function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
 end
 
 function vkQueueSubmit(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
+function vkQueueSubmit(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
 function vkQueueWaitIdle(queue)
     ccall((:vkQueueWaitIdle, libvulkan), VkResult, (VkQueue,), queue)
+end
+
+function vkQueueWaitIdle(queue, fptr)
+    ccall(fptr, VkResult, (VkQueue,), queue)
 end
 
 function vkDeviceWaitIdle(device)
     ccall((:vkDeviceWaitIdle, libvulkan), VkResult, (VkDevice,), device)
 end
 
+function vkDeviceWaitIdle(device, fptr)
+    ccall(fptr, VkResult, (VkDevice,), device)
+end
+
 function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory)
     ccall((:vkAllocateMemory, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
+end
+
+function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
 end
 
 function vkFreeMemory(device, memory, pAllocator)
     ccall((:vkFreeMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
 end
 
+function vkFreeMemory(device, memory, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
+end
+
 function vkMapMemory(device, memory, offset, size, flags, ppData)
     ccall((:vkMapMemory, libvulkan), VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
+end
+
+function vkMapMemory(device, memory, offset, size, flags, ppData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
 end
 
 function vkUnmapMemory(device, memory)
     ccall((:vkUnmapMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory), device, memory)
 end
 
+function vkUnmapMemory(device, memory, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory), device, memory)
+end
+
 function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkFlushMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
+function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
 function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkInvalidateMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
+function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
 function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes)
     ccall((:vkGetDeviceMemoryCommitment, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
+end
+
+function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
 end
 
 function vkBindBufferMemory(device, buffer, memory, memoryOffset)
     ccall((:vkBindBufferMemory, libvulkan), VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
 end
 
+function vkBindBufferMemory(device, buffer, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
+end
+
 function vkBindImageMemory(device, image, memory, memoryOffset)
     ccall((:vkBindImageMemory, libvulkan), VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
+end
+
+function vkBindImageMemory(device, image, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
 end
 
 function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
+end
+
 function vkGetImageMemoryRequirements(device, image, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements(device, image, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
 end
 
 function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
+function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
 end
 
 function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence)
     ccall((:vkQueueBindSparse, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
 end
 
+function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
+end
+
 function vkCreateFence(device, pCreateInfo, pAllocator, pFence)
     ccall((:vkCreateFence, libvulkan), VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
+end
+
+function vkCreateFence(device, pCreateInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
 end
 
 function vkDestroyFence(device, fence, pAllocator)
     ccall((:vkDestroyFence, libvulkan), Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
 end
 
+function vkDestroyFence(device, fence, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
+end
+
 function vkResetFences(device, fenceCount, pFences)
     ccall((:vkResetFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
+end
+
+function vkResetFences(device, fenceCount, pFences, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
 end
 
 function vkGetFenceStatus(device, fence)
     ccall((:vkGetFenceStatus, libvulkan), VkResult, (VkDevice, VkFence), device, fence)
 end
 
+function vkGetFenceStatus(device, fence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkFence), device, fence)
+end
+
 function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout)
     ccall((:vkWaitForFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
+end
+
+function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
 end
 
 function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore)
     ccall((:vkCreateSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
 end
 
+function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
+end
+
 function vkDestroySemaphore(device, semaphore, pAllocator)
     ccall((:vkDestroySemaphore, libvulkan), Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
+end
+
+function vkDestroySemaphore(device, semaphore, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
 end
 
 function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent)
     ccall((:vkCreateEvent, libvulkan), VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
 end
 
+function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
+end
+
 function vkDestroyEvent(device, event, pAllocator)
     ccall((:vkDestroyEvent, libvulkan), Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
+end
+
+function vkDestroyEvent(device, event, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
 end
 
 function vkGetEventStatus(device, event)
     ccall((:vkGetEventStatus, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkGetEventStatus(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkSetEvent(device, event)
     ccall((:vkSetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
+end
+
+function vkSetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
 end
 
 function vkResetEvent(device, event)
     ccall((:vkResetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkResetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool)
     ccall((:vkCreateQueryPool, libvulkan), VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
+end
+
+function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
 end
 
 function vkDestroyQueryPool(device, queryPool, pAllocator)
     ccall((:vkDestroyQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
 end
 
+function vkDestroyQueryPool(device, queryPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
+end
+
 function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
     ccall((:vkGetQueryPoolResults, libvulkan), VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
+end
+
+function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
 end
 
 function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer)
     ccall((:vkCreateBuffer, libvulkan), VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
 end
 
+function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
+end
+
 function vkDestroyBuffer(device, buffer, pAllocator)
     ccall((:vkDestroyBuffer, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
+end
+
+function vkDestroyBuffer(device, buffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
 end
 
 function vkCreateBufferView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateBufferView, libvulkan), VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
 end
 
+function vkCreateBufferView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
+end
+
 function vkDestroyBufferView(device, bufferView, pAllocator)
     ccall((:vkDestroyBufferView, libvulkan), Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
+end
+
+function vkDestroyBufferView(device, bufferView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
 end
 
 function vkCreateImage(device, pCreateInfo, pAllocator, pImage)
     ccall((:vkCreateImage, libvulkan), VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
 end
 
+function vkCreateImage(device, pCreateInfo, pAllocator, pImage, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
+end
+
 function vkDestroyImage(device, image, pAllocator)
     ccall((:vkDestroyImage, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
+end
+
+function vkDestroyImage(device, image, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
 end
 
 function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout)
     ccall((:vkGetImageSubresourceLayout, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
 end
 
+function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
+end
+
 function vkCreateImageView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateImageView, libvulkan), VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
+end
+
+function vkCreateImageView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
 end
 
 function vkDestroyImageView(device, imageView, pAllocator)
     ccall((:vkDestroyImageView, libvulkan), Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
 end
 
+function vkDestroyImageView(device, imageView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
+end
+
 function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule)
     ccall((:vkCreateShaderModule, libvulkan), VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
+end
+
+function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
 end
 
 function vkDestroyShaderModule(device, shaderModule, pAllocator)
     ccall((:vkDestroyShaderModule, libvulkan), Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
 end
 
+function vkDestroyShaderModule(device, shaderModule, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
+end
+
 function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache)
     ccall((:vkCreatePipelineCache, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
+end
+
+function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
 end
 
 function vkDestroyPipelineCache(device, pipelineCache, pAllocator)
     ccall((:vkDestroyPipelineCache, libvulkan), Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
 end
 
+function vkDestroyPipelineCache(device, pipelineCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
+end
+
 function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData)
     ccall((:vkGetPipelineCacheData, libvulkan), VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
+end
+
+function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
 end
 
 function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergePipelineCaches, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateGraphicsPipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateComputePipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
+function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
 function vkDestroyPipeline(device, pipeline, pAllocator)
     ccall((:vkDestroyPipeline, libvulkan), Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
+end
+
+function vkDestroyPipeline(device, pipeline, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
 end
 
 function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout)
     ccall((:vkCreatePipelineLayout, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
 end
 
+function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
+end
+
 function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator)
     ccall((:vkDestroyPipelineLayout, libvulkan), Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
+end
+
+function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
 end
 
 function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler)
     ccall((:vkCreateSampler, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
 end
 
+function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
+end
+
 function vkDestroySampler(device, sampler, pAllocator)
     ccall((:vkDestroySampler, libvulkan), Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
+end
+
+function vkDestroySampler(device, sampler, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
 end
 
 function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout)
     ccall((:vkCreateDescriptorSetLayout, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
 end
 
+function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
+end
+
 function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator)
     ccall((:vkDestroyDescriptorSetLayout, libvulkan), Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
+end
+
+function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
 end
 
 function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool)
     ccall((:vkCreateDescriptorPool, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
 end
 
+function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
+end
+
 function vkDestroyDescriptorPool(device, descriptorPool, pAllocator)
     ccall((:vkDestroyDescriptorPool, libvulkan), Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
+end
+
+function vkDestroyDescriptorPool(device, descriptorPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
 end
 
 function vkResetDescriptorPool(device, descriptorPool, flags)
     ccall((:vkResetDescriptorPool, libvulkan), VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
 end
 
+function vkResetDescriptorPool(device, descriptorPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
+end
+
 function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets)
     ccall((:vkAllocateDescriptorSets, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
+end
+
+function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
 end
 
 function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets)
     ccall((:vkFreeDescriptorSets, libvulkan), VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
 end
 
+function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
+end
+
 function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
     ccall((:vkUpdateDescriptorSets, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
+end
+
+function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
 end
 
 function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer)
     ccall((:vkCreateFramebuffer, libvulkan), VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
 end
 
+function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
+end
+
 function vkDestroyFramebuffer(device, framebuffer, pAllocator)
     ccall((:vkDestroyFramebuffer, libvulkan), Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
+end
+
+function vkDestroyFramebuffer(device, framebuffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
 end
 
 function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkDestroyRenderPass(device, renderPass, pAllocator)
     ccall((:vkDestroyRenderPass, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
+end
+
+function vkDestroyRenderPass(device, renderPass, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
 end
 
 function vkGetRenderAreaGranularity(device, renderPass, pGranularity)
     ccall((:vkGetRenderAreaGranularity, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
 end
 
+function vkGetRenderAreaGranularity(device, renderPass, pGranularity, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
+end
+
 function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool)
     ccall((:vkCreateCommandPool, libvulkan), VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
+end
+
+function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
 end
 
 function vkDestroyCommandPool(device, commandPool, pAllocator)
     ccall((:vkDestroyCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
 end
 
+function vkDestroyCommandPool(device, commandPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
+end
+
 function vkResetCommandPool(device, commandPool, flags)
     ccall((:vkResetCommandPool, libvulkan), VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
+end
+
+function vkResetCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
 end
 
 function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers)
     ccall((:vkAllocateCommandBuffers, libvulkan), VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
 end
 
+function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
+end
+
 function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers)
     ccall((:vkFreeCommandBuffers, libvulkan), Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
+end
+
+function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
 end
 
 function vkBeginCommandBuffer(commandBuffer, pBeginInfo)
     ccall((:vkBeginCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
 end
 
+function vkBeginCommandBuffer(commandBuffer, pBeginInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
+end
+
 function vkEndCommandBuffer(commandBuffer)
     ccall((:vkEndCommandBuffer, libvulkan), VkResult, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkEndCommandBuffer(commandBuffer, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer,), commandBuffer)
 end
 
 function vkResetCommandBuffer(commandBuffer, flags)
     ccall((:vkResetCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
 end
 
+function vkResetCommandBuffer(commandBuffer, flags, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
+end
+
 function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline)
     ccall((:vkCmdBindPipeline, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
+end
+
+function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
 end
 
 function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports)
     ccall((:vkCmdSetViewport, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
 end
 
+function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
+end
+
 function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors)
     ccall((:vkCmdSetScissor, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
+end
+
+function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
 end
 
 function vkCmdSetLineWidth(commandBuffer, lineWidth)
     ccall((:vkCmdSetLineWidth, libvulkan), Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
 end
 
+function vkCmdSetLineWidth(commandBuffer, lineWidth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
+end
+
 function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
     ccall((:vkCmdSetDepthBias, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
+end
+
+function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
 end
 
 function vkCmdSetBlendConstants(commandBuffer, blendConstants)
     ccall((:vkCmdSetBlendConstants, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
 end
 
+function vkCmdSetBlendConstants(commandBuffer, blendConstants, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
+end
+
 function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds)
     ccall((:vkCmdSetDepthBounds, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
+end
+
+function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
 end
 
 function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask)
     ccall((:vkCmdSetStencilCompareMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
 end
 
+function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
+end
+
 function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask)
     ccall((:vkCmdSetStencilWriteMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
+end
+
+function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
 end
 
 function vkCmdSetStencilReference(commandBuffer, faceMask, reference)
     ccall((:vkCmdSetStencilReference, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
 end
 
+function vkCmdSetStencilReference(commandBuffer, faceMask, reference, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
+end
+
 function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
     ccall((:vkCmdBindDescriptorSets, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
+end
+
+function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
 end
 
 function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType)
     ccall((:vkCmdBindIndexBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
 end
 
+function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
+end
+
 function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
     ccall((:vkCmdBindVertexBuffers, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
+end
+
+function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
 end
 
 function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
     ccall((:vkCmdDraw, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
 end
 
+function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
+end
+
 function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
     ccall((:vkCmdDrawIndexed, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
+end
+
+function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
 end
 
 function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndexedIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
 function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatch, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
 end
 
+function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
+end
+
 function vkCmdDispatchIndirect(commandBuffer, buffer, offset)
     ccall((:vkCmdDispatchIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
+end
+
+function vkCmdDispatchIndirect(commandBuffer, buffer, offset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
 end
 
 function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
     ccall((:vkCmdBlitImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
 end
 
+function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
+end
+
 function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyBufferToImage, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyImageToBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData)
     ccall((:vkCmdUpdateBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
+end
+
+function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
 end
 
 function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data)
     ccall((:vkCmdFillBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
 end
 
+function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
+end
+
 function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
     ccall((:vkCmdClearColorImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
+end
+
+function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
 end
 
 function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
     ccall((:vkCmdClearDepthStencilImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
 end
 
+function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
+end
+
 function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
     ccall((:vkCmdClearAttachments, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
+end
+
+function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
 end
 
 function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdResolveImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
+function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
 function vkCmdSetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdSetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
+function vkCmdSetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
 function vkCmdResetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
+function vkCmdResetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
 function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdWaitEvents, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
+function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
 function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdPipelineBarrier, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
+function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
 function vkCmdBeginQuery(commandBuffer, queryPool, query, flags)
     ccall((:vkCmdBeginQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
+end
+
+function vkCmdBeginQuery(commandBuffer, queryPool, query, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
 end
 
 function vkCmdEndQuery(commandBuffer, queryPool, query)
     ccall((:vkCmdEndQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
 end
 
+function vkCmdEndQuery(commandBuffer, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
+end
+
 function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount)
     ccall((:vkCmdResetQueryPool, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
+end
+
+function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
 end
 
 function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query)
     ccall((:vkCmdWriteTimestamp, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
+end
+
 function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
     ccall((:vkCmdCopyQueryPoolResults, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
+end
+
+function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
 end
 
 function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues)
     ccall((:vkCmdPushConstants, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
 end
 
+function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
+end
+
 function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents)
     ccall((:vkCmdBeginRenderPass, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
+end
+
+function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
 end
 
 function vkCmdNextSubpass(commandBuffer, contents)
     ccall((:vkCmdNextSubpass, libvulkan), Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
 end
 
+function vkCmdNextSubpass(commandBuffer, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
+end
+
 function vkCmdEndRenderPass(commandBuffer)
     ccall((:vkCmdEndRenderPass, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndRenderPass(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers)
     ccall((:vkCmdExecuteCommands, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
+end
+
+function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
 end
 
 const VkSamplerYcbcrConversion_T = Cvoid
@@ -5017,112 +5565,224 @@ function vkEnumerateInstanceVersion(pApiVersion)
     ccall((:vkEnumerateInstanceVersion, libvulkan), VkResult, (Ptr{UInt32},), pApiVersion)
 end
 
+function vkEnumerateInstanceVersion(pApiVersion, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32},), pApiVersion)
+end
+
 function vkBindBufferMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindBufferMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 function vkBindImageMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindImageMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
     ccall((:vkGetDeviceGroupPeerMemoryFeatures, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
+function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
 function vkCmdSetDeviceMask(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMask, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMask(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBase, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroups, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
+function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
 function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
 function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
+function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
 function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
 function vkTrimCommandPool(device, commandPool, flags)
     ccall((:vkTrimCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
+function vkTrimCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
 function vkGetDeviceQueue2(device, pQueueInfo, pQueue)
     ccall((:vkGetDeviceQueue2, libvulkan), Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
 end
 
+function vkGetDeviceQueue2(device, pQueueInfo, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
+end
+
 function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion)
     ccall((:vkCreateSamplerYcbcrConversion, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
+function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
 function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversion, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
+function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
 function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
     ccall((:vkCreateDescriptorUpdateTemplate, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
+function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
 function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
+function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
 function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFenceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphoreProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
+function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
 function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupport, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
+function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
 @cenum VkDriverId::UInt32 begin
@@ -5822,52 +6482,104 @@ function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, coun
     ccall((:vkCmdDrawIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 function vkResetQueryPool(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
+function vkResetQueryPool(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
 function vkGetSemaphoreCounterValue(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValue, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
+function vkGetSemaphoreCounterValue(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
 function vkWaitSemaphores(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphores, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphores(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphore(device, pSignalInfo)
     ccall((:vkSignalSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphore(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 function vkGetBufferDeviceAddress(device, pInfo)
     ccall((:vkGetBufferDeviceAddress, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddress(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkSurfaceKHR_T = Cvoid
@@ -5968,20 +6680,40 @@ function vkDestroySurfaceKHR(instance, surface, pAllocator)
     ccall((:vkDestroySurfaceKHR, libvulkan), Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
 end
 
+function vkDestroySurfaceKHR(instance, surface, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
+end
+
 function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported)
     ccall((:vkGetPhysicalDeviceSurfaceSupportKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
+end
+
+function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
 end
 
 function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormatsKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
 end
 
+function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
+end
+
 function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes)
     ccall((:vkGetPhysicalDeviceSurfacePresentModesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
+end
+
+function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
 end
 
 const VkSwapchainKHR_T = Cvoid
@@ -6114,36 +6846,72 @@ function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain)
     ccall((:vkCreateSwapchainKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
 end
 
+function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
+end
+
 function vkDestroySwapchainKHR(device, swapchain, pAllocator)
     ccall((:vkDestroySwapchainKHR, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
+end
+
+function vkDestroySwapchainKHR(device, swapchain, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
 end
 
 function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages)
     ccall((:vkGetSwapchainImagesKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
 end
 
+function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
+end
+
 function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex)
     ccall((:vkAcquireNextImageKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
+end
+
+function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
 end
 
 function vkQueuePresentKHR(queue, pPresentInfo)
     ccall((:vkQueuePresentKHR, libvulkan), VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
 end
 
+function vkQueuePresentKHR(queue, pPresentInfo, fptr)
+    ccall(fptr, VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
+end
+
 function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities)
     ccall((:vkGetDeviceGroupPresentCapabilitiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
+end
+
+function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
 end
 
 function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes)
     ccall((:vkGetDeviceGroupSurfacePresentModesKHR, libvulkan), VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
 end
 
+function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
+end
+
 function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects)
     ccall((:vkGetPhysicalDevicePresentRectanglesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
 end
 
+function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
+end
+
 function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex)
     ccall((:vkAcquireNextImage2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
+end
+
+function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
 end
 
 const VkDisplayKHR_T = Cvoid
@@ -6250,28 +7018,56 @@ function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount,
     ccall((:vkGetPhysicalDeviceDisplayPropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlanePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays)
     ccall((:vkGetDisplayPlaneSupportedDisplaysKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
 end
 
+function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
+end
+
 function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
+function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
 function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode)
     ccall((:vkCreateDisplayModeKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
 end
 
+function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
+end
+
 function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
 end
 
+function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
+end
+
 function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateDisplayPlaneSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
+function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
 struct VkDisplayPresentInfoKHR
@@ -6287,6 +7083,10 @@ const PFN_vkCreateSharedSwapchainsKHR = Ptr{Cvoid}
 
 function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
     ccall((:vkCreateSharedSwapchainsKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
+end
+
+function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
 end
 
 const VkRenderPassMultiviewCreateInfoKHR = VkRenderPassMultiviewCreateInfo
@@ -6338,28 +7138,56 @@ function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
 const VkPeerMemoryFeatureFlagsKHR = VkPeerMemoryFeatureFlags
@@ -6397,12 +7225,24 @@ function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceInd
     ccall((:vkGetDeviceGroupPeerMemoryFeaturesKHR, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
+function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
 function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMaskKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBaseKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 const VkCommandPoolTrimFlagsKHR = VkCommandPoolTrimFlags
@@ -6414,6 +7254,10 @@ function vkTrimCommandPoolKHR(device, commandPool, flags)
     ccall((:vkTrimCommandPoolKHR, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
+function vkTrimCommandPoolKHR(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
 const VkPhysicalDeviceGroupPropertiesKHR = VkPhysicalDeviceGroupProperties
 
 const VkDeviceGroupDeviceCreateInfoKHR = VkDeviceGroupDeviceCreateInfo
@@ -6423,6 +7267,10 @@ const PFN_vkEnumeratePhysicalDeviceGroupsKHR = Ptr{Cvoid}
 
 function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroupsKHR, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
+function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
 const VkExternalMemoryHandleTypeFlagsKHR = VkExternalMemoryHandleTypeFlags
@@ -6450,6 +7298,10 @@ const PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferPropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
+function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
 const VkExternalMemoryImageCreateInfoKHR = VkExternalMemoryImageCreateInfo
@@ -6488,8 +7340,16 @@ function vkGetMemoryFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetMemoryFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
+function vkGetMemoryFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
 function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties)
     ccall((:vkGetMemoryFdPropertiesKHR, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
+end
+
+function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
 end
 
 const VkExternalSemaphoreHandleTypeFlagsKHR = VkExternalSemaphoreHandleTypeFlags
@@ -6509,6 +7369,10 @@ const PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphorePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
+function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
 const VkSemaphoreImportFlagsKHR = VkSemaphoreImportFlags
@@ -6543,8 +7407,16 @@ function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo)
     ccall((:vkImportSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
 end
 
+function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
+end
+
 function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 struct VkPhysicalDevicePushDescriptorPropertiesKHR
@@ -6563,8 +7435,16 @@ function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set
     ccall((:vkCmdPushDescriptorSetKHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
 end
 
+function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
+end
+
 function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData)
     ccall((:vkCmdPushDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
+end
+
+function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
 end
 
 const VkPhysicalDeviceShaderFloat16Int8FeaturesKHR = VkPhysicalDeviceShaderFloat16Int8Features
@@ -6614,12 +7494,24 @@ function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pD
     ccall((:vkCreateDescriptorUpdateTemplateKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
+function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
 function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 const VkPhysicalDeviceImagelessFramebufferFeaturesKHR = VkPhysicalDeviceImagelessFramebufferFeatures
@@ -6660,16 +7552,32 @@ function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 struct VkSharedPresentSurfaceCapabilitiesKHR
@@ -6683,6 +7591,10 @@ const PFN_vkGetSwapchainStatusKHR = Ptr{Cvoid}
 
 function vkGetSwapchainStatusKHR(device, swapchain)
     ccall((:vkGetSwapchainStatusKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
+end
+
+function vkGetSwapchainStatusKHR(device, swapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
 end
 
 const VkExternalFenceHandleTypeFlagsKHR = VkExternalFenceHandleTypeFlags
@@ -6702,6 +7614,10 @@ const PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFencePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 const VkFenceImportFlagsKHR = VkFenceImportFlags
@@ -6736,8 +7652,16 @@ function vkImportFenceFdKHR(device, pImportFenceFdInfo)
     ccall((:vkImportFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
 end
 
+function vkImportFenceFdKHR(device, pImportFenceFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
+end
+
 function vkGetFenceFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetFenceFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 @cenum VkPerformanceCounterUnitKHR::UInt32 begin
@@ -6884,16 +7808,32 @@ function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physica
     ccall((:vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
 end
 
+function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
+end
+
 function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
     ccall((:vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
+end
+
+function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
 end
 
 function vkAcquireProfilingLockKHR(device, pInfo)
     ccall((:vkAcquireProfilingLockKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
 end
 
+function vkAcquireProfilingLockKHR(device, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
+end
+
 function vkReleaseProfilingLockKHR(device)
     ccall((:vkReleaseProfilingLockKHR, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkReleaseProfilingLockKHR(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 const VkPointClippingBehaviorKHR = VkPointClippingBehavior
@@ -6938,8 +7878,16 @@ function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormats2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
+end
+
+function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
 end
 
 const VkPhysicalDeviceVariablePointerFeaturesKHR = VkPhysicalDeviceVariablePointersFeatures
@@ -6993,16 +7941,32 @@ function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount
     ccall((:vkGetPhysicalDeviceDisplayProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlaneProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModeProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
+function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
 function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
+end
+
+function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
 end
 
 const VkMemoryDedicatedRequirementsKHR = VkMemoryDedicatedRequirements
@@ -7032,12 +7996,24 @@ function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 const VkImageFormatListCreateInfoKHR = VkImageFormatListCreateInfo
@@ -7072,8 +8048,16 @@ function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcb
     ccall((:vkCreateSamplerYcbcrConversionKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
+function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
 function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversionKHR, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
+function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
 const VkBindBufferMemoryInfoKHR = VkBindBufferMemoryInfo
@@ -7090,8 +8074,16 @@ function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 const VkPhysicalDeviceMaintenance3PropertiesKHR = VkPhysicalDeviceMaintenance3Properties
@@ -7105,6 +8097,10 @@ function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupportKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
+function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountKHR ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
 const PFN_vkCmdDrawIndirectCountKHR = Ptr{Cvoid}
 
@@ -7115,8 +8111,16 @@ function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 const VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR = VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures
@@ -7181,12 +8185,24 @@ function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValueKHR, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
+function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
 function vkWaitSemaphoresKHR(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphoresKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphoresKHR(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphoreKHR(device, pSignalInfo)
     ccall((:vkSignalSemaphoreKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphoreKHR(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR = VkPhysicalDeviceVulkanMemoryModelFeatures
@@ -7267,8 +8283,16 @@ function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentSha
     ccall((:vkGetPhysicalDeviceFragmentShadingRatesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
 end
 
+function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
+end
+
 function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps)
     ccall((:vkCmdSetFragmentShadingRateKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
+end
+
+function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
 end
 
 struct VkSurfaceProtectedCapabilitiesKHR
@@ -7308,12 +8332,24 @@ function vkGetBufferDeviceAddressKHR(device, pInfo)
     ccall((:vkGetBufferDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkDeferredOperationKHR_T = Cvoid
@@ -7339,20 +8375,40 @@ function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation)
     ccall((:vkCreateDeferredOperationKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
 end
 
+function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
+end
+
 function vkDestroyDeferredOperationKHR(device, operation, pAllocator)
     ccall((:vkDestroyDeferredOperationKHR, libvulkan), Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
+end
+
+function vkDestroyDeferredOperationKHR(device, operation, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
 end
 
 function vkGetDeferredOperationMaxConcurrencyKHR(device, operation)
     ccall((:vkGetDeferredOperationMaxConcurrencyKHR, libvulkan), UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationMaxConcurrencyKHR(device, operation, fptr)
+    ccall(fptr, UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkGetDeferredOperationResultKHR(device, operation)
     ccall((:vkGetDeferredOperationResultKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationResultKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkDeferredOperationJoinKHR(device, operation)
     ccall((:vkDeferredOperationJoinKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
+function vkDeferredOperationJoinKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
 @cenum VkPipelineExecutableStatisticFormatKHR::UInt32 begin
@@ -7446,12 +8502,24 @@ function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutable
     ccall((:vkGetPipelineExecutablePropertiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
 end
 
+function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutableCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
+end
+
 function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics)
     ccall((:vkGetPipelineExecutableStatisticsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
 end
 
+function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
+end
+
 function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
     ccall((:vkGetPipelineExecutableInternalRepresentationsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
+end
+
+function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
 end
 
 struct VkPipelineLibraryCreateInfoKHR
@@ -7603,32 +8671,64 @@ function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo)
     ccall((:vkCmdSetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
 end
 
+function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
+end
+
 function vkCmdResetEvent2KHR(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
+end
+
+function vkCmdResetEvent2KHR(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
 end
 
 function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos)
     ccall((:vkCmdWaitEvents2KHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
 end
 
+function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
+end
+
 function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo)
     ccall((:vkCmdPipelineBarrier2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
+end
+
+function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
 end
 
 function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query)
     ccall((:vkCmdWriteTimestamp2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
+end
+
 function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit2KHR, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
+function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
 function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarker2AMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
 end
 
+function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
+end
+
 function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointData2NV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR
@@ -7779,24 +8879,48 @@ function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo)
     ccall((:vkCmdCopyBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
 end
 
+function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
+end
+
 function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo)
     ccall((:vkCmdCopyImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
+end
+
+function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
 end
 
 function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo)
     ccall((:vkCmdCopyBufferToImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
 end
 
+function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
+end
+
 function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo)
     ccall((:vkCmdCopyImageToBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
+end
+
+function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
 end
 
 function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo)
     ccall((:vkCmdBlitImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
 end
 
+function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
+end
+
 function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo)
     ccall((:vkCmdResolveImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
+end
+
+function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
 end
 
 const VkDebugReportCallbackEXT_T = Cvoid
@@ -7882,12 +9006,24 @@ function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCall
     ccall((:vkCreateDebugReportCallbackEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
 end
 
+function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
+end
+
 function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator)
     ccall((:vkDestroyDebugReportCallbackEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
 end
 
+function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
+end
+
 function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
     ccall((:vkDebugReportMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
+end
+
+function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
 end
 
 @cenum VkRasterizationOrderAMD::UInt32 begin
@@ -7946,20 +9082,40 @@ function vkDebugMarkerSetObjectTagEXT(device, pTagInfo)
     ccall((:vkDebugMarkerSetObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
 end
 
+function vkDebugMarkerSetObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
+end
+
 function vkDebugMarkerSetObjectNameEXT(device, pNameInfo)
     ccall((:vkDebugMarkerSetObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
+end
+
+function vkDebugMarkerSetObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
 end
 
 function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerBeginEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdDebugMarkerEndEXT(commandBuffer)
     ccall((:vkCmdDebugMarkerEndEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdDebugMarkerEndEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerInsertEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
 struct VkDedicatedAllocationImageCreateInfoNV
@@ -8034,24 +9190,48 @@ function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindi
     ccall((:vkCmdBindTransformFeedbackBuffersEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
 end
 
+function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
+end
+
 function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdBeginTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
+function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
 function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdEndTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
+function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
 function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index)
     ccall((:vkCmdBeginQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
+end
+
+function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
 end
 
 function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index)
     ccall((:vkCmdEndQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
 end
 
+function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
+end
+
 function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
     ccall((:vkCmdDrawIndirectByteCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
+end
+
+function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
 end
 
 struct VkImageViewHandleInfoNVX
@@ -8079,8 +9259,16 @@ function vkGetImageViewHandleNVX(device, pInfo)
     ccall((:vkGetImageViewHandleNVX, libvulkan), UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
 end
 
+function vkGetImageViewHandleNVX(device, pInfo, fptr)
+    ccall(fptr, UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
+end
+
 function vkGetImageViewAddressNVX(device, imageView, pProperties)
     ccall((:vkGetImageViewAddressNVX, libvulkan), VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
+end
+
+function vkGetImageViewAddressNVX(device, imageView, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
 end
 
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountAMD ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
@@ -8093,8 +9281,16 @@ function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkTextureLODGatherFormatPropertiesAMD
@@ -8135,6 +9331,10 @@ function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, 
     ccall((:vkGetShaderInfoAMD, libvulkan), VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
 end
 
+function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
+end
+
 struct VkPhysicalDeviceCornerSampledImageFeaturesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8172,6 +9372,10 @@ const PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
     ccall((:vkGetPhysicalDeviceExternalImageFormatPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
 end
 
 struct VkExternalMemoryImageCreateInfoNV
@@ -8255,8 +9459,16 @@ function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingB
     ccall((:vkCmdBeginConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
 end
 
+function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
+end
+
 function vkCmdEndConditionalRenderingEXT(commandBuffer)
     ccall((:vkCmdEndConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkCmdEndConditionalRenderingEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
 struct VkViewportWScalingNV
@@ -8279,11 +9491,19 @@ function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount,
     ccall((:vkCmdSetViewportWScalingNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
 end
 
+function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
+end
+
 # typedef VkResult ( VKAPI_PTR * PFN_vkReleaseDisplayEXT ) ( VkPhysicalDevice physicalDevice , VkDisplayKHR display )
 const PFN_vkReleaseDisplayEXT = Ptr{Cvoid}
 
 function vkReleaseDisplayEXT(physicalDevice, display)
     ccall((:vkReleaseDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
+function vkReleaseDisplayEXT(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
 @cenum VkSurfaceCounterFlagBitsEXT::UInt32 begin
@@ -8315,6 +9535,10 @@ const PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2EXT, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
+function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
 @cenum VkDisplayPowerStateEXT::UInt32 begin
@@ -8374,16 +9598,32 @@ function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo)
     ccall((:vkDisplayPowerControlEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
 end
 
+function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
+end
+
 function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDeviceEventEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
+end
+
+function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
 end
 
 function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDisplayEventEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
 end
 
+function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
+end
+
 function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue)
     ccall((:vkGetSwapchainCounterEXT, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
+end
+
+function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
 end
 
 struct VkRefreshCycleDurationGOOGLE
@@ -8420,8 +9660,16 @@ function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProper
     ccall((:vkGetRefreshCycleDurationGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
 end
 
+function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
+end
+
 function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings)
     ccall((:vkGetPastPresentationTimingGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
+end
+
+function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
 end
 
 struct VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX
@@ -8487,6 +9735,10 @@ const PFN_vkCmdSetDiscardRectangleEXT = Ptr{Cvoid}
 
 function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
     ccall((:vkCmdSetDiscardRectangleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
+end
+
+function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
 end
 
 @cenum VkConservativeRasterizationModeEXT::UInt32 begin
@@ -8558,6 +9810,10 @@ const PFN_vkSetHdrMetadataEXT = Ptr{Cvoid}
 
 function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata)
     ccall((:vkSetHdrMetadataEXT, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
+end
+
+function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
 end
 
 const VkDebugUtilsMessengerEXT_T = Cvoid
@@ -8677,44 +9933,88 @@ function vkSetDebugUtilsObjectNameEXT(device, pNameInfo)
     ccall((:vkSetDebugUtilsObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
 end
 
+function vkSetDebugUtilsObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
+end
+
 function vkSetDebugUtilsObjectTagEXT(device, pTagInfo)
     ccall((:vkSetDebugUtilsObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
+end
+
+function vkSetDebugUtilsObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
 end
 
 function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkQueueEndDebugUtilsLabelEXT(queue)
     ccall((:vkQueueEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue,), queue)
+end
+
+function vkQueueEndDebugUtilsLabelEXT(queue, fptr)
+    ccall(fptr, Cvoid, (VkQueue,), queue)
 end
 
 function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCmdEndDebugUtilsLabelEXT(commandBuffer)
     ccall((:vkCmdEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndDebugUtilsLabelEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger)
     ccall((:vkCreateDebugUtilsMessengerEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
 end
 
+function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
+end
+
 function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator)
     ccall((:vkDestroyDebugUtilsMessengerEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
 end
 
+function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
+end
+
 function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData)
     ccall((:vkSubmitDebugUtilsMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
+end
+
+function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
 end
 
 const VkSamplerReductionModeEXT = VkSamplerReductionMode
@@ -8819,8 +10119,16 @@ function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo)
     ccall((:vkCmdSetSampleLocationsEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
 end
 
+function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
+end
+
 function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties)
     ccall((:vkGetPhysicalDeviceMultisamplePropertiesEXT, libvulkan), Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
+end
+
+function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
 end
 
 @cenum VkBlendOverlapEXT::UInt32 begin
@@ -8948,6 +10256,10 @@ function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties)
     ccall((:vkGetImageDrmFormatModifierPropertiesEXT, libvulkan), VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
 end
 
+function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
+end
+
 const VkValidationCacheEXT_T = Cvoid
 
 const VkValidationCacheEXT = Ptr{VkValidationCacheEXT_T}
@@ -8989,16 +10301,32 @@ function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidation
     ccall((:vkCreateValidationCacheEXT, libvulkan), VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
 end
 
+function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
+end
+
 function vkDestroyValidationCacheEXT(device, validationCache, pAllocator)
     ccall((:vkDestroyValidationCacheEXT, libvulkan), Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
+end
+
+function vkDestroyValidationCacheEXT(device, validationCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
 end
 
 function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergeValidationCachesEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData)
     ccall((:vkGetValidationCacheDataEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
+end
+
+function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
 end
 
 const VkDescriptorBindingFlagBitsEXT = VkDescriptorBindingFlagBits
@@ -9101,12 +10429,24 @@ function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout)
     ccall((:vkCmdBindShadingRateImageNV, libvulkan), Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
 end
 
+function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
+end
+
 function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
     ccall((:vkCmdSetViewportShadingRatePaletteNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
 end
 
+function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
+end
+
 function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
     ccall((:vkCmdSetCoarseSampleOrderNV, libvulkan), Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
+end
+
+function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
 end
 
 const VkAccelerationStructureNV_T = Cvoid
@@ -9433,52 +10773,104 @@ function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccel
     ccall((:vkCreateAccelerationStructureNV, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureNV, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements)
     ccall((:vkGetAccelerationStructureMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
+end
+
 function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos)
     ccall((:vkBindAccelerationStructureMemoryNV, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
 end
 
 function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
     ccall((:vkCmdBuildAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
 end
 
+function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
+end
+
 function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode)
     ccall((:vkCmdCopyAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
+end
+
+function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
 end
 
 function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
     ccall((:vkCmdTraceRaysNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
 end
 
+function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesNV, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
+function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
 function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData)
     ccall((:vkGetAccelerationStructureHandleNV, libvulkan), VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
 end
 
+function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
+function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
 function vkCompileDeferredNV(device, pipeline, shader)
     ccall((:vkCompileDeferredNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
+end
+
+function vkCompileDeferredNV(device, pipeline, shader, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
 end
 
 struct VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV
@@ -9546,11 +10938,19 @@ function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, p
     ccall((:vkGetMemoryHostPointerPropertiesEXT, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
 end
 
+function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, pMemoryHostPointerProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdWriteBufferMarkerAMD ) ( VkCommandBuffer commandBuffer , VkPipelineStageFlagBits pipelineStage , VkBuffer dstBuffer , VkDeviceSize dstOffset , uint32_t marker )
 const PFN_vkCmdWriteBufferMarkerAMD = Ptr{Cvoid}
 
 function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarkerAMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
+end
+
+function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
 end
 
 @cenum VkPipelineCompilerControlFlagBitsAMD::UInt32 begin
@@ -9589,8 +10989,16 @@ function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDom
     ccall((:vkGetPhysicalDeviceCalibrateableTimeDomainsEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
 end
 
+function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDomainCount, pTimeDomains, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
+end
+
 function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
     ccall((:vkGetCalibratedTimestampsEXT, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
+end
+
+function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
 end
 
 struct VkPhysicalDeviceShaderCorePropertiesAMD
@@ -9722,12 +11130,24 @@ function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask)
     ccall((:vkCmdDrawMeshTasksNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
 end
 
+function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
+end
+
 function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectCountNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV
@@ -9762,6 +11182,10 @@ function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclus
     ccall((:vkCmdSetExclusiveScissorNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
 end
 
+function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
+end
+
 struct VkQueueFamilyCheckpointPropertiesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -9785,8 +11209,16 @@ function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker)
     ccall((:vkCmdSetCheckpointNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
 end
 
+function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
+end
+
 function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointDataNV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL
@@ -9930,36 +11362,72 @@ function vkInitializePerformanceApiINTEL(device, pInitializeInfo)
     ccall((:vkInitializePerformanceApiINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
 end
 
+function vkInitializePerformanceApiINTEL(device, pInitializeInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
+end
+
 function vkUninitializePerformanceApiINTEL(device)
     ccall((:vkUninitializePerformanceApiINTEL, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkUninitializePerformanceApiINTEL(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceStreamMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
 function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo)
     ccall((:vkCmdSetPerformanceOverrideINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
 end
 
+function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
+end
+
 function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration)
     ccall((:vkAcquirePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
+end
+
+function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
 end
 
 function vkReleasePerformanceConfigurationINTEL(device, configuration)
     ccall((:vkReleasePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
 end
 
+function vkReleasePerformanceConfigurationINTEL(device, configuration, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
+end
+
 function vkQueueSetPerformanceConfigurationINTEL(queue, configuration)
     ccall((:vkQueueSetPerformanceConfigurationINTEL, libvulkan), VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
 end
 
+function vkQueueSetPerformanceConfigurationINTEL(queue, configuration, fptr)
+    ccall(fptr, VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
+end
+
 function vkGetPerformanceParameterINTEL(device, parameter, pValue)
     ccall((:vkGetPerformanceParameterINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
+end
+
+function vkGetPerformanceParameterINTEL(device, parameter, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
 end
 
 struct VkPhysicalDevicePCIBusInfoPropertiesEXT
@@ -9988,6 +11456,10 @@ const PFN_vkSetLocalDimmingAMD = Ptr{Cvoid}
 
 function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable)
     ccall((:vkSetLocalDimmingAMD, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
+end
+
+function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
 end
 
 struct VkPhysicalDeviceFragmentDensityMapFeaturesEXT
@@ -10112,6 +11584,10 @@ function vkGetBufferDeviceAddressEXT(device, pInfo)
     ccall((:vkGetBufferDeviceAddressEXT, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressEXT(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 @cenum VkToolPurposeFlagBitsEXT::UInt32 begin
     VK_TOOL_PURPOSE_VALIDATION_BIT_EXT = 1
     VK_TOOL_PURPOSE_PROFILING_BIT_EXT = 2
@@ -10140,6 +11616,10 @@ const PFN_vkGetPhysicalDeviceToolPropertiesEXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties)
     ccall((:vkGetPhysicalDeviceToolPropertiesEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
+end
+
+function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
 end
 
 const VkImageStencilUsageCreateInfoEXT = VkImageStencilUsageCreateInfo
@@ -10229,6 +11709,10 @@ function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPrope
     ccall((:vkGetPhysicalDeviceCooperativeMatrixPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
+end
+
 @cenum VkCoverageReductionModeNV::UInt32 begin
     VK_COVERAGE_REDUCTION_MODE_MERGE_NV = 0
     VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV = 1
@@ -10264,6 +11748,10 @@ const PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV = Pt
 
 function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations)
     ccall((:vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
+end
+
+function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
 end
 
 struct VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT
@@ -10321,6 +11809,10 @@ function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateHeadlessSurfaceEXT, libvulkan), VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 @cenum VkLineRasterizationModeEXT::UInt32 begin
     VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT = 0
     VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT = 1
@@ -10362,6 +11854,10 @@ function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePat
     ccall((:vkCmdSetLineStippleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
 end
 
+function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
+end
+
 struct VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10386,6 +11882,10 @@ const PFN_vkResetQueryPoolEXT = Ptr{Cvoid}
 
 function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPoolEXT, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
+function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
 struct VkPhysicalDeviceIndexTypeUint8FeaturesEXT
@@ -10440,48 +11940,96 @@ function vkCmdSetCullModeEXT(commandBuffer, cullMode)
     ccall((:vkCmdSetCullModeEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
 end
 
+function vkCmdSetCullModeEXT(commandBuffer, cullMode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
+end
+
 function vkCmdSetFrontFaceEXT(commandBuffer, frontFace)
     ccall((:vkCmdSetFrontFaceEXT, libvulkan), Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
+end
+
+function vkCmdSetFrontFaceEXT(commandBuffer, frontFace, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
 end
 
 function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology)
     ccall((:vkCmdSetPrimitiveTopologyEXT, libvulkan), Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
 end
 
+function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
+end
+
 function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports)
     ccall((:vkCmdSetViewportWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
+end
+
+function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
 end
 
 function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors)
     ccall((:vkCmdSetScissorWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
 end
 
+function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
+end
+
 function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
     ccall((:vkCmdBindVertexBuffers2EXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
+end
+
+function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
 end
 
 function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable)
     ccall((:vkCmdSetDepthTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
 end
 
+function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
+end
+
 function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable)
     ccall((:vkCmdSetDepthWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
+end
+
+function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
 end
 
 function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp)
     ccall((:vkCmdSetDepthCompareOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
 end
 
+function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
+end
+
 function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable)
     ccall((:vkCmdSetDepthBoundsTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
+end
+
+function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
 end
 
 function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable)
     ccall((:vkCmdSetStencilTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
 end
 
+function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
+end
+
 function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
     ccall((:vkCmdSetStencilOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
+end
+
+function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
 end
 
 struct VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT
@@ -10663,24 +12211,48 @@ function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequir
     ccall((:vkGetGeneratedCommandsMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo)
     ccall((:vkCmdPreprocessGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
+end
+
+function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
 end
 
 function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
     ccall((:vkCmdExecuteGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
 end
 
+function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
+end
+
 function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex)
     ccall((:vkCmdBindPipelineShaderGroupNV, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
+end
+
+function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
 end
 
 function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
     ccall((:vkCreateIndirectCommandsLayoutNV, libvulkan), VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
 end
 
+function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
+end
+
 function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator)
     ccall((:vkDestroyIndirectCommandsLayoutNV, libvulkan), Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
+end
+
+function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
 end
 
 struct VkPhysicalDeviceInheritedViewportScissorFeaturesNV
@@ -10844,16 +12416,32 @@ function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDat
     ccall((:vkCreatePrivateDataSlotEXT, libvulkan), VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
 end
 
+function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDataSlot, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
+end
+
 function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator)
     ccall((:vkDestroyPrivateDataSlotEXT, libvulkan), Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
+end
+
+function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
 end
 
 function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data)
     ccall((:vkSetPrivateDataEXT, libvulkan), VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
 end
 
+function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
+end
+
 function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData)
     ccall((:vkGetPrivateDataEXT, libvulkan), Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
+end
+
+function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
 end
 
 struct VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT
@@ -10934,6 +12522,10 @@ function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerO
     ccall((:vkCmdSetFragmentShadingRateEnumNV, libvulkan), Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
 end
 
+function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
+end
+
 struct VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10984,8 +12576,16 @@ function vkAcquireWinrtDisplayNV(physicalDevice, display)
     ccall((:vkAcquireWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
+function vkAcquireWinrtDisplayNV(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
 function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay)
     ccall((:vkGetWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
+end
+
+function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
 end
 
 struct VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE
@@ -11037,6 +12637,10 @@ function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pV
     ccall((:vkCmdSetVertexInputEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
 end
 
+function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
+end
+
 struct VkPhysicalDeviceExtendedDynamicState2FeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -11064,20 +12668,40 @@ function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints)
     ccall((:vkCmdSetPatchControlPointsEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
 end
 
+function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
+end
+
 function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable)
     ccall((:vkCmdSetRasterizerDiscardEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
+end
+
+function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
 end
 
 function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable)
     ccall((:vkCmdSetDepthBiasEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
 end
 
+function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
+end
+
 function vkCmdSetLogicOpEXT(commandBuffer, logicOp)
     ccall((:vkCmdSetLogicOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
 end
 
+function vkCmdSetLogicOpEXT(commandBuffer, logicOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
+end
+
 function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable)
     ccall((:vkCmdSetPrimitiveRestartEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
+end
+
+function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
 end
 
 struct VkPhysicalDeviceColorWriteEnableFeaturesEXT
@@ -11098,6 +12722,10 @@ const PFN_vkCmdSetColorWriteEnableEXT = Ptr{Cvoid}
 
 function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables)
     ccall((:vkCmdSetColorWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
+end
+
+function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
 end
 
 const VkAccelerationStructureKHR_T = Cvoid
@@ -11386,64 +13014,128 @@ function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAcce
     ccall((:vkCreateAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkCmdBuildAccelerationStructuresKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
     ccall((:vkCmdBuildAccelerationStructuresIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
+end
+
+function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
 end
 
 function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkBuildAccelerationStructuresKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureToMemoryKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
 end
 
+function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
+end
+
 function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyMemoryToAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
     ccall((:vkWriteAccelerationStructuresPropertiesKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
 end
 
+function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
+end
+
 function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureToMemoryKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
 end
 
+function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
+end
+
 function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyMemoryToAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo)
     ccall((:vkGetAccelerationStructureDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
 end
 
+function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
+function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
 function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility)
     ccall((:vkGetDeviceAccelerationStructureCompatibilityKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
 end
 
+function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
+end
+
 function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
     ccall((:vkGetAccelerationStructureBuildSizesKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
+end
+
+function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
 end
 
 @cenum VkShaderGroupShaderKHR::UInt32 begin
@@ -11546,24 +13238,48 @@ function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShader
     ccall((:vkCmdTraceRaysKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
 end
 
+function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingCaptureReplayShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
     ccall((:vkCmdTraceRaysIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
+end
+
+function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
 end
 
 function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader)
     ccall((:vkGetRayTracingShaderGroupStackSizeKHR, libvulkan), VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
 end
 
+function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader, fptr)
+    ccall(fptr, VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
+end
+
 function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize)
     ccall((:vkCmdSetRayTracingPipelineStackSizeKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
+end
+
+function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
 end
 
 struct VkPhysicalDeviceRayQueryFeaturesKHR
@@ -11596,8 +13312,16 @@ function vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateWaylandSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkWaylandSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkWaylandSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display)
     ccall((:vkGetPhysicalDeviceWaylandPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{wl_display}), physicalDevice, queueFamilyIndex, display)
+end
+
+function vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{wl_display}), physicalDevice, queueFamilyIndex, display)
 end
 
 const VkXcbSurfaceCreateFlagsKHR = VkFlags
@@ -11620,8 +13344,16 @@ function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXcbSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id)
     ccall((:vkGetPhysicalDeviceXcbPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
+end
+
+function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
 end
 
 const VkXlibSurfaceCreateFlagsKHR = VkFlags
@@ -11644,8 +13376,16 @@ function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXlibSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID)
     ccall((:vkGetPhysicalDeviceXlibPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
+end
+
+function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
 end
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkAcquireXlibDisplayEXT ) ( VkPhysicalDevice physicalDevice , Display * dpy , VkDisplayKHR display )
@@ -11658,8 +13398,16 @@ function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display)
     ccall((:vkAcquireXlibDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
 end
 
+function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
+end
+
 function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay)
     ccall((:vkGetRandROutputDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
+end
+
+function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
 end
 
 const VULKAN_H_ = 1

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -3200,6 +3200,29 @@ function Base.setproperty!(x::Ptr{VkClearColorValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
+
+function VkClearColorValue(float32::NTuple{4, Cfloat})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkClearColorValue(int32::NTuple{4, Int32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkClearColorValue(uint32::NTuple{4, UInt32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
 struct VkClearDepthStencilValue
     depth::Cfloat
     stencil::UInt32
@@ -3224,6 +3247,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkClearValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
+
+function VkClearValue(color::VkClearColorValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.color = color
+    ref[]
+end
+
+function VkClearValue(depthStencil::VkClearDepthStencilValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.depthStencil = depthStencil
+    ref[]
 end
 
 struct VkClearAttachment
@@ -7779,6 +7818,50 @@ function Base.setproperty!(x::Ptr{VkPerformanceCounterResultKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
+
+function VkPerformanceCounterResultKHR(int32::Int32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(int64::Int64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int64 = int64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint32::UInt32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint64::UInt64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint64 = uint64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float32::Cfloat)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float64::Cdouble)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float64 = float64
+    ref[]
+end
+
 struct VkAcquireProfilingLockInfoKHR
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8468,6 +8551,36 @@ end
 
 function Base.setproperty!(x::Ptr{VkPipelineExecutableStatisticValueKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
+
+function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.b32 = b32
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(i64::Int64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.i64 = i64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.u64 = u64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.f64 = f64
+    ref[]
 end
 
 struct VkPipelineExecutableStatisticKHR
@@ -10728,6 +10841,18 @@ function Base.setproperty!(x::Ptr{VkAccelerationStructureInstanceKHR}, f::Symbol
     unsafe_store!(getproperty(x, f), v)
 end
 
+function VkAccelerationStructureInstanceKHR(transform::VkTransformMatrixKHR, instanceCustomIndex::UInt32, mask::UInt32, instanceShaderBindingTableRecordOffset::UInt32, flags::VkGeometryInstanceFlagsKHR, accelerationStructureReference::UInt64)
+    ref = Ref{VkAccelerationStructureInstanceKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureInstanceKHR}, ref)
+    ptr.transform = transform
+    ptr.instanceCustomIndex = instanceCustomIndex
+    ptr.mask = mask
+    ptr.instanceShaderBindingTableRecordOffset = instanceShaderBindingTableRecordOffset
+    ptr.flags = flags
+    ptr.accelerationStructureReference = accelerationStructureReference
+    ref[]
+end
+
 const VkAccelerationStructureInstanceNV = VkAccelerationStructureInstanceKHR
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkCreateAccelerationStructureNV ) ( VkDevice device , const VkAccelerationStructureCreateInfoNV * pCreateInfo , const VkAllocationCallbacks * pAllocator , VkAccelerationStructureNV * pAccelerationStructure )
@@ -11284,6 +11409,43 @@ end
 
 function Base.setproperty!(x::Ptr{VkPerformanceValueDataINTEL}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
+
+function VkPerformanceValueDataINTEL(value32::UInt32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value32 = value32
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(value64::UInt64)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value64 = value64
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueFloat = valueFloat
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueBool::VkBool32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueBool = valueBool
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueString = valueString
+    ref[]
 end
 
 struct VkPerformanceValueINTEL
@@ -12779,6 +12941,22 @@ function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
+end
+
 struct VkDeviceOrHostAddressConstKHR
     data::NTuple{8, UInt8}
 end
@@ -12798,6 +12976,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressConstKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
 end
 
 struct VkAccelerationStructureBuildRangeInfoKHR
@@ -12853,6 +13047,29 @@ end
 
 function Base.setproperty!(x::Ptr{VkAccelerationStructureGeometryDataKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
+
+function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.triangles = triangles
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.aabbs = aabbs
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.instances = instances
+    ref[]
 end
 
 struct VkAccelerationStructureGeometryKHR

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -3202,24 +3202,16 @@ end
 
 const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
 
-function VkClearColorValue(float32::NTuple{4, Cfloat})
+function VkClearColorValue(val::__U_VkClearColorValue)
     ref = Ref{VkClearColorValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkClearColorValue(int32::NTuple{4, Int32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkClearColorValue(uint32::NTuple{4, UInt32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.uint32 = uint32
+    if val isa NTuple{4, Cfloat}
+        ptr.float32 = val
+    elseif val isa NTuple{4, Int32}
+        ptr.int32 = val
+    elseif val isa NTuple{4, UInt32}
+        ptr.uint32 = val
+    end
     ref[]
 end
 
@@ -3251,17 +3243,14 @@ end
 
 const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
 
-function VkClearValue(color::VkClearColorValue)
+function VkClearValue(val::__U_VkClearValue)
     ref = Ref{VkClearValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.color = color
-    ref[]
-end
-
-function VkClearValue(depthStencil::VkClearDepthStencilValue)
-    ref = Ref{VkClearValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.depthStencil = depthStencil
+    if val isa VkClearColorValue
+        ptr.color = val
+    elseif val isa VkClearDepthStencilValue
+        ptr.depthStencil = val
+    end
     ref[]
 end
 
@@ -7820,45 +7809,22 @@ end
 
 const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
 
-function VkPerformanceCounterResultKHR(int32::Int32)
+function VkPerformanceCounterResultKHR(val::__U_VkPerformanceCounterResultKHR)
     ref = Ref{VkPerformanceCounterResultKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(int64::Int64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int64 = int64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint32::UInt32)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint32 = uint32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint64::UInt64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint64 = uint64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float32::Cfloat)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float64::Cdouble)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float64 = float64
+    if val isa Int32
+        ptr.int32 = val
+    elseif val isa Int64
+        ptr.int64 = val
+    elseif val isa UInt32
+        ptr.uint32 = val
+    elseif val isa UInt64
+        ptr.uint64 = val
+    elseif val isa Cfloat
+        ptr.float32 = val
+    elseif val isa Cdouble
+        ptr.float64 = val
+    end
     ref[]
 end
 
@@ -8555,31 +8521,18 @@ end
 
 const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
 
-function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+function VkPipelineExecutableStatisticValueKHR(val::__U_VkPipelineExecutableStatisticValueKHR)
     ref = Ref{VkPipelineExecutableStatisticValueKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.b32 = b32
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(i64::Int64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.i64 = i64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.u64 = u64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.f64 = f64
+    if val isa VkBool32
+        ptr.b32 = val
+    elseif val isa Int64
+        ptr.i64 = val
+    elseif val isa UInt64
+        ptr.u64 = val
+    elseif val isa Cdouble
+        ptr.f64 = val
+    end
     ref[]
 end
 
@@ -11413,38 +11366,20 @@ end
 
 const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
 
-function VkPerformanceValueDataINTEL(value32::UInt32)
+function VkPerformanceValueDataINTEL(val::__U_VkPerformanceValueDataINTEL)
     ref = Ref{VkPerformanceValueDataINTEL}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value32 = value32
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(value64::UInt64)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value64 = value64
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueFloat = valueFloat
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueBool::VkBool32)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueBool = valueBool
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueString = valueString
+    if val isa UInt32
+        ptr.value32 = val
+    elseif val isa UInt64
+        ptr.value64 = val
+    elseif val isa Cfloat
+        ptr.valueFloat = val
+    elseif val isa VkBool32
+        ptr.valueBool = val
+    elseif val isa Ptr{Cchar}
+        ptr.valueString = val
+    end
     ref[]
 end
 
@@ -12943,17 +12878,14 @@ end
 
 const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressKHR(val::__U_VkDeviceOrHostAddressKHR)
     ref = Ref{VkDeviceOrHostAddressKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -12980,17 +12912,14 @@ end
 
 const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressConstKHR(val::__U_VkDeviceOrHostAddressConstKHR)
     ref = Ref{VkDeviceOrHostAddressConstKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressConstKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -13051,24 +12980,16 @@ end
 
 const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
 
-function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+function VkAccelerationStructureGeometryDataKHR(val::__U_VkAccelerationStructureGeometryDataKHR)
     ref = Ref{VkAccelerationStructureGeometryDataKHR}()
     ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.triangles = triangles
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.aabbs = aabbs
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.instances = instances
+    if val isa VkAccelerationStructureGeometryTrianglesDataKHR
+        ptr.triangles = val
+    elseif val isa VkAccelerationStructureGeometryAabbsDataKHR
+        ptr.aabbs = val
+    elseif val isa VkAccelerationStructureGeometryInstancesDataKHR
+        ptr.instances = val
+    end
     ref[]
 end
 

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -3184,24 +3184,16 @@ end
 
 const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
 
-function VkClearColorValue(float32::NTuple{4, Cfloat})
+function VkClearColorValue(val::__U_VkClearColorValue)
     ref = Ref{VkClearColorValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkClearColorValue(int32::NTuple{4, Int32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkClearColorValue(uint32::NTuple{4, UInt32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.uint32 = uint32
+    if val isa NTuple{4, Cfloat}
+        ptr.float32 = val
+    elseif val isa NTuple{4, Int32}
+        ptr.int32 = val
+    elseif val isa NTuple{4, UInt32}
+        ptr.uint32 = val
+    end
     ref[]
 end
 
@@ -3233,17 +3225,14 @@ end
 
 const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
 
-function VkClearValue(color::VkClearColorValue)
+function VkClearValue(val::__U_VkClearValue)
     ref = Ref{VkClearValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.color = color
-    ref[]
-end
-
-function VkClearValue(depthStencil::VkClearDepthStencilValue)
-    ref = Ref{VkClearValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.depthStencil = depthStencil
+    if val isa VkClearColorValue
+        ptr.color = val
+    elseif val isa VkClearDepthStencilValue
+        ptr.depthStencil = val
+    end
     ref[]
 end
 
@@ -7802,45 +7791,22 @@ end
 
 const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
 
-function VkPerformanceCounterResultKHR(int32::Int32)
+function VkPerformanceCounterResultKHR(val::__U_VkPerformanceCounterResultKHR)
     ref = Ref{VkPerformanceCounterResultKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(int64::Int64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int64 = int64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint32::UInt32)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint32 = uint32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint64::UInt64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint64 = uint64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float32::Cfloat)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float64::Cdouble)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float64 = float64
+    if val isa Int32
+        ptr.int32 = val
+    elseif val isa Int64
+        ptr.int64 = val
+    elseif val isa UInt32
+        ptr.uint32 = val
+    elseif val isa UInt64
+        ptr.uint64 = val
+    elseif val isa Cfloat
+        ptr.float32 = val
+    elseif val isa Cdouble
+        ptr.float64 = val
+    end
     ref[]
 end
 
@@ -8537,31 +8503,18 @@ end
 
 const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
 
-function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+function VkPipelineExecutableStatisticValueKHR(val::__U_VkPipelineExecutableStatisticValueKHR)
     ref = Ref{VkPipelineExecutableStatisticValueKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.b32 = b32
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(i64::Int64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.i64 = i64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.u64 = u64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.f64 = f64
+    if val isa VkBool32
+        ptr.b32 = val
+    elseif val isa Int64
+        ptr.i64 = val
+    elseif val isa UInt64
+        ptr.u64 = val
+    elseif val isa Cdouble
+        ptr.f64 = val
+    end
     ref[]
 end
 
@@ -11395,38 +11348,20 @@ end
 
 const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
 
-function VkPerformanceValueDataINTEL(value32::UInt32)
+function VkPerformanceValueDataINTEL(val::__U_VkPerformanceValueDataINTEL)
     ref = Ref{VkPerformanceValueDataINTEL}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value32 = value32
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(value64::UInt64)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value64 = value64
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueFloat = valueFloat
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueBool::VkBool32)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueBool = valueBool
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueString = valueString
+    if val isa UInt32
+        ptr.value32 = val
+    elseif val isa UInt64
+        ptr.value64 = val
+    elseif val isa Cfloat
+        ptr.valueFloat = val
+    elseif val isa VkBool32
+        ptr.valueBool = val
+    elseif val isa Ptr{Cchar}
+        ptr.valueString = val
+    end
     ref[]
 end
 
@@ -12925,17 +12860,14 @@ end
 
 const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressKHR(val::__U_VkDeviceOrHostAddressKHR)
     ref = Ref{VkDeviceOrHostAddressKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -12962,17 +12894,14 @@ end
 
 const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressConstKHR(val::__U_VkDeviceOrHostAddressConstKHR)
     ref = Ref{VkDeviceOrHostAddressConstKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressConstKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -13033,24 +12962,16 @@ end
 
 const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
 
-function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+function VkAccelerationStructureGeometryDataKHR(val::__U_VkAccelerationStructureGeometryDataKHR)
     ref = Ref{VkAccelerationStructureGeometryDataKHR}()
     ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.triangles = triangles
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.aabbs = aabbs
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.instances = instances
+    if val isa VkAccelerationStructureGeometryTrianglesDataKHR
+        ptr.triangles = val
+    elseif val isa VkAccelerationStructureGeometryAabbsDataKHR
+        ptr.aabbs = val
+    elseif val isa VkAccelerationStructureGeometryInstancesDataKHR
+        ptr.instances = val
+    end
     ref[]
 end
 

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -3182,6 +3182,29 @@ function Base.setproperty!(x::Ptr{VkClearColorValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
+
+function VkClearColorValue(float32::NTuple{4, Cfloat})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkClearColorValue(int32::NTuple{4, Int32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkClearColorValue(uint32::NTuple{4, UInt32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
 struct VkClearDepthStencilValue
     depth::Cfloat
     stencil::UInt32
@@ -3206,6 +3229,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkClearValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
+
+function VkClearValue(color::VkClearColorValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.color = color
+    ref[]
+end
+
+function VkClearValue(depthStencil::VkClearDepthStencilValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.depthStencil = depthStencil
+    ref[]
 end
 
 struct VkClearAttachment
@@ -7761,6 +7800,50 @@ function Base.setproperty!(x::Ptr{VkPerformanceCounterResultKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
+
+function VkPerformanceCounterResultKHR(int32::Int32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(int64::Int64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int64 = int64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint32::UInt32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint64::UInt64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint64 = uint64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float32::Cfloat)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float64::Cdouble)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float64 = float64
+    ref[]
+end
+
 struct VkAcquireProfilingLockInfoKHR
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8450,6 +8533,36 @@ end
 
 function Base.setproperty!(x::Ptr{VkPipelineExecutableStatisticValueKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
+
+function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.b32 = b32
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(i64::Int64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.i64 = i64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.u64 = u64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.f64 = f64
+    ref[]
 end
 
 struct VkPipelineExecutableStatisticKHR
@@ -10710,6 +10823,18 @@ function Base.setproperty!(x::Ptr{VkAccelerationStructureInstanceKHR}, f::Symbol
     unsafe_store!(getproperty(x, f), v)
 end
 
+function VkAccelerationStructureInstanceKHR(transform::VkTransformMatrixKHR, instanceCustomIndex::UInt32, mask::UInt32, instanceShaderBindingTableRecordOffset::UInt32, flags::VkGeometryInstanceFlagsKHR, accelerationStructureReference::UInt64)
+    ref = Ref{VkAccelerationStructureInstanceKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureInstanceKHR}, ref)
+    ptr.transform = transform
+    ptr.instanceCustomIndex = instanceCustomIndex
+    ptr.mask = mask
+    ptr.instanceShaderBindingTableRecordOffset = instanceShaderBindingTableRecordOffset
+    ptr.flags = flags
+    ptr.accelerationStructureReference = accelerationStructureReference
+    ref[]
+end
+
 const VkAccelerationStructureInstanceNV = VkAccelerationStructureInstanceKHR
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkCreateAccelerationStructureNV ) ( VkDevice device , const VkAccelerationStructureCreateInfoNV * pCreateInfo , const VkAllocationCallbacks * pAllocator , VkAccelerationStructureNV * pAccelerationStructure )
@@ -11266,6 +11391,43 @@ end
 
 function Base.setproperty!(x::Ptr{VkPerformanceValueDataINTEL}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
+
+function VkPerformanceValueDataINTEL(value32::UInt32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value32 = value32
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(value64::UInt64)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value64 = value64
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueFloat = valueFloat
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueBool::VkBool32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueBool = valueBool
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueString = valueString
+    ref[]
 end
 
 struct VkPerformanceValueINTEL
@@ -12761,6 +12923,22 @@ function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
+end
+
 struct VkDeviceOrHostAddressConstKHR
     data::NTuple{8, UInt8}
 end
@@ -12780,6 +12958,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressConstKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
 end
 
 struct VkAccelerationStructureBuildRangeInfoKHR
@@ -12835,6 +13029,29 @@ end
 
 function Base.setproperty!(x::Ptr{VkAccelerationStructureGeometryDataKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
+
+function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.triangles = triangles
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.aabbs = aabbs
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.instances = instances
+    ref[]
 end
 
 struct VkAccelerationStructureGeometryKHR

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -3668,548 +3668,1096 @@ function vkCreateInstance(pCreateInfo, pAllocator, pInstance)
     ccall((:vkCreateInstance, libvulkan), VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
 end
 
+function vkCreateInstance(pCreateInfo, pAllocator, pInstance, fptr)
+    ccall(fptr, VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
+end
+
 function vkDestroyInstance(instance, pAllocator)
     ccall((:vkDestroyInstance, libvulkan), Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
+end
+
+function vkDestroyInstance(instance, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
 end
 
 function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices)
     ccall((:vkEnumeratePhysicalDevices, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
 end
 
+function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
+end
+
 function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
+end
+
+function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
 end
 
 function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceProperties(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
 end
 
+function vkGetPhysicalDeviceProperties(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
+end
+
 function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
+function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
 function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetInstanceProcAddr(instance, pName)
     ccall((:vkGetInstanceProcAddr, libvulkan), PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
+end
+
+function vkGetInstanceProcAddr(instance, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
 end
 
 function vkGetDeviceProcAddr(device, pName)
     ccall((:vkGetDeviceProcAddr, libvulkan), PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
 end
 
+function vkGetDeviceProcAddr(device, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
+end
+
 function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice)
     ccall((:vkCreateDevice, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
+end
+
+function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
 end
 
 function vkDestroyDevice(device, pAllocator)
     ccall((:vkDestroyDevice, libvulkan), Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
 end
 
+function vkDestroyDevice(device, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
+end
+
 function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceExtensionProperties, libvulkan), VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceExtensionProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
+end
+
 function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceLayerProperties, libvulkan), VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceLayerProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue)
     ccall((:vkGetDeviceQueue, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
+end
+
+function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
 end
 
 function vkQueueSubmit(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
+function vkQueueSubmit(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
 function vkQueueWaitIdle(queue)
     ccall((:vkQueueWaitIdle, libvulkan), VkResult, (VkQueue,), queue)
+end
+
+function vkQueueWaitIdle(queue, fptr)
+    ccall(fptr, VkResult, (VkQueue,), queue)
 end
 
 function vkDeviceWaitIdle(device)
     ccall((:vkDeviceWaitIdle, libvulkan), VkResult, (VkDevice,), device)
 end
 
+function vkDeviceWaitIdle(device, fptr)
+    ccall(fptr, VkResult, (VkDevice,), device)
+end
+
 function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory)
     ccall((:vkAllocateMemory, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
+end
+
+function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
 end
 
 function vkFreeMemory(device, memory, pAllocator)
     ccall((:vkFreeMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
 end
 
+function vkFreeMemory(device, memory, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
+end
+
 function vkMapMemory(device, memory, offset, size, flags, ppData)
     ccall((:vkMapMemory, libvulkan), VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
+end
+
+function vkMapMemory(device, memory, offset, size, flags, ppData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
 end
 
 function vkUnmapMemory(device, memory)
     ccall((:vkUnmapMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory), device, memory)
 end
 
+function vkUnmapMemory(device, memory, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory), device, memory)
+end
+
 function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkFlushMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
+function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
 function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkInvalidateMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
+function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
 function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes)
     ccall((:vkGetDeviceMemoryCommitment, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
+end
+
+function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
 end
 
 function vkBindBufferMemory(device, buffer, memory, memoryOffset)
     ccall((:vkBindBufferMemory, libvulkan), VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
 end
 
+function vkBindBufferMemory(device, buffer, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
+end
+
 function vkBindImageMemory(device, image, memory, memoryOffset)
     ccall((:vkBindImageMemory, libvulkan), VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
+end
+
+function vkBindImageMemory(device, image, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
 end
 
 function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
+end
+
 function vkGetImageMemoryRequirements(device, image, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements(device, image, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
 end
 
 function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
+function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
 end
 
 function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence)
     ccall((:vkQueueBindSparse, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
 end
 
+function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
+end
+
 function vkCreateFence(device, pCreateInfo, pAllocator, pFence)
     ccall((:vkCreateFence, libvulkan), VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
+end
+
+function vkCreateFence(device, pCreateInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
 end
 
 function vkDestroyFence(device, fence, pAllocator)
     ccall((:vkDestroyFence, libvulkan), Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
 end
 
+function vkDestroyFence(device, fence, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
+end
+
 function vkResetFences(device, fenceCount, pFences)
     ccall((:vkResetFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
+end
+
+function vkResetFences(device, fenceCount, pFences, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
 end
 
 function vkGetFenceStatus(device, fence)
     ccall((:vkGetFenceStatus, libvulkan), VkResult, (VkDevice, VkFence), device, fence)
 end
 
+function vkGetFenceStatus(device, fence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkFence), device, fence)
+end
+
 function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout)
     ccall((:vkWaitForFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
+end
+
+function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
 end
 
 function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore)
     ccall((:vkCreateSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
 end
 
+function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
+end
+
 function vkDestroySemaphore(device, semaphore, pAllocator)
     ccall((:vkDestroySemaphore, libvulkan), Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
+end
+
+function vkDestroySemaphore(device, semaphore, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
 end
 
 function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent)
     ccall((:vkCreateEvent, libvulkan), VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
 end
 
+function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
+end
+
 function vkDestroyEvent(device, event, pAllocator)
     ccall((:vkDestroyEvent, libvulkan), Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
+end
+
+function vkDestroyEvent(device, event, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
 end
 
 function vkGetEventStatus(device, event)
     ccall((:vkGetEventStatus, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkGetEventStatus(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkSetEvent(device, event)
     ccall((:vkSetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
+end
+
+function vkSetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
 end
 
 function vkResetEvent(device, event)
     ccall((:vkResetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkResetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool)
     ccall((:vkCreateQueryPool, libvulkan), VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
+end
+
+function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
 end
 
 function vkDestroyQueryPool(device, queryPool, pAllocator)
     ccall((:vkDestroyQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
 end
 
+function vkDestroyQueryPool(device, queryPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
+end
+
 function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
     ccall((:vkGetQueryPoolResults, libvulkan), VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
+end
+
+function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
 end
 
 function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer)
     ccall((:vkCreateBuffer, libvulkan), VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
 end
 
+function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
+end
+
 function vkDestroyBuffer(device, buffer, pAllocator)
     ccall((:vkDestroyBuffer, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
+end
+
+function vkDestroyBuffer(device, buffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
 end
 
 function vkCreateBufferView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateBufferView, libvulkan), VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
 end
 
+function vkCreateBufferView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
+end
+
 function vkDestroyBufferView(device, bufferView, pAllocator)
     ccall((:vkDestroyBufferView, libvulkan), Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
+end
+
+function vkDestroyBufferView(device, bufferView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
 end
 
 function vkCreateImage(device, pCreateInfo, pAllocator, pImage)
     ccall((:vkCreateImage, libvulkan), VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
 end
 
+function vkCreateImage(device, pCreateInfo, pAllocator, pImage, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
+end
+
 function vkDestroyImage(device, image, pAllocator)
     ccall((:vkDestroyImage, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
+end
+
+function vkDestroyImage(device, image, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
 end
 
 function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout)
     ccall((:vkGetImageSubresourceLayout, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
 end
 
+function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
+end
+
 function vkCreateImageView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateImageView, libvulkan), VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
+end
+
+function vkCreateImageView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
 end
 
 function vkDestroyImageView(device, imageView, pAllocator)
     ccall((:vkDestroyImageView, libvulkan), Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
 end
 
+function vkDestroyImageView(device, imageView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
+end
+
 function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule)
     ccall((:vkCreateShaderModule, libvulkan), VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
+end
+
+function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
 end
 
 function vkDestroyShaderModule(device, shaderModule, pAllocator)
     ccall((:vkDestroyShaderModule, libvulkan), Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
 end
 
+function vkDestroyShaderModule(device, shaderModule, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
+end
+
 function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache)
     ccall((:vkCreatePipelineCache, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
+end
+
+function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
 end
 
 function vkDestroyPipelineCache(device, pipelineCache, pAllocator)
     ccall((:vkDestroyPipelineCache, libvulkan), Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
 end
 
+function vkDestroyPipelineCache(device, pipelineCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
+end
+
 function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData)
     ccall((:vkGetPipelineCacheData, libvulkan), VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
+end
+
+function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
 end
 
 function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergePipelineCaches, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateGraphicsPipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateComputePipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
+function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
 function vkDestroyPipeline(device, pipeline, pAllocator)
     ccall((:vkDestroyPipeline, libvulkan), Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
+end
+
+function vkDestroyPipeline(device, pipeline, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
 end
 
 function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout)
     ccall((:vkCreatePipelineLayout, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
 end
 
+function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
+end
+
 function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator)
     ccall((:vkDestroyPipelineLayout, libvulkan), Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
+end
+
+function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
 end
 
 function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler)
     ccall((:vkCreateSampler, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
 end
 
+function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
+end
+
 function vkDestroySampler(device, sampler, pAllocator)
     ccall((:vkDestroySampler, libvulkan), Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
+end
+
+function vkDestroySampler(device, sampler, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
 end
 
 function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout)
     ccall((:vkCreateDescriptorSetLayout, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
 end
 
+function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
+end
+
 function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator)
     ccall((:vkDestroyDescriptorSetLayout, libvulkan), Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
+end
+
+function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
 end
 
 function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool)
     ccall((:vkCreateDescriptorPool, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
 end
 
+function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
+end
+
 function vkDestroyDescriptorPool(device, descriptorPool, pAllocator)
     ccall((:vkDestroyDescriptorPool, libvulkan), Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
+end
+
+function vkDestroyDescriptorPool(device, descriptorPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
 end
 
 function vkResetDescriptorPool(device, descriptorPool, flags)
     ccall((:vkResetDescriptorPool, libvulkan), VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
 end
 
+function vkResetDescriptorPool(device, descriptorPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
+end
+
 function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets)
     ccall((:vkAllocateDescriptorSets, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
+end
+
+function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
 end
 
 function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets)
     ccall((:vkFreeDescriptorSets, libvulkan), VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
 end
 
+function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
+end
+
 function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
     ccall((:vkUpdateDescriptorSets, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
+end
+
+function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
 end
 
 function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer)
     ccall((:vkCreateFramebuffer, libvulkan), VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
 end
 
+function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
+end
+
 function vkDestroyFramebuffer(device, framebuffer, pAllocator)
     ccall((:vkDestroyFramebuffer, libvulkan), Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
+end
+
+function vkDestroyFramebuffer(device, framebuffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
 end
 
 function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkDestroyRenderPass(device, renderPass, pAllocator)
     ccall((:vkDestroyRenderPass, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
+end
+
+function vkDestroyRenderPass(device, renderPass, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
 end
 
 function vkGetRenderAreaGranularity(device, renderPass, pGranularity)
     ccall((:vkGetRenderAreaGranularity, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
 end
 
+function vkGetRenderAreaGranularity(device, renderPass, pGranularity, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
+end
+
 function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool)
     ccall((:vkCreateCommandPool, libvulkan), VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
+end
+
+function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
 end
 
 function vkDestroyCommandPool(device, commandPool, pAllocator)
     ccall((:vkDestroyCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
 end
 
+function vkDestroyCommandPool(device, commandPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
+end
+
 function vkResetCommandPool(device, commandPool, flags)
     ccall((:vkResetCommandPool, libvulkan), VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
+end
+
+function vkResetCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
 end
 
 function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers)
     ccall((:vkAllocateCommandBuffers, libvulkan), VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
 end
 
+function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
+end
+
 function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers)
     ccall((:vkFreeCommandBuffers, libvulkan), Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
+end
+
+function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
 end
 
 function vkBeginCommandBuffer(commandBuffer, pBeginInfo)
     ccall((:vkBeginCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
 end
 
+function vkBeginCommandBuffer(commandBuffer, pBeginInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
+end
+
 function vkEndCommandBuffer(commandBuffer)
     ccall((:vkEndCommandBuffer, libvulkan), VkResult, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkEndCommandBuffer(commandBuffer, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer,), commandBuffer)
 end
 
 function vkResetCommandBuffer(commandBuffer, flags)
     ccall((:vkResetCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
 end
 
+function vkResetCommandBuffer(commandBuffer, flags, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
+end
+
 function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline)
     ccall((:vkCmdBindPipeline, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
+end
+
+function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
 end
 
 function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports)
     ccall((:vkCmdSetViewport, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
 end
 
+function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
+end
+
 function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors)
     ccall((:vkCmdSetScissor, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
+end
+
+function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
 end
 
 function vkCmdSetLineWidth(commandBuffer, lineWidth)
     ccall((:vkCmdSetLineWidth, libvulkan), Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
 end
 
+function vkCmdSetLineWidth(commandBuffer, lineWidth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
+end
+
 function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
     ccall((:vkCmdSetDepthBias, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
+end
+
+function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
 end
 
 function vkCmdSetBlendConstants(commandBuffer, blendConstants)
     ccall((:vkCmdSetBlendConstants, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
 end
 
+function vkCmdSetBlendConstants(commandBuffer, blendConstants, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
+end
+
 function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds)
     ccall((:vkCmdSetDepthBounds, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
+end
+
+function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
 end
 
 function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask)
     ccall((:vkCmdSetStencilCompareMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
 end
 
+function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
+end
+
 function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask)
     ccall((:vkCmdSetStencilWriteMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
+end
+
+function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
 end
 
 function vkCmdSetStencilReference(commandBuffer, faceMask, reference)
     ccall((:vkCmdSetStencilReference, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
 end
 
+function vkCmdSetStencilReference(commandBuffer, faceMask, reference, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
+end
+
 function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
     ccall((:vkCmdBindDescriptorSets, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
+end
+
+function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
 end
 
 function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType)
     ccall((:vkCmdBindIndexBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
 end
 
+function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
+end
+
 function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
     ccall((:vkCmdBindVertexBuffers, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
+end
+
+function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
 end
 
 function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
     ccall((:vkCmdDraw, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
 end
 
+function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
+end
+
 function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
     ccall((:vkCmdDrawIndexed, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
+end
+
+function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
 end
 
 function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndexedIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
 function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatch, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
 end
 
+function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
+end
+
 function vkCmdDispatchIndirect(commandBuffer, buffer, offset)
     ccall((:vkCmdDispatchIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
+end
+
+function vkCmdDispatchIndirect(commandBuffer, buffer, offset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
 end
 
 function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
     ccall((:vkCmdBlitImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
 end
 
+function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
+end
+
 function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyBufferToImage, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyImageToBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData)
     ccall((:vkCmdUpdateBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
+end
+
+function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
 end
 
 function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data)
     ccall((:vkCmdFillBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
 end
 
+function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
+end
+
 function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
     ccall((:vkCmdClearColorImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
+end
+
+function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
 end
 
 function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
     ccall((:vkCmdClearDepthStencilImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
 end
 
+function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
+end
+
 function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
     ccall((:vkCmdClearAttachments, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
+end
+
+function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
 end
 
 function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdResolveImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
+function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
 function vkCmdSetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdSetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
+function vkCmdSetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
 function vkCmdResetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
+function vkCmdResetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
 function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdWaitEvents, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
+function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
 function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdPipelineBarrier, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
+function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
 function vkCmdBeginQuery(commandBuffer, queryPool, query, flags)
     ccall((:vkCmdBeginQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
+end
+
+function vkCmdBeginQuery(commandBuffer, queryPool, query, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
 end
 
 function vkCmdEndQuery(commandBuffer, queryPool, query)
     ccall((:vkCmdEndQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
 end
 
+function vkCmdEndQuery(commandBuffer, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
+end
+
 function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount)
     ccall((:vkCmdResetQueryPool, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
+end
+
+function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
 end
 
 function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query)
     ccall((:vkCmdWriteTimestamp, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
+end
+
 function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
     ccall((:vkCmdCopyQueryPoolResults, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
+end
+
+function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
 end
 
 function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues)
     ccall((:vkCmdPushConstants, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
 end
 
+function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
+end
+
 function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents)
     ccall((:vkCmdBeginRenderPass, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
+end
+
+function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
 end
 
 function vkCmdNextSubpass(commandBuffer, contents)
     ccall((:vkCmdNextSubpass, libvulkan), Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
 end
 
+function vkCmdNextSubpass(commandBuffer, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
+end
+
 function vkCmdEndRenderPass(commandBuffer)
     ccall((:vkCmdEndRenderPass, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndRenderPass(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers)
     ccall((:vkCmdExecuteCommands, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
+end
+
+function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
 end
 
 const VkSamplerYcbcrConversion_T = Cvoid
@@ -4999,112 +5547,224 @@ function vkEnumerateInstanceVersion(pApiVersion)
     ccall((:vkEnumerateInstanceVersion, libvulkan), VkResult, (Ptr{UInt32},), pApiVersion)
 end
 
+function vkEnumerateInstanceVersion(pApiVersion, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32},), pApiVersion)
+end
+
 function vkBindBufferMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindBufferMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 function vkBindImageMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindImageMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
     ccall((:vkGetDeviceGroupPeerMemoryFeatures, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
+function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
 function vkCmdSetDeviceMask(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMask, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMask(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBase, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroups, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
+function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
 function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
 function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
+function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
 function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
 function vkTrimCommandPool(device, commandPool, flags)
     ccall((:vkTrimCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
+function vkTrimCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
 function vkGetDeviceQueue2(device, pQueueInfo, pQueue)
     ccall((:vkGetDeviceQueue2, libvulkan), Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
 end
 
+function vkGetDeviceQueue2(device, pQueueInfo, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
+end
+
 function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion)
     ccall((:vkCreateSamplerYcbcrConversion, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
+function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
 function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversion, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
+function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
 function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
     ccall((:vkCreateDescriptorUpdateTemplate, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
+function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
 function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
+function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
 function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFenceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphoreProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
+function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
 function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupport, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
+function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
 @cenum VkDriverId::UInt32 begin
@@ -5804,52 +6464,104 @@ function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, coun
     ccall((:vkCmdDrawIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 function vkResetQueryPool(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
+function vkResetQueryPool(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
 function vkGetSemaphoreCounterValue(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValue, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
+function vkGetSemaphoreCounterValue(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
 function vkWaitSemaphores(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphores, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphores(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphore(device, pSignalInfo)
     ccall((:vkSignalSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphore(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 function vkGetBufferDeviceAddress(device, pInfo)
     ccall((:vkGetBufferDeviceAddress, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddress(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkSurfaceKHR_T = Cvoid
@@ -5950,20 +6662,40 @@ function vkDestroySurfaceKHR(instance, surface, pAllocator)
     ccall((:vkDestroySurfaceKHR, libvulkan), Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
 end
 
+function vkDestroySurfaceKHR(instance, surface, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
+end
+
 function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported)
     ccall((:vkGetPhysicalDeviceSurfaceSupportKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
+end
+
+function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
 end
 
 function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormatsKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
 end
 
+function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
+end
+
 function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes)
     ccall((:vkGetPhysicalDeviceSurfacePresentModesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
+end
+
+function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
 end
 
 const VkSwapchainKHR_T = Cvoid
@@ -6096,36 +6828,72 @@ function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain)
     ccall((:vkCreateSwapchainKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
 end
 
+function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
+end
+
 function vkDestroySwapchainKHR(device, swapchain, pAllocator)
     ccall((:vkDestroySwapchainKHR, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
+end
+
+function vkDestroySwapchainKHR(device, swapchain, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
 end
 
 function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages)
     ccall((:vkGetSwapchainImagesKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
 end
 
+function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
+end
+
 function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex)
     ccall((:vkAcquireNextImageKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
+end
+
+function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
 end
 
 function vkQueuePresentKHR(queue, pPresentInfo)
     ccall((:vkQueuePresentKHR, libvulkan), VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
 end
 
+function vkQueuePresentKHR(queue, pPresentInfo, fptr)
+    ccall(fptr, VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
+end
+
 function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities)
     ccall((:vkGetDeviceGroupPresentCapabilitiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
+end
+
+function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
 end
 
 function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes)
     ccall((:vkGetDeviceGroupSurfacePresentModesKHR, libvulkan), VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
 end
 
+function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
+end
+
 function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects)
     ccall((:vkGetPhysicalDevicePresentRectanglesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
 end
 
+function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
+end
+
 function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex)
     ccall((:vkAcquireNextImage2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
+end
+
+function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
 end
 
 const VkDisplayKHR_T = Cvoid
@@ -6232,28 +7000,56 @@ function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount,
     ccall((:vkGetPhysicalDeviceDisplayPropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlanePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays)
     ccall((:vkGetDisplayPlaneSupportedDisplaysKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
 end
 
+function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
+end
+
 function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
+function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
 function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode)
     ccall((:vkCreateDisplayModeKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
 end
 
+function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
+end
+
 function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
 end
 
+function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
+end
+
 function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateDisplayPlaneSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
+function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
 struct VkDisplayPresentInfoKHR
@@ -6269,6 +7065,10 @@ const PFN_vkCreateSharedSwapchainsKHR = Ptr{Cvoid}
 
 function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
     ccall((:vkCreateSharedSwapchainsKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
+end
+
+function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
 end
 
 const VkRenderPassMultiviewCreateInfoKHR = VkRenderPassMultiviewCreateInfo
@@ -6320,28 +7120,56 @@ function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
 const VkPeerMemoryFeatureFlagsKHR = VkPeerMemoryFeatureFlags
@@ -6379,12 +7207,24 @@ function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceInd
     ccall((:vkGetDeviceGroupPeerMemoryFeaturesKHR, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
+function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
 function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMaskKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBaseKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 const VkCommandPoolTrimFlagsKHR = VkCommandPoolTrimFlags
@@ -6396,6 +7236,10 @@ function vkTrimCommandPoolKHR(device, commandPool, flags)
     ccall((:vkTrimCommandPoolKHR, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
+function vkTrimCommandPoolKHR(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
 const VkPhysicalDeviceGroupPropertiesKHR = VkPhysicalDeviceGroupProperties
 
 const VkDeviceGroupDeviceCreateInfoKHR = VkDeviceGroupDeviceCreateInfo
@@ -6405,6 +7249,10 @@ const PFN_vkEnumeratePhysicalDeviceGroupsKHR = Ptr{Cvoid}
 
 function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroupsKHR, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
+function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
 const VkExternalMemoryHandleTypeFlagsKHR = VkExternalMemoryHandleTypeFlags
@@ -6432,6 +7280,10 @@ const PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferPropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
+function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
 const VkExternalMemoryImageCreateInfoKHR = VkExternalMemoryImageCreateInfo
@@ -6470,8 +7322,16 @@ function vkGetMemoryFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetMemoryFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
+function vkGetMemoryFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
 function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties)
     ccall((:vkGetMemoryFdPropertiesKHR, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
+end
+
+function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
 end
 
 const VkExternalSemaphoreHandleTypeFlagsKHR = VkExternalSemaphoreHandleTypeFlags
@@ -6491,6 +7351,10 @@ const PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphorePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
+function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
 const VkSemaphoreImportFlagsKHR = VkSemaphoreImportFlags
@@ -6525,8 +7389,16 @@ function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo)
     ccall((:vkImportSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
 end
 
+function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
+end
+
 function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 struct VkPhysicalDevicePushDescriptorPropertiesKHR
@@ -6545,8 +7417,16 @@ function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set
     ccall((:vkCmdPushDescriptorSetKHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
 end
 
+function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
+end
+
 function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData)
     ccall((:vkCmdPushDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
+end
+
+function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
 end
 
 const VkPhysicalDeviceShaderFloat16Int8FeaturesKHR = VkPhysicalDeviceShaderFloat16Int8Features
@@ -6596,12 +7476,24 @@ function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pD
     ccall((:vkCreateDescriptorUpdateTemplateKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
+function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
 function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 const VkPhysicalDeviceImagelessFramebufferFeaturesKHR = VkPhysicalDeviceImagelessFramebufferFeatures
@@ -6642,16 +7534,32 @@ function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 struct VkSharedPresentSurfaceCapabilitiesKHR
@@ -6665,6 +7573,10 @@ const PFN_vkGetSwapchainStatusKHR = Ptr{Cvoid}
 
 function vkGetSwapchainStatusKHR(device, swapchain)
     ccall((:vkGetSwapchainStatusKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
+end
+
+function vkGetSwapchainStatusKHR(device, swapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
 end
 
 const VkExternalFenceHandleTypeFlagsKHR = VkExternalFenceHandleTypeFlags
@@ -6684,6 +7596,10 @@ const PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFencePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 const VkFenceImportFlagsKHR = VkFenceImportFlags
@@ -6718,8 +7634,16 @@ function vkImportFenceFdKHR(device, pImportFenceFdInfo)
     ccall((:vkImportFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
 end
 
+function vkImportFenceFdKHR(device, pImportFenceFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
+end
+
 function vkGetFenceFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetFenceFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 @cenum VkPerformanceCounterUnitKHR::UInt32 begin
@@ -6866,16 +7790,32 @@ function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physica
     ccall((:vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
 end
 
+function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
+end
+
 function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
     ccall((:vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
+end
+
+function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
 end
 
 function vkAcquireProfilingLockKHR(device, pInfo)
     ccall((:vkAcquireProfilingLockKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
 end
 
+function vkAcquireProfilingLockKHR(device, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
+end
+
 function vkReleaseProfilingLockKHR(device)
     ccall((:vkReleaseProfilingLockKHR, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkReleaseProfilingLockKHR(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 const VkPointClippingBehaviorKHR = VkPointClippingBehavior
@@ -6920,8 +7860,16 @@ function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormats2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
+end
+
+function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
 end
 
 const VkPhysicalDeviceVariablePointerFeaturesKHR = VkPhysicalDeviceVariablePointersFeatures
@@ -6975,16 +7923,32 @@ function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount
     ccall((:vkGetPhysicalDeviceDisplayProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlaneProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModeProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
+function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
 function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
+end
+
+function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
 end
 
 const VkMemoryDedicatedRequirementsKHR = VkMemoryDedicatedRequirements
@@ -7014,12 +7978,24 @@ function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 const VkImageFormatListCreateInfoKHR = VkImageFormatListCreateInfo
@@ -7054,8 +8030,16 @@ function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcb
     ccall((:vkCreateSamplerYcbcrConversionKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
+function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
 function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversionKHR, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
+function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
 const VkBindBufferMemoryInfoKHR = VkBindBufferMemoryInfo
@@ -7072,8 +8056,16 @@ function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 const VkPhysicalDeviceMaintenance3PropertiesKHR = VkPhysicalDeviceMaintenance3Properties
@@ -7087,6 +8079,10 @@ function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupportKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
+function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountKHR ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
 const PFN_vkCmdDrawIndirectCountKHR = Ptr{Cvoid}
 
@@ -7097,8 +8093,16 @@ function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 const VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR = VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures
@@ -7163,12 +8167,24 @@ function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValueKHR, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
+function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
 function vkWaitSemaphoresKHR(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphoresKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphoresKHR(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphoreKHR(device, pSignalInfo)
     ccall((:vkSignalSemaphoreKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphoreKHR(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR = VkPhysicalDeviceVulkanMemoryModelFeatures
@@ -7249,8 +8265,16 @@ function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentSha
     ccall((:vkGetPhysicalDeviceFragmentShadingRatesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
 end
 
+function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
+end
+
 function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps)
     ccall((:vkCmdSetFragmentShadingRateKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
+end
+
+function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
 end
 
 struct VkSurfaceProtectedCapabilitiesKHR
@@ -7290,12 +8314,24 @@ function vkGetBufferDeviceAddressKHR(device, pInfo)
     ccall((:vkGetBufferDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkDeferredOperationKHR_T = Cvoid
@@ -7321,20 +8357,40 @@ function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation)
     ccall((:vkCreateDeferredOperationKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
 end
 
+function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
+end
+
 function vkDestroyDeferredOperationKHR(device, operation, pAllocator)
     ccall((:vkDestroyDeferredOperationKHR, libvulkan), Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
+end
+
+function vkDestroyDeferredOperationKHR(device, operation, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
 end
 
 function vkGetDeferredOperationMaxConcurrencyKHR(device, operation)
     ccall((:vkGetDeferredOperationMaxConcurrencyKHR, libvulkan), UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationMaxConcurrencyKHR(device, operation, fptr)
+    ccall(fptr, UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkGetDeferredOperationResultKHR(device, operation)
     ccall((:vkGetDeferredOperationResultKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationResultKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkDeferredOperationJoinKHR(device, operation)
     ccall((:vkDeferredOperationJoinKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
+function vkDeferredOperationJoinKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
 @cenum VkPipelineExecutableStatisticFormatKHR::UInt32 begin
@@ -7428,12 +8484,24 @@ function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutable
     ccall((:vkGetPipelineExecutablePropertiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
 end
 
+function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutableCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
+end
+
 function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics)
     ccall((:vkGetPipelineExecutableStatisticsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
 end
 
+function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
+end
+
 function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
     ccall((:vkGetPipelineExecutableInternalRepresentationsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
+end
+
+function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
 end
 
 struct VkPipelineLibraryCreateInfoKHR
@@ -7585,32 +8653,64 @@ function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo)
     ccall((:vkCmdSetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
 end
 
+function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
+end
+
 function vkCmdResetEvent2KHR(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
+end
+
+function vkCmdResetEvent2KHR(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
 end
 
 function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos)
     ccall((:vkCmdWaitEvents2KHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
 end
 
+function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
+end
+
 function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo)
     ccall((:vkCmdPipelineBarrier2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
+end
+
+function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
 end
 
 function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query)
     ccall((:vkCmdWriteTimestamp2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
+end
+
 function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit2KHR, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
+function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
 function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarker2AMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
 end
 
+function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
+end
+
 function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointData2NV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR
@@ -7761,24 +8861,48 @@ function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo)
     ccall((:vkCmdCopyBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
 end
 
+function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
+end
+
 function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo)
     ccall((:vkCmdCopyImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
+end
+
+function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
 end
 
 function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo)
     ccall((:vkCmdCopyBufferToImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
 end
 
+function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
+end
+
 function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo)
     ccall((:vkCmdCopyImageToBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
+end
+
+function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
 end
 
 function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo)
     ccall((:vkCmdBlitImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
 end
 
+function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
+end
+
 function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo)
     ccall((:vkCmdResolveImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
+end
+
+function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
 end
 
 const VkDebugReportCallbackEXT_T = Cvoid
@@ -7864,12 +8988,24 @@ function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCall
     ccall((:vkCreateDebugReportCallbackEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
 end
 
+function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
+end
+
 function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator)
     ccall((:vkDestroyDebugReportCallbackEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
 end
 
+function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
+end
+
 function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
     ccall((:vkDebugReportMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
+end
+
+function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
 end
 
 @cenum VkRasterizationOrderAMD::UInt32 begin
@@ -7928,20 +9064,40 @@ function vkDebugMarkerSetObjectTagEXT(device, pTagInfo)
     ccall((:vkDebugMarkerSetObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
 end
 
+function vkDebugMarkerSetObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
+end
+
 function vkDebugMarkerSetObjectNameEXT(device, pNameInfo)
     ccall((:vkDebugMarkerSetObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
+end
+
+function vkDebugMarkerSetObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
 end
 
 function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerBeginEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdDebugMarkerEndEXT(commandBuffer)
     ccall((:vkCmdDebugMarkerEndEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdDebugMarkerEndEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerInsertEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
 struct VkDedicatedAllocationImageCreateInfoNV
@@ -8016,24 +9172,48 @@ function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindi
     ccall((:vkCmdBindTransformFeedbackBuffersEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
 end
 
+function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
+end
+
 function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdBeginTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
+function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
 function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdEndTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
+function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
 function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index)
     ccall((:vkCmdBeginQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
+end
+
+function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
 end
 
 function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index)
     ccall((:vkCmdEndQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
 end
 
+function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
+end
+
 function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
     ccall((:vkCmdDrawIndirectByteCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
+end
+
+function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
 end
 
 struct VkImageViewHandleInfoNVX
@@ -8061,8 +9241,16 @@ function vkGetImageViewHandleNVX(device, pInfo)
     ccall((:vkGetImageViewHandleNVX, libvulkan), UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
 end
 
+function vkGetImageViewHandleNVX(device, pInfo, fptr)
+    ccall(fptr, UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
+end
+
 function vkGetImageViewAddressNVX(device, imageView, pProperties)
     ccall((:vkGetImageViewAddressNVX, libvulkan), VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
+end
+
+function vkGetImageViewAddressNVX(device, imageView, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
 end
 
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountAMD ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
@@ -8075,8 +9263,16 @@ function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkTextureLODGatherFormatPropertiesAMD
@@ -8117,6 +9313,10 @@ function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, 
     ccall((:vkGetShaderInfoAMD, libvulkan), VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
 end
 
+function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
+end
+
 struct VkPhysicalDeviceCornerSampledImageFeaturesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8154,6 +9354,10 @@ const PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
     ccall((:vkGetPhysicalDeviceExternalImageFormatPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
 end
 
 struct VkExternalMemoryImageCreateInfoNV
@@ -8237,8 +9441,16 @@ function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingB
     ccall((:vkCmdBeginConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
 end
 
+function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
+end
+
 function vkCmdEndConditionalRenderingEXT(commandBuffer)
     ccall((:vkCmdEndConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkCmdEndConditionalRenderingEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
 struct VkViewportWScalingNV
@@ -8261,11 +9473,19 @@ function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount,
     ccall((:vkCmdSetViewportWScalingNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
 end
 
+function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
+end
+
 # typedef VkResult ( VKAPI_PTR * PFN_vkReleaseDisplayEXT ) ( VkPhysicalDevice physicalDevice , VkDisplayKHR display )
 const PFN_vkReleaseDisplayEXT = Ptr{Cvoid}
 
 function vkReleaseDisplayEXT(physicalDevice, display)
     ccall((:vkReleaseDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
+function vkReleaseDisplayEXT(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
 @cenum VkSurfaceCounterFlagBitsEXT::UInt32 begin
@@ -8297,6 +9517,10 @@ const PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2EXT, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
+function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
 @cenum VkDisplayPowerStateEXT::UInt32 begin
@@ -8356,16 +9580,32 @@ function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo)
     ccall((:vkDisplayPowerControlEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
 end
 
+function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
+end
+
 function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDeviceEventEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
+end
+
+function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
 end
 
 function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDisplayEventEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
 end
 
+function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
+end
+
 function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue)
     ccall((:vkGetSwapchainCounterEXT, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
+end
+
+function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
 end
 
 struct VkRefreshCycleDurationGOOGLE
@@ -8402,8 +9642,16 @@ function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProper
     ccall((:vkGetRefreshCycleDurationGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
 end
 
+function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
+end
+
 function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings)
     ccall((:vkGetPastPresentationTimingGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
+end
+
+function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
 end
 
 struct VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX
@@ -8469,6 +9717,10 @@ const PFN_vkCmdSetDiscardRectangleEXT = Ptr{Cvoid}
 
 function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
     ccall((:vkCmdSetDiscardRectangleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
+end
+
+function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
 end
 
 @cenum VkConservativeRasterizationModeEXT::UInt32 begin
@@ -8540,6 +9792,10 @@ const PFN_vkSetHdrMetadataEXT = Ptr{Cvoid}
 
 function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata)
     ccall((:vkSetHdrMetadataEXT, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
+end
+
+function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
 end
 
 const VkDebugUtilsMessengerEXT_T = Cvoid
@@ -8659,44 +9915,88 @@ function vkSetDebugUtilsObjectNameEXT(device, pNameInfo)
     ccall((:vkSetDebugUtilsObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
 end
 
+function vkSetDebugUtilsObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
+end
+
 function vkSetDebugUtilsObjectTagEXT(device, pTagInfo)
     ccall((:vkSetDebugUtilsObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
+end
+
+function vkSetDebugUtilsObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
 end
 
 function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkQueueEndDebugUtilsLabelEXT(queue)
     ccall((:vkQueueEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue,), queue)
+end
+
+function vkQueueEndDebugUtilsLabelEXT(queue, fptr)
+    ccall(fptr, Cvoid, (VkQueue,), queue)
 end
 
 function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCmdEndDebugUtilsLabelEXT(commandBuffer)
     ccall((:vkCmdEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndDebugUtilsLabelEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger)
     ccall((:vkCreateDebugUtilsMessengerEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
 end
 
+function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
+end
+
 function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator)
     ccall((:vkDestroyDebugUtilsMessengerEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
 end
 
+function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
+end
+
 function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData)
     ccall((:vkSubmitDebugUtilsMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
+end
+
+function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
 end
 
 const VkSamplerReductionModeEXT = VkSamplerReductionMode
@@ -8801,8 +10101,16 @@ function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo)
     ccall((:vkCmdSetSampleLocationsEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
 end
 
+function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
+end
+
 function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties)
     ccall((:vkGetPhysicalDeviceMultisamplePropertiesEXT, libvulkan), Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
+end
+
+function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
 end
 
 @cenum VkBlendOverlapEXT::UInt32 begin
@@ -8930,6 +10238,10 @@ function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties)
     ccall((:vkGetImageDrmFormatModifierPropertiesEXT, libvulkan), VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
 end
 
+function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
+end
+
 const VkValidationCacheEXT_T = Cvoid
 
 const VkValidationCacheEXT = Ptr{VkValidationCacheEXT_T}
@@ -8971,16 +10283,32 @@ function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidation
     ccall((:vkCreateValidationCacheEXT, libvulkan), VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
 end
 
+function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
+end
+
 function vkDestroyValidationCacheEXT(device, validationCache, pAllocator)
     ccall((:vkDestroyValidationCacheEXT, libvulkan), Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
+end
+
+function vkDestroyValidationCacheEXT(device, validationCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
 end
 
 function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergeValidationCachesEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData)
     ccall((:vkGetValidationCacheDataEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
+end
+
+function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
 end
 
 const VkDescriptorBindingFlagBitsEXT = VkDescriptorBindingFlagBits
@@ -9083,12 +10411,24 @@ function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout)
     ccall((:vkCmdBindShadingRateImageNV, libvulkan), Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
 end
 
+function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
+end
+
 function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
     ccall((:vkCmdSetViewportShadingRatePaletteNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
 end
 
+function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
+end
+
 function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
     ccall((:vkCmdSetCoarseSampleOrderNV, libvulkan), Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
+end
+
+function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
 end
 
 const VkAccelerationStructureNV_T = Cvoid
@@ -9415,52 +10755,104 @@ function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccel
     ccall((:vkCreateAccelerationStructureNV, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureNV, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements)
     ccall((:vkGetAccelerationStructureMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
+end
+
 function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos)
     ccall((:vkBindAccelerationStructureMemoryNV, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
 end
 
 function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
     ccall((:vkCmdBuildAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
 end
 
+function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
+end
+
 function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode)
     ccall((:vkCmdCopyAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
+end
+
+function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
 end
 
 function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
     ccall((:vkCmdTraceRaysNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
 end
 
+function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesNV, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
+function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
 function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData)
     ccall((:vkGetAccelerationStructureHandleNV, libvulkan), VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
 end
 
+function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
+function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
 function vkCompileDeferredNV(device, pipeline, shader)
     ccall((:vkCompileDeferredNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
+end
+
+function vkCompileDeferredNV(device, pipeline, shader, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
 end
 
 struct VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV
@@ -9528,11 +10920,19 @@ function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, p
     ccall((:vkGetMemoryHostPointerPropertiesEXT, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
 end
 
+function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, pMemoryHostPointerProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdWriteBufferMarkerAMD ) ( VkCommandBuffer commandBuffer , VkPipelineStageFlagBits pipelineStage , VkBuffer dstBuffer , VkDeviceSize dstOffset , uint32_t marker )
 const PFN_vkCmdWriteBufferMarkerAMD = Ptr{Cvoid}
 
 function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarkerAMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
+end
+
+function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
 end
 
 @cenum VkPipelineCompilerControlFlagBitsAMD::UInt32 begin
@@ -9571,8 +10971,16 @@ function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDom
     ccall((:vkGetPhysicalDeviceCalibrateableTimeDomainsEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
 end
 
+function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDomainCount, pTimeDomains, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
+end
+
 function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
     ccall((:vkGetCalibratedTimestampsEXT, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
+end
+
+function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
 end
 
 struct VkPhysicalDeviceShaderCorePropertiesAMD
@@ -9704,12 +11112,24 @@ function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask)
     ccall((:vkCmdDrawMeshTasksNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
 end
 
+function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
+end
+
 function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectCountNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV
@@ -9744,6 +11164,10 @@ function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclus
     ccall((:vkCmdSetExclusiveScissorNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
 end
 
+function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
+end
+
 struct VkQueueFamilyCheckpointPropertiesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -9767,8 +11191,16 @@ function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker)
     ccall((:vkCmdSetCheckpointNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
 end
 
+function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
+end
+
 function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointDataNV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL
@@ -9912,36 +11344,72 @@ function vkInitializePerformanceApiINTEL(device, pInitializeInfo)
     ccall((:vkInitializePerformanceApiINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
 end
 
+function vkInitializePerformanceApiINTEL(device, pInitializeInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
+end
+
 function vkUninitializePerformanceApiINTEL(device)
     ccall((:vkUninitializePerformanceApiINTEL, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkUninitializePerformanceApiINTEL(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceStreamMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
 function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo)
     ccall((:vkCmdSetPerformanceOverrideINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
 end
 
+function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
+end
+
 function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration)
     ccall((:vkAcquirePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
+end
+
+function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
 end
 
 function vkReleasePerformanceConfigurationINTEL(device, configuration)
     ccall((:vkReleasePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
 end
 
+function vkReleasePerformanceConfigurationINTEL(device, configuration, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
+end
+
 function vkQueueSetPerformanceConfigurationINTEL(queue, configuration)
     ccall((:vkQueueSetPerformanceConfigurationINTEL, libvulkan), VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
 end
 
+function vkQueueSetPerformanceConfigurationINTEL(queue, configuration, fptr)
+    ccall(fptr, VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
+end
+
 function vkGetPerformanceParameterINTEL(device, parameter, pValue)
     ccall((:vkGetPerformanceParameterINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
+end
+
+function vkGetPerformanceParameterINTEL(device, parameter, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
 end
 
 struct VkPhysicalDevicePCIBusInfoPropertiesEXT
@@ -9970,6 +11438,10 @@ const PFN_vkSetLocalDimmingAMD = Ptr{Cvoid}
 
 function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable)
     ccall((:vkSetLocalDimmingAMD, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
+end
+
+function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
 end
 
 struct VkPhysicalDeviceFragmentDensityMapFeaturesEXT
@@ -10094,6 +11566,10 @@ function vkGetBufferDeviceAddressEXT(device, pInfo)
     ccall((:vkGetBufferDeviceAddressEXT, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressEXT(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 @cenum VkToolPurposeFlagBitsEXT::UInt32 begin
     VK_TOOL_PURPOSE_VALIDATION_BIT_EXT = 1
     VK_TOOL_PURPOSE_PROFILING_BIT_EXT = 2
@@ -10122,6 +11598,10 @@ const PFN_vkGetPhysicalDeviceToolPropertiesEXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties)
     ccall((:vkGetPhysicalDeviceToolPropertiesEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
+end
+
+function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
 end
 
 const VkImageStencilUsageCreateInfoEXT = VkImageStencilUsageCreateInfo
@@ -10211,6 +11691,10 @@ function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPrope
     ccall((:vkGetPhysicalDeviceCooperativeMatrixPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
+end
+
 @cenum VkCoverageReductionModeNV::UInt32 begin
     VK_COVERAGE_REDUCTION_MODE_MERGE_NV = 0
     VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV = 1
@@ -10246,6 +11730,10 @@ const PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV = Pt
 
 function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations)
     ccall((:vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
+end
+
+function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
 end
 
 struct VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT
@@ -10303,6 +11791,10 @@ function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateHeadlessSurfaceEXT, libvulkan), VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 @cenum VkLineRasterizationModeEXT::UInt32 begin
     VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT = 0
     VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT = 1
@@ -10344,6 +11836,10 @@ function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePat
     ccall((:vkCmdSetLineStippleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
 end
 
+function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
+end
+
 struct VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10368,6 +11864,10 @@ const PFN_vkResetQueryPoolEXT = Ptr{Cvoid}
 
 function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPoolEXT, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
+function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
 struct VkPhysicalDeviceIndexTypeUint8FeaturesEXT
@@ -10422,48 +11922,96 @@ function vkCmdSetCullModeEXT(commandBuffer, cullMode)
     ccall((:vkCmdSetCullModeEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
 end
 
+function vkCmdSetCullModeEXT(commandBuffer, cullMode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
+end
+
 function vkCmdSetFrontFaceEXT(commandBuffer, frontFace)
     ccall((:vkCmdSetFrontFaceEXT, libvulkan), Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
+end
+
+function vkCmdSetFrontFaceEXT(commandBuffer, frontFace, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
 end
 
 function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology)
     ccall((:vkCmdSetPrimitiveTopologyEXT, libvulkan), Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
 end
 
+function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
+end
+
 function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports)
     ccall((:vkCmdSetViewportWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
+end
+
+function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
 end
 
 function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors)
     ccall((:vkCmdSetScissorWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
 end
 
+function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
+end
+
 function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
     ccall((:vkCmdBindVertexBuffers2EXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
+end
+
+function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
 end
 
 function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable)
     ccall((:vkCmdSetDepthTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
 end
 
+function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
+end
+
 function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable)
     ccall((:vkCmdSetDepthWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
+end
+
+function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
 end
 
 function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp)
     ccall((:vkCmdSetDepthCompareOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
 end
 
+function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
+end
+
 function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable)
     ccall((:vkCmdSetDepthBoundsTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
+end
+
+function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
 end
 
 function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable)
     ccall((:vkCmdSetStencilTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
 end
 
+function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
+end
+
 function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
     ccall((:vkCmdSetStencilOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
+end
+
+function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
 end
 
 struct VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT
@@ -10645,24 +12193,48 @@ function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequir
     ccall((:vkGetGeneratedCommandsMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo)
     ccall((:vkCmdPreprocessGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
+end
+
+function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
 end
 
 function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
     ccall((:vkCmdExecuteGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
 end
 
+function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
+end
+
 function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex)
     ccall((:vkCmdBindPipelineShaderGroupNV, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
+end
+
+function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
 end
 
 function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
     ccall((:vkCreateIndirectCommandsLayoutNV, libvulkan), VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
 end
 
+function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
+end
+
 function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator)
     ccall((:vkDestroyIndirectCommandsLayoutNV, libvulkan), Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
+end
+
+function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
 end
 
 struct VkPhysicalDeviceInheritedViewportScissorFeaturesNV
@@ -10826,16 +12398,32 @@ function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDat
     ccall((:vkCreatePrivateDataSlotEXT, libvulkan), VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
 end
 
+function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDataSlot, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
+end
+
 function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator)
     ccall((:vkDestroyPrivateDataSlotEXT, libvulkan), Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
+end
+
+function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
 end
 
 function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data)
     ccall((:vkSetPrivateDataEXT, libvulkan), VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
 end
 
+function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
+end
+
 function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData)
     ccall((:vkGetPrivateDataEXT, libvulkan), Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
+end
+
+function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
 end
 
 struct VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT
@@ -10916,6 +12504,10 @@ function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerO
     ccall((:vkCmdSetFragmentShadingRateEnumNV, libvulkan), Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
 end
 
+function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
+end
+
 struct VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10966,8 +12558,16 @@ function vkAcquireWinrtDisplayNV(physicalDevice, display)
     ccall((:vkAcquireWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
+function vkAcquireWinrtDisplayNV(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
 function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay)
     ccall((:vkGetWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
+end
+
+function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
 end
 
 struct VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE
@@ -11019,6 +12619,10 @@ function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pV
     ccall((:vkCmdSetVertexInputEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
 end
 
+function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
+end
+
 struct VkPhysicalDeviceExtendedDynamicState2FeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -11046,20 +12650,40 @@ function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints)
     ccall((:vkCmdSetPatchControlPointsEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
 end
 
+function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
+end
+
 function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable)
     ccall((:vkCmdSetRasterizerDiscardEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
+end
+
+function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
 end
 
 function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable)
     ccall((:vkCmdSetDepthBiasEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
 end
 
+function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
+end
+
 function vkCmdSetLogicOpEXT(commandBuffer, logicOp)
     ccall((:vkCmdSetLogicOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
 end
 
+function vkCmdSetLogicOpEXT(commandBuffer, logicOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
+end
+
 function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable)
     ccall((:vkCmdSetPrimitiveRestartEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
+end
+
+function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
 end
 
 struct VkPhysicalDeviceColorWriteEnableFeaturesEXT
@@ -11080,6 +12704,10 @@ const PFN_vkCmdSetColorWriteEnableEXT = Ptr{Cvoid}
 
 function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables)
     ccall((:vkCmdSetColorWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
+end
+
+function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
 end
 
 const VkAccelerationStructureKHR_T = Cvoid
@@ -11368,64 +12996,128 @@ function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAcce
     ccall((:vkCreateAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkCmdBuildAccelerationStructuresKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
     ccall((:vkCmdBuildAccelerationStructuresIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
+end
+
+function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
 end
 
 function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkBuildAccelerationStructuresKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureToMemoryKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
 end
 
+function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
+end
+
 function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyMemoryToAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
     ccall((:vkWriteAccelerationStructuresPropertiesKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
 end
 
+function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
+end
+
 function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureToMemoryKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
 end
 
+function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
+end
+
 function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyMemoryToAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo)
     ccall((:vkGetAccelerationStructureDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
 end
 
+function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
+function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
 function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility)
     ccall((:vkGetDeviceAccelerationStructureCompatibilityKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
 end
 
+function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
+end
+
 function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
     ccall((:vkGetAccelerationStructureBuildSizesKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
+end
+
+function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
 end
 
 @cenum VkShaderGroupShaderKHR::UInt32 begin
@@ -11528,24 +13220,48 @@ function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShader
     ccall((:vkCmdTraceRaysKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
 end
 
+function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingCaptureReplayShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
     ccall((:vkCmdTraceRaysIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
+end
+
+function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
 end
 
 function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader)
     ccall((:vkGetRayTracingShaderGroupStackSizeKHR, libvulkan), VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
 end
 
+function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader, fptr)
+    ccall(fptr, VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
+end
+
 function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize)
     ccall((:vkCmdSetRayTracingPipelineStackSizeKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
+end
+
+function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
 end
 
 struct VkPhysicalDeviceRayQueryFeaturesKHR
@@ -11570,6 +13286,10 @@ function vkCreateMacOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateMacOSSurfaceMVK, libvulkan), VkResult, (VkInstance, Ptr{VkMacOSSurfaceCreateInfoMVK}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateMacOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkMacOSSurfaceCreateInfoMVK}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 const CAMetalLayer = Cvoid
 
 const VkMetalSurfaceCreateFlagsEXT = VkFlags
@@ -11586,6 +13306,10 @@ const PFN_vkCreateMetalSurfaceEXT = Ptr{Cvoid}
 
 function vkCreateMetalSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateMetalSurfaceEXT, libvulkan), VkResult, (VkInstance, Ptr{VkMetalSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
+function vkCreateMetalSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkMetalSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
 const VULKAN_H_ = 1

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -3686,548 +3686,1096 @@ function vkCreateInstance(pCreateInfo, pAllocator, pInstance)
     ccall((:vkCreateInstance, libvulkan), VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
 end
 
+function vkCreateInstance(pCreateInfo, pAllocator, pInstance, fptr)
+    ccall(fptr, VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
+end
+
 function vkDestroyInstance(instance, pAllocator)
     ccall((:vkDestroyInstance, libvulkan), Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
+end
+
+function vkDestroyInstance(instance, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
 end
 
 function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices)
     ccall((:vkEnumeratePhysicalDevices, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
 end
 
+function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
+end
+
 function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
+end
+
+function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
 end
 
 function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceProperties(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
 end
 
+function vkGetPhysicalDeviceProperties(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
+end
+
 function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
+function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
 function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetInstanceProcAddr(instance, pName)
     ccall((:vkGetInstanceProcAddr, libvulkan), PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
+end
+
+function vkGetInstanceProcAddr(instance, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
 end
 
 function vkGetDeviceProcAddr(device, pName)
     ccall((:vkGetDeviceProcAddr, libvulkan), PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
 end
 
+function vkGetDeviceProcAddr(device, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
+end
+
 function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice)
     ccall((:vkCreateDevice, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
+end
+
+function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
 end
 
 function vkDestroyDevice(device, pAllocator)
     ccall((:vkDestroyDevice, libvulkan), Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
 end
 
+function vkDestroyDevice(device, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
+end
+
 function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceExtensionProperties, libvulkan), VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceExtensionProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
+end
+
 function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceLayerProperties, libvulkan), VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceLayerProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue)
     ccall((:vkGetDeviceQueue, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
+end
+
+function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
 end
 
 function vkQueueSubmit(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
+function vkQueueSubmit(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
 function vkQueueWaitIdle(queue)
     ccall((:vkQueueWaitIdle, libvulkan), VkResult, (VkQueue,), queue)
+end
+
+function vkQueueWaitIdle(queue, fptr)
+    ccall(fptr, VkResult, (VkQueue,), queue)
 end
 
 function vkDeviceWaitIdle(device)
     ccall((:vkDeviceWaitIdle, libvulkan), VkResult, (VkDevice,), device)
 end
 
+function vkDeviceWaitIdle(device, fptr)
+    ccall(fptr, VkResult, (VkDevice,), device)
+end
+
 function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory)
     ccall((:vkAllocateMemory, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
+end
+
+function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
 end
 
 function vkFreeMemory(device, memory, pAllocator)
     ccall((:vkFreeMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
 end
 
+function vkFreeMemory(device, memory, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
+end
+
 function vkMapMemory(device, memory, offset, size, flags, ppData)
     ccall((:vkMapMemory, libvulkan), VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
+end
+
+function vkMapMemory(device, memory, offset, size, flags, ppData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
 end
 
 function vkUnmapMemory(device, memory)
     ccall((:vkUnmapMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory), device, memory)
 end
 
+function vkUnmapMemory(device, memory, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory), device, memory)
+end
+
 function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkFlushMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
+function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
 function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkInvalidateMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
+function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
 function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes)
     ccall((:vkGetDeviceMemoryCommitment, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
+end
+
+function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
 end
 
 function vkBindBufferMemory(device, buffer, memory, memoryOffset)
     ccall((:vkBindBufferMemory, libvulkan), VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
 end
 
+function vkBindBufferMemory(device, buffer, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
+end
+
 function vkBindImageMemory(device, image, memory, memoryOffset)
     ccall((:vkBindImageMemory, libvulkan), VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
+end
+
+function vkBindImageMemory(device, image, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
 end
 
 function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
+end
+
 function vkGetImageMemoryRequirements(device, image, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements(device, image, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
 end
 
 function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
+function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
 end
 
 function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence)
     ccall((:vkQueueBindSparse, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
 end
 
+function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
+end
+
 function vkCreateFence(device, pCreateInfo, pAllocator, pFence)
     ccall((:vkCreateFence, libvulkan), VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
+end
+
+function vkCreateFence(device, pCreateInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
 end
 
 function vkDestroyFence(device, fence, pAllocator)
     ccall((:vkDestroyFence, libvulkan), Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
 end
 
+function vkDestroyFence(device, fence, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
+end
+
 function vkResetFences(device, fenceCount, pFences)
     ccall((:vkResetFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
+end
+
+function vkResetFences(device, fenceCount, pFences, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
 end
 
 function vkGetFenceStatus(device, fence)
     ccall((:vkGetFenceStatus, libvulkan), VkResult, (VkDevice, VkFence), device, fence)
 end
 
+function vkGetFenceStatus(device, fence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkFence), device, fence)
+end
+
 function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout)
     ccall((:vkWaitForFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
+end
+
+function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
 end
 
 function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore)
     ccall((:vkCreateSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
 end
 
+function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
+end
+
 function vkDestroySemaphore(device, semaphore, pAllocator)
     ccall((:vkDestroySemaphore, libvulkan), Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
+end
+
+function vkDestroySemaphore(device, semaphore, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
 end
 
 function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent)
     ccall((:vkCreateEvent, libvulkan), VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
 end
 
+function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
+end
+
 function vkDestroyEvent(device, event, pAllocator)
     ccall((:vkDestroyEvent, libvulkan), Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
+end
+
+function vkDestroyEvent(device, event, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
 end
 
 function vkGetEventStatus(device, event)
     ccall((:vkGetEventStatus, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkGetEventStatus(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkSetEvent(device, event)
     ccall((:vkSetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
+end
+
+function vkSetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
 end
 
 function vkResetEvent(device, event)
     ccall((:vkResetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkResetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool)
     ccall((:vkCreateQueryPool, libvulkan), VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
+end
+
+function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
 end
 
 function vkDestroyQueryPool(device, queryPool, pAllocator)
     ccall((:vkDestroyQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
 end
 
+function vkDestroyQueryPool(device, queryPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
+end
+
 function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
     ccall((:vkGetQueryPoolResults, libvulkan), VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
+end
+
+function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
 end
 
 function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer)
     ccall((:vkCreateBuffer, libvulkan), VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
 end
 
+function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
+end
+
 function vkDestroyBuffer(device, buffer, pAllocator)
     ccall((:vkDestroyBuffer, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
+end
+
+function vkDestroyBuffer(device, buffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
 end
 
 function vkCreateBufferView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateBufferView, libvulkan), VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
 end
 
+function vkCreateBufferView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
+end
+
 function vkDestroyBufferView(device, bufferView, pAllocator)
     ccall((:vkDestroyBufferView, libvulkan), Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
+end
+
+function vkDestroyBufferView(device, bufferView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
 end
 
 function vkCreateImage(device, pCreateInfo, pAllocator, pImage)
     ccall((:vkCreateImage, libvulkan), VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
 end
 
+function vkCreateImage(device, pCreateInfo, pAllocator, pImage, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
+end
+
 function vkDestroyImage(device, image, pAllocator)
     ccall((:vkDestroyImage, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
+end
+
+function vkDestroyImage(device, image, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
 end
 
 function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout)
     ccall((:vkGetImageSubresourceLayout, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
 end
 
+function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
+end
+
 function vkCreateImageView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateImageView, libvulkan), VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
+end
+
+function vkCreateImageView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
 end
 
 function vkDestroyImageView(device, imageView, pAllocator)
     ccall((:vkDestroyImageView, libvulkan), Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
 end
 
+function vkDestroyImageView(device, imageView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
+end
+
 function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule)
     ccall((:vkCreateShaderModule, libvulkan), VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
+end
+
+function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
 end
 
 function vkDestroyShaderModule(device, shaderModule, pAllocator)
     ccall((:vkDestroyShaderModule, libvulkan), Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
 end
 
+function vkDestroyShaderModule(device, shaderModule, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
+end
+
 function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache)
     ccall((:vkCreatePipelineCache, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
+end
+
+function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
 end
 
 function vkDestroyPipelineCache(device, pipelineCache, pAllocator)
     ccall((:vkDestroyPipelineCache, libvulkan), Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
 end
 
+function vkDestroyPipelineCache(device, pipelineCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
+end
+
 function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData)
     ccall((:vkGetPipelineCacheData, libvulkan), VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
+end
+
+function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
 end
 
 function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergePipelineCaches, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateGraphicsPipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateComputePipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
+function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
 function vkDestroyPipeline(device, pipeline, pAllocator)
     ccall((:vkDestroyPipeline, libvulkan), Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
+end
+
+function vkDestroyPipeline(device, pipeline, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
 end
 
 function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout)
     ccall((:vkCreatePipelineLayout, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
 end
 
+function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
+end
+
 function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator)
     ccall((:vkDestroyPipelineLayout, libvulkan), Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
+end
+
+function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
 end
 
 function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler)
     ccall((:vkCreateSampler, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
 end
 
+function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
+end
+
 function vkDestroySampler(device, sampler, pAllocator)
     ccall((:vkDestroySampler, libvulkan), Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
+end
+
+function vkDestroySampler(device, sampler, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
 end
 
 function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout)
     ccall((:vkCreateDescriptorSetLayout, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
 end
 
+function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
+end
+
 function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator)
     ccall((:vkDestroyDescriptorSetLayout, libvulkan), Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
+end
+
+function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
 end
 
 function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool)
     ccall((:vkCreateDescriptorPool, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
 end
 
+function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
+end
+
 function vkDestroyDescriptorPool(device, descriptorPool, pAllocator)
     ccall((:vkDestroyDescriptorPool, libvulkan), Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
+end
+
+function vkDestroyDescriptorPool(device, descriptorPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
 end
 
 function vkResetDescriptorPool(device, descriptorPool, flags)
     ccall((:vkResetDescriptorPool, libvulkan), VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
 end
 
+function vkResetDescriptorPool(device, descriptorPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
+end
+
 function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets)
     ccall((:vkAllocateDescriptorSets, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
+end
+
+function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
 end
 
 function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets)
     ccall((:vkFreeDescriptorSets, libvulkan), VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
 end
 
+function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
+end
+
 function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
     ccall((:vkUpdateDescriptorSets, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
+end
+
+function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
 end
 
 function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer)
     ccall((:vkCreateFramebuffer, libvulkan), VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
 end
 
+function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
+end
+
 function vkDestroyFramebuffer(device, framebuffer, pAllocator)
     ccall((:vkDestroyFramebuffer, libvulkan), Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
+end
+
+function vkDestroyFramebuffer(device, framebuffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
 end
 
 function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkDestroyRenderPass(device, renderPass, pAllocator)
     ccall((:vkDestroyRenderPass, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
+end
+
+function vkDestroyRenderPass(device, renderPass, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
 end
 
 function vkGetRenderAreaGranularity(device, renderPass, pGranularity)
     ccall((:vkGetRenderAreaGranularity, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
 end
 
+function vkGetRenderAreaGranularity(device, renderPass, pGranularity, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
+end
+
 function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool)
     ccall((:vkCreateCommandPool, libvulkan), VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
+end
+
+function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
 end
 
 function vkDestroyCommandPool(device, commandPool, pAllocator)
     ccall((:vkDestroyCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
 end
 
+function vkDestroyCommandPool(device, commandPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
+end
+
 function vkResetCommandPool(device, commandPool, flags)
     ccall((:vkResetCommandPool, libvulkan), VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
+end
+
+function vkResetCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
 end
 
 function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers)
     ccall((:vkAllocateCommandBuffers, libvulkan), VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
 end
 
+function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
+end
+
 function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers)
     ccall((:vkFreeCommandBuffers, libvulkan), Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
+end
+
+function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
 end
 
 function vkBeginCommandBuffer(commandBuffer, pBeginInfo)
     ccall((:vkBeginCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
 end
 
+function vkBeginCommandBuffer(commandBuffer, pBeginInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
+end
+
 function vkEndCommandBuffer(commandBuffer)
     ccall((:vkEndCommandBuffer, libvulkan), VkResult, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkEndCommandBuffer(commandBuffer, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer,), commandBuffer)
 end
 
 function vkResetCommandBuffer(commandBuffer, flags)
     ccall((:vkResetCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
 end
 
+function vkResetCommandBuffer(commandBuffer, flags, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
+end
+
 function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline)
     ccall((:vkCmdBindPipeline, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
+end
+
+function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
 end
 
 function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports)
     ccall((:vkCmdSetViewport, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
 end
 
+function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
+end
+
 function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors)
     ccall((:vkCmdSetScissor, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
+end
+
+function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
 end
 
 function vkCmdSetLineWidth(commandBuffer, lineWidth)
     ccall((:vkCmdSetLineWidth, libvulkan), Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
 end
 
+function vkCmdSetLineWidth(commandBuffer, lineWidth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
+end
+
 function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
     ccall((:vkCmdSetDepthBias, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
+end
+
+function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
 end
 
 function vkCmdSetBlendConstants(commandBuffer, blendConstants)
     ccall((:vkCmdSetBlendConstants, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
 end
 
+function vkCmdSetBlendConstants(commandBuffer, blendConstants, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
+end
+
 function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds)
     ccall((:vkCmdSetDepthBounds, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
+end
+
+function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
 end
 
 function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask)
     ccall((:vkCmdSetStencilCompareMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
 end
 
+function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
+end
+
 function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask)
     ccall((:vkCmdSetStencilWriteMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
+end
+
+function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
 end
 
 function vkCmdSetStencilReference(commandBuffer, faceMask, reference)
     ccall((:vkCmdSetStencilReference, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
 end
 
+function vkCmdSetStencilReference(commandBuffer, faceMask, reference, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
+end
+
 function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
     ccall((:vkCmdBindDescriptorSets, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
+end
+
+function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
 end
 
 function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType)
     ccall((:vkCmdBindIndexBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
 end
 
+function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
+end
+
 function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
     ccall((:vkCmdBindVertexBuffers, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
+end
+
+function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
 end
 
 function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
     ccall((:vkCmdDraw, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
 end
 
+function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
+end
+
 function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
     ccall((:vkCmdDrawIndexed, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
+end
+
+function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
 end
 
 function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndexedIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
 function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatch, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
 end
 
+function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
+end
+
 function vkCmdDispatchIndirect(commandBuffer, buffer, offset)
     ccall((:vkCmdDispatchIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
+end
+
+function vkCmdDispatchIndirect(commandBuffer, buffer, offset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
 end
 
 function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
     ccall((:vkCmdBlitImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
 end
 
+function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
+end
+
 function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyBufferToImage, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyImageToBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData)
     ccall((:vkCmdUpdateBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
+end
+
+function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
 end
 
 function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data)
     ccall((:vkCmdFillBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
 end
 
+function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
+end
+
 function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
     ccall((:vkCmdClearColorImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
+end
+
+function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
 end
 
 function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
     ccall((:vkCmdClearDepthStencilImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
 end
 
+function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
+end
+
 function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
     ccall((:vkCmdClearAttachments, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
+end
+
+function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
 end
 
 function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdResolveImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
+function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
 function vkCmdSetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdSetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
+function vkCmdSetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
 function vkCmdResetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
+function vkCmdResetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
 function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdWaitEvents, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
+function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
 function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdPipelineBarrier, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
+function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
 function vkCmdBeginQuery(commandBuffer, queryPool, query, flags)
     ccall((:vkCmdBeginQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
+end
+
+function vkCmdBeginQuery(commandBuffer, queryPool, query, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
 end
 
 function vkCmdEndQuery(commandBuffer, queryPool, query)
     ccall((:vkCmdEndQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
 end
 
+function vkCmdEndQuery(commandBuffer, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
+end
+
 function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount)
     ccall((:vkCmdResetQueryPool, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
+end
+
+function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
 end
 
 function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query)
     ccall((:vkCmdWriteTimestamp, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
+end
+
 function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
     ccall((:vkCmdCopyQueryPoolResults, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
+end
+
+function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
 end
 
 function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues)
     ccall((:vkCmdPushConstants, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
 end
 
+function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
+end
+
 function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents)
     ccall((:vkCmdBeginRenderPass, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
+end
+
+function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
 end
 
 function vkCmdNextSubpass(commandBuffer, contents)
     ccall((:vkCmdNextSubpass, libvulkan), Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
 end
 
+function vkCmdNextSubpass(commandBuffer, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
+end
+
 function vkCmdEndRenderPass(commandBuffer)
     ccall((:vkCmdEndRenderPass, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndRenderPass(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers)
     ccall((:vkCmdExecuteCommands, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
+end
+
+function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
 end
 
 const VkSamplerYcbcrConversion_T = Cvoid
@@ -5017,112 +5565,224 @@ function vkEnumerateInstanceVersion(pApiVersion)
     ccall((:vkEnumerateInstanceVersion, libvulkan), VkResult, (Ptr{UInt32},), pApiVersion)
 end
 
+function vkEnumerateInstanceVersion(pApiVersion, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32},), pApiVersion)
+end
+
 function vkBindBufferMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindBufferMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 function vkBindImageMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindImageMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
     ccall((:vkGetDeviceGroupPeerMemoryFeatures, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
+function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
 function vkCmdSetDeviceMask(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMask, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMask(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBase, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroups, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
+function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
 function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
 function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
+function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
 function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
 function vkTrimCommandPool(device, commandPool, flags)
     ccall((:vkTrimCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
+function vkTrimCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
 function vkGetDeviceQueue2(device, pQueueInfo, pQueue)
     ccall((:vkGetDeviceQueue2, libvulkan), Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
 end
 
+function vkGetDeviceQueue2(device, pQueueInfo, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
+end
+
 function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion)
     ccall((:vkCreateSamplerYcbcrConversion, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
+function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
 function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversion, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
+function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
 function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
     ccall((:vkCreateDescriptorUpdateTemplate, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
+function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
 function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
+function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
 function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFenceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphoreProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
+function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
 function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupport, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
+function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
 @cenum VkDriverId::UInt32 begin
@@ -5822,52 +6482,104 @@ function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, coun
     ccall((:vkCmdDrawIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 function vkResetQueryPool(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
+function vkResetQueryPool(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
 function vkGetSemaphoreCounterValue(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValue, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
+function vkGetSemaphoreCounterValue(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
 function vkWaitSemaphores(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphores, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphores(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphore(device, pSignalInfo)
     ccall((:vkSignalSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphore(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 function vkGetBufferDeviceAddress(device, pInfo)
     ccall((:vkGetBufferDeviceAddress, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddress(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkSurfaceKHR_T = Cvoid
@@ -5968,20 +6680,40 @@ function vkDestroySurfaceKHR(instance, surface, pAllocator)
     ccall((:vkDestroySurfaceKHR, libvulkan), Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
 end
 
+function vkDestroySurfaceKHR(instance, surface, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
+end
+
 function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported)
     ccall((:vkGetPhysicalDeviceSurfaceSupportKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
+end
+
+function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
 end
 
 function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormatsKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
 end
 
+function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
+end
+
 function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes)
     ccall((:vkGetPhysicalDeviceSurfacePresentModesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
+end
+
+function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
 end
 
 const VkSwapchainKHR_T = Cvoid
@@ -6114,36 +6846,72 @@ function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain)
     ccall((:vkCreateSwapchainKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
 end
 
+function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
+end
+
 function vkDestroySwapchainKHR(device, swapchain, pAllocator)
     ccall((:vkDestroySwapchainKHR, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
+end
+
+function vkDestroySwapchainKHR(device, swapchain, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
 end
 
 function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages)
     ccall((:vkGetSwapchainImagesKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
 end
 
+function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
+end
+
 function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex)
     ccall((:vkAcquireNextImageKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
+end
+
+function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
 end
 
 function vkQueuePresentKHR(queue, pPresentInfo)
     ccall((:vkQueuePresentKHR, libvulkan), VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
 end
 
+function vkQueuePresentKHR(queue, pPresentInfo, fptr)
+    ccall(fptr, VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
+end
+
 function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities)
     ccall((:vkGetDeviceGroupPresentCapabilitiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
+end
+
+function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
 end
 
 function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes)
     ccall((:vkGetDeviceGroupSurfacePresentModesKHR, libvulkan), VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
 end
 
+function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
+end
+
 function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects)
     ccall((:vkGetPhysicalDevicePresentRectanglesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
 end
 
+function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
+end
+
 function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex)
     ccall((:vkAcquireNextImage2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
+end
+
+function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
 end
 
 const VkDisplayKHR_T = Cvoid
@@ -6250,28 +7018,56 @@ function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount,
     ccall((:vkGetPhysicalDeviceDisplayPropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlanePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays)
     ccall((:vkGetDisplayPlaneSupportedDisplaysKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
 end
 
+function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
+end
+
 function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
+function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
 function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode)
     ccall((:vkCreateDisplayModeKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
 end
 
+function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
+end
+
 function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
 end
 
+function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
+end
+
 function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateDisplayPlaneSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
+function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
 struct VkDisplayPresentInfoKHR
@@ -6287,6 +7083,10 @@ const PFN_vkCreateSharedSwapchainsKHR = Ptr{Cvoid}
 
 function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
     ccall((:vkCreateSharedSwapchainsKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
+end
+
+function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
 end
 
 const VkRenderPassMultiviewCreateInfoKHR = VkRenderPassMultiviewCreateInfo
@@ -6338,28 +7138,56 @@ function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
 const VkPeerMemoryFeatureFlagsKHR = VkPeerMemoryFeatureFlags
@@ -6397,12 +7225,24 @@ function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceInd
     ccall((:vkGetDeviceGroupPeerMemoryFeaturesKHR, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
+function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
 function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMaskKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBaseKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 const VkCommandPoolTrimFlagsKHR = VkCommandPoolTrimFlags
@@ -6414,6 +7254,10 @@ function vkTrimCommandPoolKHR(device, commandPool, flags)
     ccall((:vkTrimCommandPoolKHR, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
+function vkTrimCommandPoolKHR(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
 const VkPhysicalDeviceGroupPropertiesKHR = VkPhysicalDeviceGroupProperties
 
 const VkDeviceGroupDeviceCreateInfoKHR = VkDeviceGroupDeviceCreateInfo
@@ -6423,6 +7267,10 @@ const PFN_vkEnumeratePhysicalDeviceGroupsKHR = Ptr{Cvoid}
 
 function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroupsKHR, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
+function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
 const VkExternalMemoryHandleTypeFlagsKHR = VkExternalMemoryHandleTypeFlags
@@ -6450,6 +7298,10 @@ const PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferPropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
+function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
 const VkExternalMemoryImageCreateInfoKHR = VkExternalMemoryImageCreateInfo
@@ -6488,8 +7340,16 @@ function vkGetMemoryFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetMemoryFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
+function vkGetMemoryFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
 function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties)
     ccall((:vkGetMemoryFdPropertiesKHR, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
+end
+
+function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
 end
 
 const VkExternalSemaphoreHandleTypeFlagsKHR = VkExternalSemaphoreHandleTypeFlags
@@ -6509,6 +7369,10 @@ const PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphorePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
+function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
 const VkSemaphoreImportFlagsKHR = VkSemaphoreImportFlags
@@ -6543,8 +7407,16 @@ function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo)
     ccall((:vkImportSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
 end
 
+function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
+end
+
 function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 struct VkPhysicalDevicePushDescriptorPropertiesKHR
@@ -6563,8 +7435,16 @@ function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set
     ccall((:vkCmdPushDescriptorSetKHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
 end
 
+function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
+end
+
 function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData)
     ccall((:vkCmdPushDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
+end
+
+function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
 end
 
 const VkPhysicalDeviceShaderFloat16Int8FeaturesKHR = VkPhysicalDeviceShaderFloat16Int8Features
@@ -6614,12 +7494,24 @@ function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pD
     ccall((:vkCreateDescriptorUpdateTemplateKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
+function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
 function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 const VkPhysicalDeviceImagelessFramebufferFeaturesKHR = VkPhysicalDeviceImagelessFramebufferFeatures
@@ -6660,16 +7552,32 @@ function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 struct VkSharedPresentSurfaceCapabilitiesKHR
@@ -6683,6 +7591,10 @@ const PFN_vkGetSwapchainStatusKHR = Ptr{Cvoid}
 
 function vkGetSwapchainStatusKHR(device, swapchain)
     ccall((:vkGetSwapchainStatusKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
+end
+
+function vkGetSwapchainStatusKHR(device, swapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
 end
 
 const VkExternalFenceHandleTypeFlagsKHR = VkExternalFenceHandleTypeFlags
@@ -6702,6 +7614,10 @@ const PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFencePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 const VkFenceImportFlagsKHR = VkFenceImportFlags
@@ -6736,8 +7652,16 @@ function vkImportFenceFdKHR(device, pImportFenceFdInfo)
     ccall((:vkImportFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
 end
 
+function vkImportFenceFdKHR(device, pImportFenceFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
+end
+
 function vkGetFenceFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetFenceFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 @cenum VkPerformanceCounterUnitKHR::UInt32 begin
@@ -6884,16 +7808,32 @@ function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physica
     ccall((:vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
 end
 
+function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
+end
+
 function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
     ccall((:vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
+end
+
+function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
 end
 
 function vkAcquireProfilingLockKHR(device, pInfo)
     ccall((:vkAcquireProfilingLockKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
 end
 
+function vkAcquireProfilingLockKHR(device, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
+end
+
 function vkReleaseProfilingLockKHR(device)
     ccall((:vkReleaseProfilingLockKHR, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkReleaseProfilingLockKHR(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 const VkPointClippingBehaviorKHR = VkPointClippingBehavior
@@ -6938,8 +7878,16 @@ function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormats2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
+end
+
+function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
 end
 
 const VkPhysicalDeviceVariablePointerFeaturesKHR = VkPhysicalDeviceVariablePointersFeatures
@@ -6993,16 +7941,32 @@ function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount
     ccall((:vkGetPhysicalDeviceDisplayProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlaneProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModeProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
+function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
 function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
+end
+
+function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
 end
 
 const VkMemoryDedicatedRequirementsKHR = VkMemoryDedicatedRequirements
@@ -7032,12 +7996,24 @@ function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 const VkImageFormatListCreateInfoKHR = VkImageFormatListCreateInfo
@@ -7072,8 +8048,16 @@ function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcb
     ccall((:vkCreateSamplerYcbcrConversionKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
+function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
 function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversionKHR, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
+function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
 const VkBindBufferMemoryInfoKHR = VkBindBufferMemoryInfo
@@ -7090,8 +8074,16 @@ function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 const VkPhysicalDeviceMaintenance3PropertiesKHR = VkPhysicalDeviceMaintenance3Properties
@@ -7105,6 +8097,10 @@ function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupportKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
+function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountKHR ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
 const PFN_vkCmdDrawIndirectCountKHR = Ptr{Cvoid}
 
@@ -7115,8 +8111,16 @@ function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 const VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR = VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures
@@ -7181,12 +8185,24 @@ function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValueKHR, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
+function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
 function vkWaitSemaphoresKHR(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphoresKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphoresKHR(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphoreKHR(device, pSignalInfo)
     ccall((:vkSignalSemaphoreKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphoreKHR(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR = VkPhysicalDeviceVulkanMemoryModelFeatures
@@ -7267,8 +8283,16 @@ function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentSha
     ccall((:vkGetPhysicalDeviceFragmentShadingRatesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
 end
 
+function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
+end
+
 function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps)
     ccall((:vkCmdSetFragmentShadingRateKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
+end
+
+function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
 end
 
 struct VkSurfaceProtectedCapabilitiesKHR
@@ -7308,12 +8332,24 @@ function vkGetBufferDeviceAddressKHR(device, pInfo)
     ccall((:vkGetBufferDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkDeferredOperationKHR_T = Cvoid
@@ -7339,20 +8375,40 @@ function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation)
     ccall((:vkCreateDeferredOperationKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
 end
 
+function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
+end
+
 function vkDestroyDeferredOperationKHR(device, operation, pAllocator)
     ccall((:vkDestroyDeferredOperationKHR, libvulkan), Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
+end
+
+function vkDestroyDeferredOperationKHR(device, operation, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
 end
 
 function vkGetDeferredOperationMaxConcurrencyKHR(device, operation)
     ccall((:vkGetDeferredOperationMaxConcurrencyKHR, libvulkan), UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationMaxConcurrencyKHR(device, operation, fptr)
+    ccall(fptr, UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkGetDeferredOperationResultKHR(device, operation)
     ccall((:vkGetDeferredOperationResultKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationResultKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkDeferredOperationJoinKHR(device, operation)
     ccall((:vkDeferredOperationJoinKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
+function vkDeferredOperationJoinKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
 @cenum VkPipelineExecutableStatisticFormatKHR::UInt32 begin
@@ -7446,12 +8502,24 @@ function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutable
     ccall((:vkGetPipelineExecutablePropertiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
 end
 
+function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutableCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
+end
+
 function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics)
     ccall((:vkGetPipelineExecutableStatisticsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
 end
 
+function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
+end
+
 function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
     ccall((:vkGetPipelineExecutableInternalRepresentationsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
+end
+
+function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
 end
 
 struct VkPipelineLibraryCreateInfoKHR
@@ -7603,32 +8671,64 @@ function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo)
     ccall((:vkCmdSetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
 end
 
+function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
+end
+
 function vkCmdResetEvent2KHR(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
+end
+
+function vkCmdResetEvent2KHR(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
 end
 
 function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos)
     ccall((:vkCmdWaitEvents2KHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
 end
 
+function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
+end
+
 function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo)
     ccall((:vkCmdPipelineBarrier2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
+end
+
+function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
 end
 
 function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query)
     ccall((:vkCmdWriteTimestamp2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
+end
+
 function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit2KHR, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
+function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
 function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarker2AMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
 end
 
+function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
+end
+
 function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointData2NV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR
@@ -7779,24 +8879,48 @@ function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo)
     ccall((:vkCmdCopyBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
 end
 
+function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
+end
+
 function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo)
     ccall((:vkCmdCopyImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
+end
+
+function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
 end
 
 function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo)
     ccall((:vkCmdCopyBufferToImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
 end
 
+function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
+end
+
 function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo)
     ccall((:vkCmdCopyImageToBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
+end
+
+function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
 end
 
 function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo)
     ccall((:vkCmdBlitImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
 end
 
+function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
+end
+
 function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo)
     ccall((:vkCmdResolveImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
+end
+
+function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
 end
 
 const VkDebugReportCallbackEXT_T = Cvoid
@@ -7882,12 +9006,24 @@ function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCall
     ccall((:vkCreateDebugReportCallbackEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
 end
 
+function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
+end
+
 function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator)
     ccall((:vkDestroyDebugReportCallbackEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
 end
 
+function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
+end
+
 function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
     ccall((:vkDebugReportMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
+end
+
+function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
 end
 
 @cenum VkRasterizationOrderAMD::UInt32 begin
@@ -7946,20 +9082,40 @@ function vkDebugMarkerSetObjectTagEXT(device, pTagInfo)
     ccall((:vkDebugMarkerSetObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
 end
 
+function vkDebugMarkerSetObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
+end
+
 function vkDebugMarkerSetObjectNameEXT(device, pNameInfo)
     ccall((:vkDebugMarkerSetObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
+end
+
+function vkDebugMarkerSetObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
 end
 
 function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerBeginEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdDebugMarkerEndEXT(commandBuffer)
     ccall((:vkCmdDebugMarkerEndEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdDebugMarkerEndEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerInsertEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
 struct VkDedicatedAllocationImageCreateInfoNV
@@ -8034,24 +9190,48 @@ function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindi
     ccall((:vkCmdBindTransformFeedbackBuffersEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
 end
 
+function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
+end
+
 function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdBeginTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
+function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
 function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdEndTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
+function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
 function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index)
     ccall((:vkCmdBeginQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
+end
+
+function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
 end
 
 function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index)
     ccall((:vkCmdEndQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
 end
 
+function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
+end
+
 function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
     ccall((:vkCmdDrawIndirectByteCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
+end
+
+function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
 end
 
 struct VkImageViewHandleInfoNVX
@@ -8079,8 +9259,16 @@ function vkGetImageViewHandleNVX(device, pInfo)
     ccall((:vkGetImageViewHandleNVX, libvulkan), UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
 end
 
+function vkGetImageViewHandleNVX(device, pInfo, fptr)
+    ccall(fptr, UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
+end
+
 function vkGetImageViewAddressNVX(device, imageView, pProperties)
     ccall((:vkGetImageViewAddressNVX, libvulkan), VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
+end
+
+function vkGetImageViewAddressNVX(device, imageView, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
 end
 
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountAMD ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
@@ -8093,8 +9281,16 @@ function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkTextureLODGatherFormatPropertiesAMD
@@ -8135,6 +9331,10 @@ function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, 
     ccall((:vkGetShaderInfoAMD, libvulkan), VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
 end
 
+function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
+end
+
 struct VkPhysicalDeviceCornerSampledImageFeaturesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8172,6 +9372,10 @@ const PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
     ccall((:vkGetPhysicalDeviceExternalImageFormatPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
 end
 
 struct VkExternalMemoryImageCreateInfoNV
@@ -8255,8 +9459,16 @@ function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingB
     ccall((:vkCmdBeginConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
 end
 
+function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
+end
+
 function vkCmdEndConditionalRenderingEXT(commandBuffer)
     ccall((:vkCmdEndConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkCmdEndConditionalRenderingEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
 struct VkViewportWScalingNV
@@ -8279,11 +9491,19 @@ function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount,
     ccall((:vkCmdSetViewportWScalingNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
 end
 
+function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
+end
+
 # typedef VkResult ( VKAPI_PTR * PFN_vkReleaseDisplayEXT ) ( VkPhysicalDevice physicalDevice , VkDisplayKHR display )
 const PFN_vkReleaseDisplayEXT = Ptr{Cvoid}
 
 function vkReleaseDisplayEXT(physicalDevice, display)
     ccall((:vkReleaseDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
+function vkReleaseDisplayEXT(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
 @cenum VkSurfaceCounterFlagBitsEXT::UInt32 begin
@@ -8315,6 +9535,10 @@ const PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2EXT, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
+function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
 @cenum VkDisplayPowerStateEXT::UInt32 begin
@@ -8374,16 +9598,32 @@ function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo)
     ccall((:vkDisplayPowerControlEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
 end
 
+function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
+end
+
 function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDeviceEventEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
+end
+
+function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
 end
 
 function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDisplayEventEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
 end
 
+function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
+end
+
 function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue)
     ccall((:vkGetSwapchainCounterEXT, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
+end
+
+function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
 end
 
 struct VkRefreshCycleDurationGOOGLE
@@ -8420,8 +9660,16 @@ function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProper
     ccall((:vkGetRefreshCycleDurationGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
 end
 
+function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
+end
+
 function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings)
     ccall((:vkGetPastPresentationTimingGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
+end
+
+function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
 end
 
 struct VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX
@@ -8487,6 +9735,10 @@ const PFN_vkCmdSetDiscardRectangleEXT = Ptr{Cvoid}
 
 function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
     ccall((:vkCmdSetDiscardRectangleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
+end
+
+function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
 end
 
 @cenum VkConservativeRasterizationModeEXT::UInt32 begin
@@ -8558,6 +9810,10 @@ const PFN_vkSetHdrMetadataEXT = Ptr{Cvoid}
 
 function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata)
     ccall((:vkSetHdrMetadataEXT, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
+end
+
+function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
 end
 
 const VkDebugUtilsMessengerEXT_T = Cvoid
@@ -8677,44 +9933,88 @@ function vkSetDebugUtilsObjectNameEXT(device, pNameInfo)
     ccall((:vkSetDebugUtilsObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
 end
 
+function vkSetDebugUtilsObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
+end
+
 function vkSetDebugUtilsObjectTagEXT(device, pTagInfo)
     ccall((:vkSetDebugUtilsObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
+end
+
+function vkSetDebugUtilsObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
 end
 
 function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkQueueEndDebugUtilsLabelEXT(queue)
     ccall((:vkQueueEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue,), queue)
+end
+
+function vkQueueEndDebugUtilsLabelEXT(queue, fptr)
+    ccall(fptr, Cvoid, (VkQueue,), queue)
 end
 
 function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCmdEndDebugUtilsLabelEXT(commandBuffer)
     ccall((:vkCmdEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndDebugUtilsLabelEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger)
     ccall((:vkCreateDebugUtilsMessengerEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
 end
 
+function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
+end
+
 function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator)
     ccall((:vkDestroyDebugUtilsMessengerEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
 end
 
+function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
+end
+
 function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData)
     ccall((:vkSubmitDebugUtilsMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
+end
+
+function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
 end
 
 const VkSamplerReductionModeEXT = VkSamplerReductionMode
@@ -8819,8 +10119,16 @@ function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo)
     ccall((:vkCmdSetSampleLocationsEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
 end
 
+function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
+end
+
 function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties)
     ccall((:vkGetPhysicalDeviceMultisamplePropertiesEXT, libvulkan), Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
+end
+
+function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
 end
 
 @cenum VkBlendOverlapEXT::UInt32 begin
@@ -8948,6 +10256,10 @@ function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties)
     ccall((:vkGetImageDrmFormatModifierPropertiesEXT, libvulkan), VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
 end
 
+function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
+end
+
 const VkValidationCacheEXT_T = Cvoid
 
 const VkValidationCacheEXT = Ptr{VkValidationCacheEXT_T}
@@ -8989,16 +10301,32 @@ function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidation
     ccall((:vkCreateValidationCacheEXT, libvulkan), VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
 end
 
+function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
+end
+
 function vkDestroyValidationCacheEXT(device, validationCache, pAllocator)
     ccall((:vkDestroyValidationCacheEXT, libvulkan), Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
+end
+
+function vkDestroyValidationCacheEXT(device, validationCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
 end
 
 function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergeValidationCachesEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData)
     ccall((:vkGetValidationCacheDataEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
+end
+
+function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
 end
 
 const VkDescriptorBindingFlagBitsEXT = VkDescriptorBindingFlagBits
@@ -9101,12 +10429,24 @@ function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout)
     ccall((:vkCmdBindShadingRateImageNV, libvulkan), Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
 end
 
+function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
+end
+
 function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
     ccall((:vkCmdSetViewportShadingRatePaletteNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
 end
 
+function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
+end
+
 function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
     ccall((:vkCmdSetCoarseSampleOrderNV, libvulkan), Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
+end
+
+function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
 end
 
 const VkAccelerationStructureNV_T = Cvoid
@@ -9433,52 +10773,104 @@ function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccel
     ccall((:vkCreateAccelerationStructureNV, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureNV, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements)
     ccall((:vkGetAccelerationStructureMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
+end
+
 function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos)
     ccall((:vkBindAccelerationStructureMemoryNV, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
 end
 
 function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
     ccall((:vkCmdBuildAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
 end
 
+function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
+end
+
 function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode)
     ccall((:vkCmdCopyAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
+end
+
+function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
 end
 
 function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
     ccall((:vkCmdTraceRaysNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
 end
 
+function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesNV, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
+function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
 function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData)
     ccall((:vkGetAccelerationStructureHandleNV, libvulkan), VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
 end
 
+function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
+function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
 function vkCompileDeferredNV(device, pipeline, shader)
     ccall((:vkCompileDeferredNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
+end
+
+function vkCompileDeferredNV(device, pipeline, shader, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
 end
 
 struct VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV
@@ -9546,11 +10938,19 @@ function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, p
     ccall((:vkGetMemoryHostPointerPropertiesEXT, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
 end
 
+function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, pMemoryHostPointerProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdWriteBufferMarkerAMD ) ( VkCommandBuffer commandBuffer , VkPipelineStageFlagBits pipelineStage , VkBuffer dstBuffer , VkDeviceSize dstOffset , uint32_t marker )
 const PFN_vkCmdWriteBufferMarkerAMD = Ptr{Cvoid}
 
 function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarkerAMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
+end
+
+function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
 end
 
 @cenum VkPipelineCompilerControlFlagBitsAMD::UInt32 begin
@@ -9589,8 +10989,16 @@ function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDom
     ccall((:vkGetPhysicalDeviceCalibrateableTimeDomainsEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
 end
 
+function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDomainCount, pTimeDomains, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
+end
+
 function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
     ccall((:vkGetCalibratedTimestampsEXT, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
+end
+
+function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
 end
 
 struct VkPhysicalDeviceShaderCorePropertiesAMD
@@ -9722,12 +11130,24 @@ function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask)
     ccall((:vkCmdDrawMeshTasksNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
 end
 
+function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
+end
+
 function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectCountNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV
@@ -9762,6 +11182,10 @@ function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclus
     ccall((:vkCmdSetExclusiveScissorNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
 end
 
+function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
+end
+
 struct VkQueueFamilyCheckpointPropertiesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -9785,8 +11209,16 @@ function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker)
     ccall((:vkCmdSetCheckpointNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
 end
 
+function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
+end
+
 function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointDataNV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL
@@ -9930,36 +11362,72 @@ function vkInitializePerformanceApiINTEL(device, pInitializeInfo)
     ccall((:vkInitializePerformanceApiINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
 end
 
+function vkInitializePerformanceApiINTEL(device, pInitializeInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
+end
+
 function vkUninitializePerformanceApiINTEL(device)
     ccall((:vkUninitializePerformanceApiINTEL, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkUninitializePerformanceApiINTEL(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceStreamMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
 function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo)
     ccall((:vkCmdSetPerformanceOverrideINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
 end
 
+function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
+end
+
 function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration)
     ccall((:vkAcquirePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
+end
+
+function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
 end
 
 function vkReleasePerformanceConfigurationINTEL(device, configuration)
     ccall((:vkReleasePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
 end
 
+function vkReleasePerformanceConfigurationINTEL(device, configuration, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
+end
+
 function vkQueueSetPerformanceConfigurationINTEL(queue, configuration)
     ccall((:vkQueueSetPerformanceConfigurationINTEL, libvulkan), VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
 end
 
+function vkQueueSetPerformanceConfigurationINTEL(queue, configuration, fptr)
+    ccall(fptr, VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
+end
+
 function vkGetPerformanceParameterINTEL(device, parameter, pValue)
     ccall((:vkGetPerformanceParameterINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
+end
+
+function vkGetPerformanceParameterINTEL(device, parameter, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
 end
 
 struct VkPhysicalDevicePCIBusInfoPropertiesEXT
@@ -9988,6 +11456,10 @@ const PFN_vkSetLocalDimmingAMD = Ptr{Cvoid}
 
 function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable)
     ccall((:vkSetLocalDimmingAMD, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
+end
+
+function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
 end
 
 struct VkPhysicalDeviceFragmentDensityMapFeaturesEXT
@@ -10112,6 +11584,10 @@ function vkGetBufferDeviceAddressEXT(device, pInfo)
     ccall((:vkGetBufferDeviceAddressEXT, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressEXT(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 @cenum VkToolPurposeFlagBitsEXT::UInt32 begin
     VK_TOOL_PURPOSE_VALIDATION_BIT_EXT = 1
     VK_TOOL_PURPOSE_PROFILING_BIT_EXT = 2
@@ -10140,6 +11616,10 @@ const PFN_vkGetPhysicalDeviceToolPropertiesEXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties)
     ccall((:vkGetPhysicalDeviceToolPropertiesEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
+end
+
+function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
 end
 
 const VkImageStencilUsageCreateInfoEXT = VkImageStencilUsageCreateInfo
@@ -10229,6 +11709,10 @@ function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPrope
     ccall((:vkGetPhysicalDeviceCooperativeMatrixPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
+end
+
 @cenum VkCoverageReductionModeNV::UInt32 begin
     VK_COVERAGE_REDUCTION_MODE_MERGE_NV = 0
     VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV = 1
@@ -10264,6 +11748,10 @@ const PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV = Pt
 
 function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations)
     ccall((:vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
+end
+
+function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
 end
 
 struct VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT
@@ -10321,6 +11809,10 @@ function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateHeadlessSurfaceEXT, libvulkan), VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 @cenum VkLineRasterizationModeEXT::UInt32 begin
     VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT = 0
     VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT = 1
@@ -10362,6 +11854,10 @@ function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePat
     ccall((:vkCmdSetLineStippleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
 end
 
+function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
+end
+
 struct VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10386,6 +11882,10 @@ const PFN_vkResetQueryPoolEXT = Ptr{Cvoid}
 
 function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPoolEXT, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
+function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
 struct VkPhysicalDeviceIndexTypeUint8FeaturesEXT
@@ -10440,48 +11940,96 @@ function vkCmdSetCullModeEXT(commandBuffer, cullMode)
     ccall((:vkCmdSetCullModeEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
 end
 
+function vkCmdSetCullModeEXT(commandBuffer, cullMode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
+end
+
 function vkCmdSetFrontFaceEXT(commandBuffer, frontFace)
     ccall((:vkCmdSetFrontFaceEXT, libvulkan), Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
+end
+
+function vkCmdSetFrontFaceEXT(commandBuffer, frontFace, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
 end
 
 function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology)
     ccall((:vkCmdSetPrimitiveTopologyEXT, libvulkan), Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
 end
 
+function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
+end
+
 function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports)
     ccall((:vkCmdSetViewportWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
+end
+
+function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
 end
 
 function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors)
     ccall((:vkCmdSetScissorWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
 end
 
+function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
+end
+
 function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
     ccall((:vkCmdBindVertexBuffers2EXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
+end
+
+function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
 end
 
 function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable)
     ccall((:vkCmdSetDepthTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
 end
 
+function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
+end
+
 function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable)
     ccall((:vkCmdSetDepthWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
+end
+
+function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
 end
 
 function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp)
     ccall((:vkCmdSetDepthCompareOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
 end
 
+function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
+end
+
 function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable)
     ccall((:vkCmdSetDepthBoundsTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
+end
+
+function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
 end
 
 function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable)
     ccall((:vkCmdSetStencilTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
 end
 
+function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
+end
+
 function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
     ccall((:vkCmdSetStencilOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
+end
+
+function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
 end
 
 struct VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT
@@ -10663,24 +12211,48 @@ function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequir
     ccall((:vkGetGeneratedCommandsMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo)
     ccall((:vkCmdPreprocessGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
+end
+
+function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
 end
 
 function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
     ccall((:vkCmdExecuteGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
 end
 
+function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
+end
+
 function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex)
     ccall((:vkCmdBindPipelineShaderGroupNV, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
+end
+
+function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
 end
 
 function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
     ccall((:vkCreateIndirectCommandsLayoutNV, libvulkan), VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
 end
 
+function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
+end
+
 function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator)
     ccall((:vkDestroyIndirectCommandsLayoutNV, libvulkan), Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
+end
+
+function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
 end
 
 struct VkPhysicalDeviceInheritedViewportScissorFeaturesNV
@@ -10844,16 +12416,32 @@ function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDat
     ccall((:vkCreatePrivateDataSlotEXT, libvulkan), VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
 end
 
+function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDataSlot, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
+end
+
 function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator)
     ccall((:vkDestroyPrivateDataSlotEXT, libvulkan), Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
+end
+
+function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
 end
 
 function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data)
     ccall((:vkSetPrivateDataEXT, libvulkan), VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
 end
 
+function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
+end
+
 function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData)
     ccall((:vkGetPrivateDataEXT, libvulkan), Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
+end
+
+function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
 end
 
 struct VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT
@@ -10934,6 +12522,10 @@ function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerO
     ccall((:vkCmdSetFragmentShadingRateEnumNV, libvulkan), Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
 end
 
+function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
+end
+
 struct VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10984,8 +12576,16 @@ function vkAcquireWinrtDisplayNV(physicalDevice, display)
     ccall((:vkAcquireWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
+function vkAcquireWinrtDisplayNV(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
 function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay)
     ccall((:vkGetWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
+end
+
+function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
 end
 
 struct VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE
@@ -11037,6 +12637,10 @@ function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pV
     ccall((:vkCmdSetVertexInputEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
 end
 
+function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
+end
+
 struct VkPhysicalDeviceExtendedDynamicState2FeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -11064,20 +12668,40 @@ function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints)
     ccall((:vkCmdSetPatchControlPointsEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
 end
 
+function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
+end
+
 function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable)
     ccall((:vkCmdSetRasterizerDiscardEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
+end
+
+function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
 end
 
 function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable)
     ccall((:vkCmdSetDepthBiasEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
 end
 
+function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
+end
+
 function vkCmdSetLogicOpEXT(commandBuffer, logicOp)
     ccall((:vkCmdSetLogicOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
 end
 
+function vkCmdSetLogicOpEXT(commandBuffer, logicOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
+end
+
 function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable)
     ccall((:vkCmdSetPrimitiveRestartEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
+end
+
+function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
 end
 
 struct VkPhysicalDeviceColorWriteEnableFeaturesEXT
@@ -11098,6 +12722,10 @@ const PFN_vkCmdSetColorWriteEnableEXT = Ptr{Cvoid}
 
 function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables)
     ccall((:vkCmdSetColorWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
+end
+
+function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
 end
 
 const VkAccelerationStructureKHR_T = Cvoid
@@ -11386,64 +13014,128 @@ function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAcce
     ccall((:vkCreateAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkCmdBuildAccelerationStructuresKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
     ccall((:vkCmdBuildAccelerationStructuresIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
+end
+
+function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
 end
 
 function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkBuildAccelerationStructuresKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureToMemoryKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
 end
 
+function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
+end
+
 function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyMemoryToAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
     ccall((:vkWriteAccelerationStructuresPropertiesKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
 end
 
+function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
+end
+
 function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureToMemoryKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
 end
 
+function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
+end
+
 function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyMemoryToAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo)
     ccall((:vkGetAccelerationStructureDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
 end
 
+function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
+function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
 function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility)
     ccall((:vkGetDeviceAccelerationStructureCompatibilityKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
 end
 
+function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
+end
+
 function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
     ccall((:vkGetAccelerationStructureBuildSizesKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
+end
+
+function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
 end
 
 @cenum VkShaderGroupShaderKHR::UInt32 begin
@@ -11546,24 +13238,48 @@ function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShader
     ccall((:vkCmdTraceRaysKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
 end
 
+function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingCaptureReplayShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
     ccall((:vkCmdTraceRaysIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
+end
+
+function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
 end
 
 function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader)
     ccall((:vkGetRayTracingShaderGroupStackSizeKHR, libvulkan), VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
 end
 
+function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader, fptr)
+    ccall(fptr, VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
+end
+
 function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize)
     ccall((:vkCmdSetRayTracingPipelineStackSizeKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
+end
+
+function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
 end
 
 struct VkPhysicalDeviceRayQueryFeaturesKHR
@@ -11596,8 +13312,16 @@ function vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateWaylandSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkWaylandSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkWaylandSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display)
     ccall((:vkGetPhysicalDeviceWaylandPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{wl_display}), physicalDevice, queueFamilyIndex, display)
+end
+
+function vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{wl_display}), physicalDevice, queueFamilyIndex, display)
 end
 
 const VkXcbSurfaceCreateFlagsKHR = VkFlags
@@ -11620,8 +13344,16 @@ function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXcbSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id)
     ccall((:vkGetPhysicalDeviceXcbPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
+end
+
+function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
 end
 
 const VkXlibSurfaceCreateFlagsKHR = VkFlags
@@ -11644,8 +13376,16 @@ function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXlibSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID)
     ccall((:vkGetPhysicalDeviceXlibPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
+end
+
+function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
 end
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkAcquireXlibDisplayEXT ) ( VkPhysicalDevice physicalDevice , Display * dpy , VkDisplayKHR display )
@@ -11658,8 +13398,16 @@ function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display)
     ccall((:vkAcquireXlibDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
 end
 
+function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
+end
+
 function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay)
     ccall((:vkGetRandROutputDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
+end
+
+function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
 end
 
 const VULKAN_H_ = 1

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -3200,6 +3200,29 @@ function Base.setproperty!(x::Ptr{VkClearColorValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
+
+function VkClearColorValue(float32::NTuple{4, Cfloat})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkClearColorValue(int32::NTuple{4, Int32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkClearColorValue(uint32::NTuple{4, UInt32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
 struct VkClearDepthStencilValue
     depth::Cfloat
     stencil::UInt32
@@ -3224,6 +3247,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkClearValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
+
+function VkClearValue(color::VkClearColorValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.color = color
+    ref[]
+end
+
+function VkClearValue(depthStencil::VkClearDepthStencilValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.depthStencil = depthStencil
+    ref[]
 end
 
 struct VkClearAttachment
@@ -7779,6 +7818,50 @@ function Base.setproperty!(x::Ptr{VkPerformanceCounterResultKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
+
+function VkPerformanceCounterResultKHR(int32::Int32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(int64::Int64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int64 = int64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint32::UInt32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint64::UInt64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint64 = uint64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float32::Cfloat)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float64::Cdouble)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float64 = float64
+    ref[]
+end
+
 struct VkAcquireProfilingLockInfoKHR
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8468,6 +8551,36 @@ end
 
 function Base.setproperty!(x::Ptr{VkPipelineExecutableStatisticValueKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
+
+function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.b32 = b32
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(i64::Int64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.i64 = i64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.u64 = u64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.f64 = f64
+    ref[]
 end
 
 struct VkPipelineExecutableStatisticKHR
@@ -10728,6 +10841,18 @@ function Base.setproperty!(x::Ptr{VkAccelerationStructureInstanceKHR}, f::Symbol
     unsafe_store!(getproperty(x, f), v)
 end
 
+function VkAccelerationStructureInstanceKHR(transform::VkTransformMatrixKHR, instanceCustomIndex::UInt32, mask::UInt32, instanceShaderBindingTableRecordOffset::UInt32, flags::VkGeometryInstanceFlagsKHR, accelerationStructureReference::UInt64)
+    ref = Ref{VkAccelerationStructureInstanceKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureInstanceKHR}, ref)
+    ptr.transform = transform
+    ptr.instanceCustomIndex = instanceCustomIndex
+    ptr.mask = mask
+    ptr.instanceShaderBindingTableRecordOffset = instanceShaderBindingTableRecordOffset
+    ptr.flags = flags
+    ptr.accelerationStructureReference = accelerationStructureReference
+    ref[]
+end
+
 const VkAccelerationStructureInstanceNV = VkAccelerationStructureInstanceKHR
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkCreateAccelerationStructureNV ) ( VkDevice device , const VkAccelerationStructureCreateInfoNV * pCreateInfo , const VkAllocationCallbacks * pAllocator , VkAccelerationStructureNV * pAccelerationStructure )
@@ -11284,6 +11409,43 @@ end
 
 function Base.setproperty!(x::Ptr{VkPerformanceValueDataINTEL}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
+
+function VkPerformanceValueDataINTEL(value32::UInt32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value32 = value32
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(value64::UInt64)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value64 = value64
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueFloat = valueFloat
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueBool::VkBool32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueBool = valueBool
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueString = valueString
+    ref[]
 end
 
 struct VkPerformanceValueINTEL
@@ -12779,6 +12941,22 @@ function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
+end
+
 struct VkDeviceOrHostAddressConstKHR
     data::NTuple{8, UInt8}
 end
@@ -12798,6 +12976,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressConstKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
 end
 
 struct VkAccelerationStructureBuildRangeInfoKHR
@@ -12853,6 +13047,29 @@ end
 
 function Base.setproperty!(x::Ptr{VkAccelerationStructureGeometryDataKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
+
+function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.triangles = triangles
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.aabbs = aabbs
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.instances = instances
+    ref[]
 end
 
 struct VkAccelerationStructureGeometryKHR

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -3202,24 +3202,16 @@ end
 
 const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
 
-function VkClearColorValue(float32::NTuple{4, Cfloat})
+function VkClearColorValue(val::__U_VkClearColorValue)
     ref = Ref{VkClearColorValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkClearColorValue(int32::NTuple{4, Int32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkClearColorValue(uint32::NTuple{4, UInt32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.uint32 = uint32
+    if val isa NTuple{4, Cfloat}
+        ptr.float32 = val
+    elseif val isa NTuple{4, Int32}
+        ptr.int32 = val
+    elseif val isa NTuple{4, UInt32}
+        ptr.uint32 = val
+    end
     ref[]
 end
 
@@ -3251,17 +3243,14 @@ end
 
 const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
 
-function VkClearValue(color::VkClearColorValue)
+function VkClearValue(val::__U_VkClearValue)
     ref = Ref{VkClearValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.color = color
-    ref[]
-end
-
-function VkClearValue(depthStencil::VkClearDepthStencilValue)
-    ref = Ref{VkClearValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.depthStencil = depthStencil
+    if val isa VkClearColorValue
+        ptr.color = val
+    elseif val isa VkClearDepthStencilValue
+        ptr.depthStencil = val
+    end
     ref[]
 end
 
@@ -7820,45 +7809,22 @@ end
 
 const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
 
-function VkPerformanceCounterResultKHR(int32::Int32)
+function VkPerformanceCounterResultKHR(val::__U_VkPerformanceCounterResultKHR)
     ref = Ref{VkPerformanceCounterResultKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(int64::Int64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int64 = int64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint32::UInt32)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint32 = uint32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint64::UInt64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint64 = uint64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float32::Cfloat)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float64::Cdouble)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float64 = float64
+    if val isa Int32
+        ptr.int32 = val
+    elseif val isa Int64
+        ptr.int64 = val
+    elseif val isa UInt32
+        ptr.uint32 = val
+    elseif val isa UInt64
+        ptr.uint64 = val
+    elseif val isa Cfloat
+        ptr.float32 = val
+    elseif val isa Cdouble
+        ptr.float64 = val
+    end
     ref[]
 end
 
@@ -8555,31 +8521,18 @@ end
 
 const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
 
-function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+function VkPipelineExecutableStatisticValueKHR(val::__U_VkPipelineExecutableStatisticValueKHR)
     ref = Ref{VkPipelineExecutableStatisticValueKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.b32 = b32
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(i64::Int64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.i64 = i64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.u64 = u64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.f64 = f64
+    if val isa VkBool32
+        ptr.b32 = val
+    elseif val isa Int64
+        ptr.i64 = val
+    elseif val isa UInt64
+        ptr.u64 = val
+    elseif val isa Cdouble
+        ptr.f64 = val
+    end
     ref[]
 end
 
@@ -11413,38 +11366,20 @@ end
 
 const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
 
-function VkPerformanceValueDataINTEL(value32::UInt32)
+function VkPerformanceValueDataINTEL(val::__U_VkPerformanceValueDataINTEL)
     ref = Ref{VkPerformanceValueDataINTEL}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value32 = value32
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(value64::UInt64)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value64 = value64
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueFloat = valueFloat
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueBool::VkBool32)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueBool = valueBool
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueString = valueString
+    if val isa UInt32
+        ptr.value32 = val
+    elseif val isa UInt64
+        ptr.value64 = val
+    elseif val isa Cfloat
+        ptr.valueFloat = val
+    elseif val isa VkBool32
+        ptr.valueBool = val
+    elseif val isa Ptr{Cchar}
+        ptr.valueString = val
+    end
     ref[]
 end
 
@@ -12943,17 +12878,14 @@ end
 
 const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressKHR(val::__U_VkDeviceOrHostAddressKHR)
     ref = Ref{VkDeviceOrHostAddressKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -12980,17 +12912,14 @@ end
 
 const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressConstKHR(val::__U_VkDeviceOrHostAddressConstKHR)
     ref = Ref{VkDeviceOrHostAddressConstKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressConstKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -13051,24 +12980,16 @@ end
 
 const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
 
-function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+function VkAccelerationStructureGeometryDataKHR(val::__U_VkAccelerationStructureGeometryDataKHR)
     ref = Ref{VkAccelerationStructureGeometryDataKHR}()
     ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.triangles = triangles
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.aabbs = aabbs
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.instances = instances
+    if val isa VkAccelerationStructureGeometryTrianglesDataKHR
+        ptr.triangles = val
+    elseif val isa VkAccelerationStructureGeometryAabbsDataKHR
+        ptr.aabbs = val
+    elseif val isa VkAccelerationStructureGeometryInstancesDataKHR
+        ptr.instances = val
+    end
     ref[]
 end
 

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -3686,548 +3686,1096 @@ function vkCreateInstance(pCreateInfo, pAllocator, pInstance)
     ccall((:vkCreateInstance, libvulkan), VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
 end
 
+function vkCreateInstance(pCreateInfo, pAllocator, pInstance, fptr)
+    ccall(fptr, VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
+end
+
 function vkDestroyInstance(instance, pAllocator)
     ccall((:vkDestroyInstance, libvulkan), Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
+end
+
+function vkDestroyInstance(instance, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
 end
 
 function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices)
     ccall((:vkEnumeratePhysicalDevices, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
 end
 
+function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
+end
+
 function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
+end
+
+function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
 end
 
 function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceProperties(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
 end
 
+function vkGetPhysicalDeviceProperties(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
+end
+
 function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
+function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
 function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetInstanceProcAddr(instance, pName)
     ccall((:vkGetInstanceProcAddr, libvulkan), PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
+end
+
+function vkGetInstanceProcAddr(instance, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
 end
 
 function vkGetDeviceProcAddr(device, pName)
     ccall((:vkGetDeviceProcAddr, libvulkan), PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
 end
 
+function vkGetDeviceProcAddr(device, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
+end
+
 function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice)
     ccall((:vkCreateDevice, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
+end
+
+function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
 end
 
 function vkDestroyDevice(device, pAllocator)
     ccall((:vkDestroyDevice, libvulkan), Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
 end
 
+function vkDestroyDevice(device, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
+end
+
 function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceExtensionProperties, libvulkan), VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceExtensionProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
+end
+
 function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceLayerProperties, libvulkan), VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceLayerProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue)
     ccall((:vkGetDeviceQueue, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
+end
+
+function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
 end
 
 function vkQueueSubmit(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
+function vkQueueSubmit(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
 function vkQueueWaitIdle(queue)
     ccall((:vkQueueWaitIdle, libvulkan), VkResult, (VkQueue,), queue)
+end
+
+function vkQueueWaitIdle(queue, fptr)
+    ccall(fptr, VkResult, (VkQueue,), queue)
 end
 
 function vkDeviceWaitIdle(device)
     ccall((:vkDeviceWaitIdle, libvulkan), VkResult, (VkDevice,), device)
 end
 
+function vkDeviceWaitIdle(device, fptr)
+    ccall(fptr, VkResult, (VkDevice,), device)
+end
+
 function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory)
     ccall((:vkAllocateMemory, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
+end
+
+function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
 end
 
 function vkFreeMemory(device, memory, pAllocator)
     ccall((:vkFreeMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
 end
 
+function vkFreeMemory(device, memory, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
+end
+
 function vkMapMemory(device, memory, offset, size, flags, ppData)
     ccall((:vkMapMemory, libvulkan), VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
+end
+
+function vkMapMemory(device, memory, offset, size, flags, ppData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
 end
 
 function vkUnmapMemory(device, memory)
     ccall((:vkUnmapMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory), device, memory)
 end
 
+function vkUnmapMemory(device, memory, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory), device, memory)
+end
+
 function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkFlushMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
+function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
 function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkInvalidateMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
+function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
 function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes)
     ccall((:vkGetDeviceMemoryCommitment, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
+end
+
+function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
 end
 
 function vkBindBufferMemory(device, buffer, memory, memoryOffset)
     ccall((:vkBindBufferMemory, libvulkan), VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
 end
 
+function vkBindBufferMemory(device, buffer, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
+end
+
 function vkBindImageMemory(device, image, memory, memoryOffset)
     ccall((:vkBindImageMemory, libvulkan), VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
+end
+
+function vkBindImageMemory(device, image, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
 end
 
 function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
+end
+
 function vkGetImageMemoryRequirements(device, image, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements(device, image, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
 end
 
 function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
+function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
 end
 
 function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence)
     ccall((:vkQueueBindSparse, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
 end
 
+function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
+end
+
 function vkCreateFence(device, pCreateInfo, pAllocator, pFence)
     ccall((:vkCreateFence, libvulkan), VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
+end
+
+function vkCreateFence(device, pCreateInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
 end
 
 function vkDestroyFence(device, fence, pAllocator)
     ccall((:vkDestroyFence, libvulkan), Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
 end
 
+function vkDestroyFence(device, fence, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
+end
+
 function vkResetFences(device, fenceCount, pFences)
     ccall((:vkResetFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
+end
+
+function vkResetFences(device, fenceCount, pFences, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
 end
 
 function vkGetFenceStatus(device, fence)
     ccall((:vkGetFenceStatus, libvulkan), VkResult, (VkDevice, VkFence), device, fence)
 end
 
+function vkGetFenceStatus(device, fence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkFence), device, fence)
+end
+
 function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout)
     ccall((:vkWaitForFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
+end
+
+function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
 end
 
 function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore)
     ccall((:vkCreateSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
 end
 
+function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
+end
+
 function vkDestroySemaphore(device, semaphore, pAllocator)
     ccall((:vkDestroySemaphore, libvulkan), Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
+end
+
+function vkDestroySemaphore(device, semaphore, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
 end
 
 function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent)
     ccall((:vkCreateEvent, libvulkan), VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
 end
 
+function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
+end
+
 function vkDestroyEvent(device, event, pAllocator)
     ccall((:vkDestroyEvent, libvulkan), Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
+end
+
+function vkDestroyEvent(device, event, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
 end
 
 function vkGetEventStatus(device, event)
     ccall((:vkGetEventStatus, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkGetEventStatus(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkSetEvent(device, event)
     ccall((:vkSetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
+end
+
+function vkSetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
 end
 
 function vkResetEvent(device, event)
     ccall((:vkResetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkResetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool)
     ccall((:vkCreateQueryPool, libvulkan), VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
+end
+
+function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
 end
 
 function vkDestroyQueryPool(device, queryPool, pAllocator)
     ccall((:vkDestroyQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
 end
 
+function vkDestroyQueryPool(device, queryPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
+end
+
 function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
     ccall((:vkGetQueryPoolResults, libvulkan), VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
+end
+
+function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
 end
 
 function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer)
     ccall((:vkCreateBuffer, libvulkan), VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
 end
 
+function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
+end
+
 function vkDestroyBuffer(device, buffer, pAllocator)
     ccall((:vkDestroyBuffer, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
+end
+
+function vkDestroyBuffer(device, buffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
 end
 
 function vkCreateBufferView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateBufferView, libvulkan), VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
 end
 
+function vkCreateBufferView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
+end
+
 function vkDestroyBufferView(device, bufferView, pAllocator)
     ccall((:vkDestroyBufferView, libvulkan), Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
+end
+
+function vkDestroyBufferView(device, bufferView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
 end
 
 function vkCreateImage(device, pCreateInfo, pAllocator, pImage)
     ccall((:vkCreateImage, libvulkan), VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
 end
 
+function vkCreateImage(device, pCreateInfo, pAllocator, pImage, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
+end
+
 function vkDestroyImage(device, image, pAllocator)
     ccall((:vkDestroyImage, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
+end
+
+function vkDestroyImage(device, image, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
 end
 
 function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout)
     ccall((:vkGetImageSubresourceLayout, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
 end
 
+function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
+end
+
 function vkCreateImageView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateImageView, libvulkan), VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
+end
+
+function vkCreateImageView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
 end
 
 function vkDestroyImageView(device, imageView, pAllocator)
     ccall((:vkDestroyImageView, libvulkan), Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
 end
 
+function vkDestroyImageView(device, imageView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
+end
+
 function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule)
     ccall((:vkCreateShaderModule, libvulkan), VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
+end
+
+function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
 end
 
 function vkDestroyShaderModule(device, shaderModule, pAllocator)
     ccall((:vkDestroyShaderModule, libvulkan), Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
 end
 
+function vkDestroyShaderModule(device, shaderModule, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
+end
+
 function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache)
     ccall((:vkCreatePipelineCache, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
+end
+
+function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
 end
 
 function vkDestroyPipelineCache(device, pipelineCache, pAllocator)
     ccall((:vkDestroyPipelineCache, libvulkan), Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
 end
 
+function vkDestroyPipelineCache(device, pipelineCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
+end
+
 function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData)
     ccall((:vkGetPipelineCacheData, libvulkan), VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
+end
+
+function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
 end
 
 function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergePipelineCaches, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateGraphicsPipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateComputePipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
+function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
 function vkDestroyPipeline(device, pipeline, pAllocator)
     ccall((:vkDestroyPipeline, libvulkan), Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
+end
+
+function vkDestroyPipeline(device, pipeline, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
 end
 
 function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout)
     ccall((:vkCreatePipelineLayout, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
 end
 
+function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
+end
+
 function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator)
     ccall((:vkDestroyPipelineLayout, libvulkan), Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
+end
+
+function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
 end
 
 function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler)
     ccall((:vkCreateSampler, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
 end
 
+function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
+end
+
 function vkDestroySampler(device, sampler, pAllocator)
     ccall((:vkDestroySampler, libvulkan), Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
+end
+
+function vkDestroySampler(device, sampler, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
 end
 
 function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout)
     ccall((:vkCreateDescriptorSetLayout, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
 end
 
+function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
+end
+
 function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator)
     ccall((:vkDestroyDescriptorSetLayout, libvulkan), Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
+end
+
+function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
 end
 
 function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool)
     ccall((:vkCreateDescriptorPool, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
 end
 
+function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
+end
+
 function vkDestroyDescriptorPool(device, descriptorPool, pAllocator)
     ccall((:vkDestroyDescriptorPool, libvulkan), Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
+end
+
+function vkDestroyDescriptorPool(device, descriptorPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
 end
 
 function vkResetDescriptorPool(device, descriptorPool, flags)
     ccall((:vkResetDescriptorPool, libvulkan), VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
 end
 
+function vkResetDescriptorPool(device, descriptorPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
+end
+
 function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets)
     ccall((:vkAllocateDescriptorSets, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
+end
+
+function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
 end
 
 function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets)
     ccall((:vkFreeDescriptorSets, libvulkan), VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
 end
 
+function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
+end
+
 function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
     ccall((:vkUpdateDescriptorSets, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
+end
+
+function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
 end
 
 function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer)
     ccall((:vkCreateFramebuffer, libvulkan), VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
 end
 
+function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
+end
+
 function vkDestroyFramebuffer(device, framebuffer, pAllocator)
     ccall((:vkDestroyFramebuffer, libvulkan), Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
+end
+
+function vkDestroyFramebuffer(device, framebuffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
 end
 
 function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkDestroyRenderPass(device, renderPass, pAllocator)
     ccall((:vkDestroyRenderPass, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
+end
+
+function vkDestroyRenderPass(device, renderPass, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
 end
 
 function vkGetRenderAreaGranularity(device, renderPass, pGranularity)
     ccall((:vkGetRenderAreaGranularity, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
 end
 
+function vkGetRenderAreaGranularity(device, renderPass, pGranularity, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
+end
+
 function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool)
     ccall((:vkCreateCommandPool, libvulkan), VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
+end
+
+function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
 end
 
 function vkDestroyCommandPool(device, commandPool, pAllocator)
     ccall((:vkDestroyCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
 end
 
+function vkDestroyCommandPool(device, commandPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
+end
+
 function vkResetCommandPool(device, commandPool, flags)
     ccall((:vkResetCommandPool, libvulkan), VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
+end
+
+function vkResetCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
 end
 
 function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers)
     ccall((:vkAllocateCommandBuffers, libvulkan), VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
 end
 
+function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
+end
+
 function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers)
     ccall((:vkFreeCommandBuffers, libvulkan), Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
+end
+
+function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
 end
 
 function vkBeginCommandBuffer(commandBuffer, pBeginInfo)
     ccall((:vkBeginCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
 end
 
+function vkBeginCommandBuffer(commandBuffer, pBeginInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
+end
+
 function vkEndCommandBuffer(commandBuffer)
     ccall((:vkEndCommandBuffer, libvulkan), VkResult, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkEndCommandBuffer(commandBuffer, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer,), commandBuffer)
 end
 
 function vkResetCommandBuffer(commandBuffer, flags)
     ccall((:vkResetCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
 end
 
+function vkResetCommandBuffer(commandBuffer, flags, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
+end
+
 function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline)
     ccall((:vkCmdBindPipeline, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
+end
+
+function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
 end
 
 function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports)
     ccall((:vkCmdSetViewport, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
 end
 
+function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
+end
+
 function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors)
     ccall((:vkCmdSetScissor, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
+end
+
+function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
 end
 
 function vkCmdSetLineWidth(commandBuffer, lineWidth)
     ccall((:vkCmdSetLineWidth, libvulkan), Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
 end
 
+function vkCmdSetLineWidth(commandBuffer, lineWidth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
+end
+
 function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
     ccall((:vkCmdSetDepthBias, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
+end
+
+function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
 end
 
 function vkCmdSetBlendConstants(commandBuffer, blendConstants)
     ccall((:vkCmdSetBlendConstants, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
 end
 
+function vkCmdSetBlendConstants(commandBuffer, blendConstants, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
+end
+
 function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds)
     ccall((:vkCmdSetDepthBounds, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
+end
+
+function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
 end
 
 function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask)
     ccall((:vkCmdSetStencilCompareMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
 end
 
+function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
+end
+
 function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask)
     ccall((:vkCmdSetStencilWriteMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
+end
+
+function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
 end
 
 function vkCmdSetStencilReference(commandBuffer, faceMask, reference)
     ccall((:vkCmdSetStencilReference, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
 end
 
+function vkCmdSetStencilReference(commandBuffer, faceMask, reference, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
+end
+
 function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
     ccall((:vkCmdBindDescriptorSets, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
+end
+
+function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
 end
 
 function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType)
     ccall((:vkCmdBindIndexBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
 end
 
+function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
+end
+
 function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
     ccall((:vkCmdBindVertexBuffers, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
+end
+
+function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
 end
 
 function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
     ccall((:vkCmdDraw, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
 end
 
+function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
+end
+
 function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
     ccall((:vkCmdDrawIndexed, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
+end
+
+function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
 end
 
 function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndexedIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
 function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatch, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
 end
 
+function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
+end
+
 function vkCmdDispatchIndirect(commandBuffer, buffer, offset)
     ccall((:vkCmdDispatchIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
+end
+
+function vkCmdDispatchIndirect(commandBuffer, buffer, offset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
 end
 
 function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
     ccall((:vkCmdBlitImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
 end
 
+function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
+end
+
 function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyBufferToImage, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyImageToBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData)
     ccall((:vkCmdUpdateBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
+end
+
+function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
 end
 
 function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data)
     ccall((:vkCmdFillBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
 end
 
+function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
+end
+
 function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
     ccall((:vkCmdClearColorImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
+end
+
+function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
 end
 
 function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
     ccall((:vkCmdClearDepthStencilImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
 end
 
+function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
+end
+
 function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
     ccall((:vkCmdClearAttachments, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
+end
+
+function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
 end
 
 function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdResolveImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
+function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
 function vkCmdSetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdSetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
+function vkCmdSetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
 function vkCmdResetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
+function vkCmdResetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
 function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdWaitEvents, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
+function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
 function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdPipelineBarrier, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
+function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
 function vkCmdBeginQuery(commandBuffer, queryPool, query, flags)
     ccall((:vkCmdBeginQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
+end
+
+function vkCmdBeginQuery(commandBuffer, queryPool, query, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
 end
 
 function vkCmdEndQuery(commandBuffer, queryPool, query)
     ccall((:vkCmdEndQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
 end
 
+function vkCmdEndQuery(commandBuffer, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
+end
+
 function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount)
     ccall((:vkCmdResetQueryPool, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
+end
+
+function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
 end
 
 function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query)
     ccall((:vkCmdWriteTimestamp, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
+end
+
 function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
     ccall((:vkCmdCopyQueryPoolResults, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
+end
+
+function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
 end
 
 function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues)
     ccall((:vkCmdPushConstants, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
 end
 
+function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
+end
+
 function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents)
     ccall((:vkCmdBeginRenderPass, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
+end
+
+function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
 end
 
 function vkCmdNextSubpass(commandBuffer, contents)
     ccall((:vkCmdNextSubpass, libvulkan), Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
 end
 
+function vkCmdNextSubpass(commandBuffer, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
+end
+
 function vkCmdEndRenderPass(commandBuffer)
     ccall((:vkCmdEndRenderPass, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndRenderPass(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers)
     ccall((:vkCmdExecuteCommands, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
+end
+
+function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
 end
 
 const VkSamplerYcbcrConversion_T = Cvoid
@@ -5017,112 +5565,224 @@ function vkEnumerateInstanceVersion(pApiVersion)
     ccall((:vkEnumerateInstanceVersion, libvulkan), VkResult, (Ptr{UInt32},), pApiVersion)
 end
 
+function vkEnumerateInstanceVersion(pApiVersion, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32},), pApiVersion)
+end
+
 function vkBindBufferMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindBufferMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 function vkBindImageMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindImageMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
     ccall((:vkGetDeviceGroupPeerMemoryFeatures, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
+function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
 function vkCmdSetDeviceMask(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMask, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMask(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBase, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroups, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
+function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
 function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
 function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
+function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
 function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
 function vkTrimCommandPool(device, commandPool, flags)
     ccall((:vkTrimCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
+function vkTrimCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
 function vkGetDeviceQueue2(device, pQueueInfo, pQueue)
     ccall((:vkGetDeviceQueue2, libvulkan), Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
 end
 
+function vkGetDeviceQueue2(device, pQueueInfo, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
+end
+
 function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion)
     ccall((:vkCreateSamplerYcbcrConversion, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
+function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
 function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversion, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
+function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
 function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
     ccall((:vkCreateDescriptorUpdateTemplate, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
+function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
 function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
+function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
 function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFenceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphoreProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
+function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
 function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupport, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
+function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
 @cenum VkDriverId::UInt32 begin
@@ -5822,52 +6482,104 @@ function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, coun
     ccall((:vkCmdDrawIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 function vkResetQueryPool(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
+function vkResetQueryPool(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
 function vkGetSemaphoreCounterValue(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValue, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
+function vkGetSemaphoreCounterValue(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
 function vkWaitSemaphores(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphores, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphores(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphore(device, pSignalInfo)
     ccall((:vkSignalSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphore(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 function vkGetBufferDeviceAddress(device, pInfo)
     ccall((:vkGetBufferDeviceAddress, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddress(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkSurfaceKHR_T = Cvoid
@@ -5968,20 +6680,40 @@ function vkDestroySurfaceKHR(instance, surface, pAllocator)
     ccall((:vkDestroySurfaceKHR, libvulkan), Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
 end
 
+function vkDestroySurfaceKHR(instance, surface, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
+end
+
 function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported)
     ccall((:vkGetPhysicalDeviceSurfaceSupportKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
+end
+
+function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
 end
 
 function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormatsKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
 end
 
+function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
+end
+
 function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes)
     ccall((:vkGetPhysicalDeviceSurfacePresentModesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
+end
+
+function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
 end
 
 const VkSwapchainKHR_T = Cvoid
@@ -6114,36 +6846,72 @@ function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain)
     ccall((:vkCreateSwapchainKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
 end
 
+function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
+end
+
 function vkDestroySwapchainKHR(device, swapchain, pAllocator)
     ccall((:vkDestroySwapchainKHR, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
+end
+
+function vkDestroySwapchainKHR(device, swapchain, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
 end
 
 function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages)
     ccall((:vkGetSwapchainImagesKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
 end
 
+function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
+end
+
 function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex)
     ccall((:vkAcquireNextImageKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
+end
+
+function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
 end
 
 function vkQueuePresentKHR(queue, pPresentInfo)
     ccall((:vkQueuePresentKHR, libvulkan), VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
 end
 
+function vkQueuePresentKHR(queue, pPresentInfo, fptr)
+    ccall(fptr, VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
+end
+
 function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities)
     ccall((:vkGetDeviceGroupPresentCapabilitiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
+end
+
+function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
 end
 
 function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes)
     ccall((:vkGetDeviceGroupSurfacePresentModesKHR, libvulkan), VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
 end
 
+function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
+end
+
 function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects)
     ccall((:vkGetPhysicalDevicePresentRectanglesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
 end
 
+function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
+end
+
 function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex)
     ccall((:vkAcquireNextImage2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
+end
+
+function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
 end
 
 const VkDisplayKHR_T = Cvoid
@@ -6250,28 +7018,56 @@ function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount,
     ccall((:vkGetPhysicalDeviceDisplayPropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlanePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays)
     ccall((:vkGetDisplayPlaneSupportedDisplaysKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
 end
 
+function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
+end
+
 function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
+function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
 function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode)
     ccall((:vkCreateDisplayModeKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
 end
 
+function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
+end
+
 function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
 end
 
+function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
+end
+
 function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateDisplayPlaneSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
+function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
 struct VkDisplayPresentInfoKHR
@@ -6287,6 +7083,10 @@ const PFN_vkCreateSharedSwapchainsKHR = Ptr{Cvoid}
 
 function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
     ccall((:vkCreateSharedSwapchainsKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
+end
+
+function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
 end
 
 const VkRenderPassMultiviewCreateInfoKHR = VkRenderPassMultiviewCreateInfo
@@ -6338,28 +7138,56 @@ function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
 const VkPeerMemoryFeatureFlagsKHR = VkPeerMemoryFeatureFlags
@@ -6397,12 +7225,24 @@ function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceInd
     ccall((:vkGetDeviceGroupPeerMemoryFeaturesKHR, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
+function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
 function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMaskKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBaseKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 const VkCommandPoolTrimFlagsKHR = VkCommandPoolTrimFlags
@@ -6414,6 +7254,10 @@ function vkTrimCommandPoolKHR(device, commandPool, flags)
     ccall((:vkTrimCommandPoolKHR, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
+function vkTrimCommandPoolKHR(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
 const VkPhysicalDeviceGroupPropertiesKHR = VkPhysicalDeviceGroupProperties
 
 const VkDeviceGroupDeviceCreateInfoKHR = VkDeviceGroupDeviceCreateInfo
@@ -6423,6 +7267,10 @@ const PFN_vkEnumeratePhysicalDeviceGroupsKHR = Ptr{Cvoid}
 
 function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroupsKHR, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
+function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
 const VkExternalMemoryHandleTypeFlagsKHR = VkExternalMemoryHandleTypeFlags
@@ -6450,6 +7298,10 @@ const PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferPropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
+function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
 const VkExternalMemoryImageCreateInfoKHR = VkExternalMemoryImageCreateInfo
@@ -6488,8 +7340,16 @@ function vkGetMemoryFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetMemoryFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
+function vkGetMemoryFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
 function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties)
     ccall((:vkGetMemoryFdPropertiesKHR, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
+end
+
+function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
 end
 
 const VkExternalSemaphoreHandleTypeFlagsKHR = VkExternalSemaphoreHandleTypeFlags
@@ -6509,6 +7369,10 @@ const PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphorePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
+function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
 const VkSemaphoreImportFlagsKHR = VkSemaphoreImportFlags
@@ -6543,8 +7407,16 @@ function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo)
     ccall((:vkImportSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
 end
 
+function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
+end
+
 function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 struct VkPhysicalDevicePushDescriptorPropertiesKHR
@@ -6563,8 +7435,16 @@ function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set
     ccall((:vkCmdPushDescriptorSetKHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
 end
 
+function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
+end
+
 function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData)
     ccall((:vkCmdPushDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
+end
+
+function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
 end
 
 const VkPhysicalDeviceShaderFloat16Int8FeaturesKHR = VkPhysicalDeviceShaderFloat16Int8Features
@@ -6614,12 +7494,24 @@ function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pD
     ccall((:vkCreateDescriptorUpdateTemplateKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
+function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
 function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 const VkPhysicalDeviceImagelessFramebufferFeaturesKHR = VkPhysicalDeviceImagelessFramebufferFeatures
@@ -6660,16 +7552,32 @@ function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 struct VkSharedPresentSurfaceCapabilitiesKHR
@@ -6683,6 +7591,10 @@ const PFN_vkGetSwapchainStatusKHR = Ptr{Cvoid}
 
 function vkGetSwapchainStatusKHR(device, swapchain)
     ccall((:vkGetSwapchainStatusKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
+end
+
+function vkGetSwapchainStatusKHR(device, swapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
 end
 
 const VkExternalFenceHandleTypeFlagsKHR = VkExternalFenceHandleTypeFlags
@@ -6702,6 +7614,10 @@ const PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFencePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 const VkFenceImportFlagsKHR = VkFenceImportFlags
@@ -6736,8 +7652,16 @@ function vkImportFenceFdKHR(device, pImportFenceFdInfo)
     ccall((:vkImportFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
 end
 
+function vkImportFenceFdKHR(device, pImportFenceFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
+end
+
 function vkGetFenceFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetFenceFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 @cenum VkPerformanceCounterUnitKHR::UInt32 begin
@@ -6884,16 +7808,32 @@ function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physica
     ccall((:vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
 end
 
+function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
+end
+
 function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
     ccall((:vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
+end
+
+function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
 end
 
 function vkAcquireProfilingLockKHR(device, pInfo)
     ccall((:vkAcquireProfilingLockKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
 end
 
+function vkAcquireProfilingLockKHR(device, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
+end
+
 function vkReleaseProfilingLockKHR(device)
     ccall((:vkReleaseProfilingLockKHR, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkReleaseProfilingLockKHR(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 const VkPointClippingBehaviorKHR = VkPointClippingBehavior
@@ -6938,8 +7878,16 @@ function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormats2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
+end
+
+function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
 end
 
 const VkPhysicalDeviceVariablePointerFeaturesKHR = VkPhysicalDeviceVariablePointersFeatures
@@ -6993,16 +7941,32 @@ function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount
     ccall((:vkGetPhysicalDeviceDisplayProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlaneProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModeProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
+function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
 function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
+end
+
+function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
 end
 
 const VkMemoryDedicatedRequirementsKHR = VkMemoryDedicatedRequirements
@@ -7032,12 +7996,24 @@ function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 const VkImageFormatListCreateInfoKHR = VkImageFormatListCreateInfo
@@ -7072,8 +8048,16 @@ function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcb
     ccall((:vkCreateSamplerYcbcrConversionKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
+function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
 function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversionKHR, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
+function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
 const VkBindBufferMemoryInfoKHR = VkBindBufferMemoryInfo
@@ -7090,8 +8074,16 @@ function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 const VkPhysicalDeviceMaintenance3PropertiesKHR = VkPhysicalDeviceMaintenance3Properties
@@ -7105,6 +8097,10 @@ function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupportKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
+function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountKHR ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
 const PFN_vkCmdDrawIndirectCountKHR = Ptr{Cvoid}
 
@@ -7115,8 +8111,16 @@ function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 const VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR = VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures
@@ -7181,12 +8185,24 @@ function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValueKHR, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
+function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
 function vkWaitSemaphoresKHR(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphoresKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphoresKHR(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphoreKHR(device, pSignalInfo)
     ccall((:vkSignalSemaphoreKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphoreKHR(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR = VkPhysicalDeviceVulkanMemoryModelFeatures
@@ -7267,8 +8283,16 @@ function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentSha
     ccall((:vkGetPhysicalDeviceFragmentShadingRatesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
 end
 
+function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
+end
+
 function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps)
     ccall((:vkCmdSetFragmentShadingRateKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
+end
+
+function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
 end
 
 struct VkSurfaceProtectedCapabilitiesKHR
@@ -7308,12 +8332,24 @@ function vkGetBufferDeviceAddressKHR(device, pInfo)
     ccall((:vkGetBufferDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkDeferredOperationKHR_T = Cvoid
@@ -7339,20 +8375,40 @@ function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation)
     ccall((:vkCreateDeferredOperationKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
 end
 
+function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
+end
+
 function vkDestroyDeferredOperationKHR(device, operation, pAllocator)
     ccall((:vkDestroyDeferredOperationKHR, libvulkan), Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
+end
+
+function vkDestroyDeferredOperationKHR(device, operation, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
 end
 
 function vkGetDeferredOperationMaxConcurrencyKHR(device, operation)
     ccall((:vkGetDeferredOperationMaxConcurrencyKHR, libvulkan), UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationMaxConcurrencyKHR(device, operation, fptr)
+    ccall(fptr, UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkGetDeferredOperationResultKHR(device, operation)
     ccall((:vkGetDeferredOperationResultKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationResultKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkDeferredOperationJoinKHR(device, operation)
     ccall((:vkDeferredOperationJoinKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
+function vkDeferredOperationJoinKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
 @cenum VkPipelineExecutableStatisticFormatKHR::UInt32 begin
@@ -7446,12 +8502,24 @@ function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutable
     ccall((:vkGetPipelineExecutablePropertiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
 end
 
+function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutableCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
+end
+
 function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics)
     ccall((:vkGetPipelineExecutableStatisticsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
 end
 
+function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
+end
+
 function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
     ccall((:vkGetPipelineExecutableInternalRepresentationsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
+end
+
+function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
 end
 
 struct VkPipelineLibraryCreateInfoKHR
@@ -7603,32 +8671,64 @@ function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo)
     ccall((:vkCmdSetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
 end
 
+function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
+end
+
 function vkCmdResetEvent2KHR(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
+end
+
+function vkCmdResetEvent2KHR(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
 end
 
 function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos)
     ccall((:vkCmdWaitEvents2KHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
 end
 
+function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
+end
+
 function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo)
     ccall((:vkCmdPipelineBarrier2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
+end
+
+function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
 end
 
 function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query)
     ccall((:vkCmdWriteTimestamp2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
+end
+
 function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit2KHR, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
+function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
 function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarker2AMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
 end
 
+function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
+end
+
 function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointData2NV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR
@@ -7779,24 +8879,48 @@ function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo)
     ccall((:vkCmdCopyBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
 end
 
+function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
+end
+
 function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo)
     ccall((:vkCmdCopyImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
+end
+
+function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
 end
 
 function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo)
     ccall((:vkCmdCopyBufferToImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
 end
 
+function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
+end
+
 function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo)
     ccall((:vkCmdCopyImageToBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
+end
+
+function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
 end
 
 function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo)
     ccall((:vkCmdBlitImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
 end
 
+function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
+end
+
 function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo)
     ccall((:vkCmdResolveImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
+end
+
+function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
 end
 
 const VkDebugReportCallbackEXT_T = Cvoid
@@ -7882,12 +9006,24 @@ function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCall
     ccall((:vkCreateDebugReportCallbackEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
 end
 
+function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
+end
+
 function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator)
     ccall((:vkDestroyDebugReportCallbackEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
 end
 
+function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
+end
+
 function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
     ccall((:vkDebugReportMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
+end
+
+function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
 end
 
 @cenum VkRasterizationOrderAMD::UInt32 begin
@@ -7946,20 +9082,40 @@ function vkDebugMarkerSetObjectTagEXT(device, pTagInfo)
     ccall((:vkDebugMarkerSetObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
 end
 
+function vkDebugMarkerSetObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
+end
+
 function vkDebugMarkerSetObjectNameEXT(device, pNameInfo)
     ccall((:vkDebugMarkerSetObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
+end
+
+function vkDebugMarkerSetObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
 end
 
 function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerBeginEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdDebugMarkerEndEXT(commandBuffer)
     ccall((:vkCmdDebugMarkerEndEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdDebugMarkerEndEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerInsertEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
 struct VkDedicatedAllocationImageCreateInfoNV
@@ -8034,24 +9190,48 @@ function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindi
     ccall((:vkCmdBindTransformFeedbackBuffersEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
 end
 
+function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
+end
+
 function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdBeginTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
+function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
 function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdEndTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
+function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
 function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index)
     ccall((:vkCmdBeginQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
+end
+
+function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
 end
 
 function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index)
     ccall((:vkCmdEndQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
 end
 
+function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
+end
+
 function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
     ccall((:vkCmdDrawIndirectByteCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
+end
+
+function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
 end
 
 struct VkImageViewHandleInfoNVX
@@ -8079,8 +9259,16 @@ function vkGetImageViewHandleNVX(device, pInfo)
     ccall((:vkGetImageViewHandleNVX, libvulkan), UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
 end
 
+function vkGetImageViewHandleNVX(device, pInfo, fptr)
+    ccall(fptr, UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
+end
+
 function vkGetImageViewAddressNVX(device, imageView, pProperties)
     ccall((:vkGetImageViewAddressNVX, libvulkan), VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
+end
+
+function vkGetImageViewAddressNVX(device, imageView, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
 end
 
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountAMD ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
@@ -8093,8 +9281,16 @@ function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkTextureLODGatherFormatPropertiesAMD
@@ -8135,6 +9331,10 @@ function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, 
     ccall((:vkGetShaderInfoAMD, libvulkan), VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
 end
 
+function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
+end
+
 struct VkPhysicalDeviceCornerSampledImageFeaturesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8172,6 +9372,10 @@ const PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
     ccall((:vkGetPhysicalDeviceExternalImageFormatPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
 end
 
 struct VkExternalMemoryImageCreateInfoNV
@@ -8255,8 +9459,16 @@ function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingB
     ccall((:vkCmdBeginConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
 end
 
+function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
+end
+
 function vkCmdEndConditionalRenderingEXT(commandBuffer)
     ccall((:vkCmdEndConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkCmdEndConditionalRenderingEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
 struct VkViewportWScalingNV
@@ -8279,11 +9491,19 @@ function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount,
     ccall((:vkCmdSetViewportWScalingNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
 end
 
+function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
+end
+
 # typedef VkResult ( VKAPI_PTR * PFN_vkReleaseDisplayEXT ) ( VkPhysicalDevice physicalDevice , VkDisplayKHR display )
 const PFN_vkReleaseDisplayEXT = Ptr{Cvoid}
 
 function vkReleaseDisplayEXT(physicalDevice, display)
     ccall((:vkReleaseDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
+function vkReleaseDisplayEXT(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
 @cenum VkSurfaceCounterFlagBitsEXT::UInt32 begin
@@ -8315,6 +9535,10 @@ const PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2EXT, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
+function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
 @cenum VkDisplayPowerStateEXT::UInt32 begin
@@ -8374,16 +9598,32 @@ function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo)
     ccall((:vkDisplayPowerControlEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
 end
 
+function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
+end
+
 function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDeviceEventEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
+end
+
+function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
 end
 
 function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDisplayEventEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
 end
 
+function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
+end
+
 function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue)
     ccall((:vkGetSwapchainCounterEXT, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
+end
+
+function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
 end
 
 struct VkRefreshCycleDurationGOOGLE
@@ -8420,8 +9660,16 @@ function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProper
     ccall((:vkGetRefreshCycleDurationGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
 end
 
+function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
+end
+
 function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings)
     ccall((:vkGetPastPresentationTimingGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
+end
+
+function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
 end
 
 struct VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX
@@ -8487,6 +9735,10 @@ const PFN_vkCmdSetDiscardRectangleEXT = Ptr{Cvoid}
 
 function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
     ccall((:vkCmdSetDiscardRectangleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
+end
+
+function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
 end
 
 @cenum VkConservativeRasterizationModeEXT::UInt32 begin
@@ -8558,6 +9810,10 @@ const PFN_vkSetHdrMetadataEXT = Ptr{Cvoid}
 
 function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata)
     ccall((:vkSetHdrMetadataEXT, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
+end
+
+function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
 end
 
 const VkDebugUtilsMessengerEXT_T = Cvoid
@@ -8677,44 +9933,88 @@ function vkSetDebugUtilsObjectNameEXT(device, pNameInfo)
     ccall((:vkSetDebugUtilsObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
 end
 
+function vkSetDebugUtilsObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
+end
+
 function vkSetDebugUtilsObjectTagEXT(device, pTagInfo)
     ccall((:vkSetDebugUtilsObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
+end
+
+function vkSetDebugUtilsObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
 end
 
 function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkQueueEndDebugUtilsLabelEXT(queue)
     ccall((:vkQueueEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue,), queue)
+end
+
+function vkQueueEndDebugUtilsLabelEXT(queue, fptr)
+    ccall(fptr, Cvoid, (VkQueue,), queue)
 end
 
 function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCmdEndDebugUtilsLabelEXT(commandBuffer)
     ccall((:vkCmdEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndDebugUtilsLabelEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger)
     ccall((:vkCreateDebugUtilsMessengerEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
 end
 
+function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
+end
+
 function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator)
     ccall((:vkDestroyDebugUtilsMessengerEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
 end
 
+function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
+end
+
 function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData)
     ccall((:vkSubmitDebugUtilsMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
+end
+
+function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
 end
 
 const VkSamplerReductionModeEXT = VkSamplerReductionMode
@@ -8819,8 +10119,16 @@ function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo)
     ccall((:vkCmdSetSampleLocationsEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
 end
 
+function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
+end
+
 function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties)
     ccall((:vkGetPhysicalDeviceMultisamplePropertiesEXT, libvulkan), Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
+end
+
+function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
 end
 
 @cenum VkBlendOverlapEXT::UInt32 begin
@@ -8948,6 +10256,10 @@ function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties)
     ccall((:vkGetImageDrmFormatModifierPropertiesEXT, libvulkan), VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
 end
 
+function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
+end
+
 const VkValidationCacheEXT_T = Cvoid
 
 const VkValidationCacheEXT = Ptr{VkValidationCacheEXT_T}
@@ -8989,16 +10301,32 @@ function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidation
     ccall((:vkCreateValidationCacheEXT, libvulkan), VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
 end
 
+function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
+end
+
 function vkDestroyValidationCacheEXT(device, validationCache, pAllocator)
     ccall((:vkDestroyValidationCacheEXT, libvulkan), Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
+end
+
+function vkDestroyValidationCacheEXT(device, validationCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
 end
 
 function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergeValidationCachesEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData)
     ccall((:vkGetValidationCacheDataEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
+end
+
+function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
 end
 
 const VkDescriptorBindingFlagBitsEXT = VkDescriptorBindingFlagBits
@@ -9101,12 +10429,24 @@ function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout)
     ccall((:vkCmdBindShadingRateImageNV, libvulkan), Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
 end
 
+function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
+end
+
 function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
     ccall((:vkCmdSetViewportShadingRatePaletteNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
 end
 
+function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
+end
+
 function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
     ccall((:vkCmdSetCoarseSampleOrderNV, libvulkan), Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
+end
+
+function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
 end
 
 const VkAccelerationStructureNV_T = Cvoid
@@ -9433,52 +10773,104 @@ function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccel
     ccall((:vkCreateAccelerationStructureNV, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureNV, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements)
     ccall((:vkGetAccelerationStructureMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
+end
+
 function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos)
     ccall((:vkBindAccelerationStructureMemoryNV, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
 end
 
 function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
     ccall((:vkCmdBuildAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
 end
 
+function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
+end
+
 function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode)
     ccall((:vkCmdCopyAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
+end
+
+function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
 end
 
 function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
     ccall((:vkCmdTraceRaysNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
 end
 
+function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesNV, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
+function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
 function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData)
     ccall((:vkGetAccelerationStructureHandleNV, libvulkan), VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
 end
 
+function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
+function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
 function vkCompileDeferredNV(device, pipeline, shader)
     ccall((:vkCompileDeferredNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
+end
+
+function vkCompileDeferredNV(device, pipeline, shader, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
 end
 
 struct VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV
@@ -9546,11 +10938,19 @@ function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, p
     ccall((:vkGetMemoryHostPointerPropertiesEXT, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
 end
 
+function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, pMemoryHostPointerProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdWriteBufferMarkerAMD ) ( VkCommandBuffer commandBuffer , VkPipelineStageFlagBits pipelineStage , VkBuffer dstBuffer , VkDeviceSize dstOffset , uint32_t marker )
 const PFN_vkCmdWriteBufferMarkerAMD = Ptr{Cvoid}
 
 function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarkerAMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
+end
+
+function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
 end
 
 @cenum VkPipelineCompilerControlFlagBitsAMD::UInt32 begin
@@ -9589,8 +10989,16 @@ function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDom
     ccall((:vkGetPhysicalDeviceCalibrateableTimeDomainsEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
 end
 
+function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDomainCount, pTimeDomains, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
+end
+
 function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
     ccall((:vkGetCalibratedTimestampsEXT, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
+end
+
+function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
 end
 
 struct VkPhysicalDeviceShaderCorePropertiesAMD
@@ -9722,12 +11130,24 @@ function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask)
     ccall((:vkCmdDrawMeshTasksNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
 end
 
+function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
+end
+
 function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectCountNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV
@@ -9762,6 +11182,10 @@ function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclus
     ccall((:vkCmdSetExclusiveScissorNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
 end
 
+function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
+end
+
 struct VkQueueFamilyCheckpointPropertiesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -9785,8 +11209,16 @@ function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker)
     ccall((:vkCmdSetCheckpointNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
 end
 
+function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
+end
+
 function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointDataNV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL
@@ -9930,36 +11362,72 @@ function vkInitializePerformanceApiINTEL(device, pInitializeInfo)
     ccall((:vkInitializePerformanceApiINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
 end
 
+function vkInitializePerformanceApiINTEL(device, pInitializeInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
+end
+
 function vkUninitializePerformanceApiINTEL(device)
     ccall((:vkUninitializePerformanceApiINTEL, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkUninitializePerformanceApiINTEL(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceStreamMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
 function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo)
     ccall((:vkCmdSetPerformanceOverrideINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
 end
 
+function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
+end
+
 function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration)
     ccall((:vkAcquirePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
+end
+
+function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
 end
 
 function vkReleasePerformanceConfigurationINTEL(device, configuration)
     ccall((:vkReleasePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
 end
 
+function vkReleasePerformanceConfigurationINTEL(device, configuration, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
+end
+
 function vkQueueSetPerformanceConfigurationINTEL(queue, configuration)
     ccall((:vkQueueSetPerformanceConfigurationINTEL, libvulkan), VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
 end
 
+function vkQueueSetPerformanceConfigurationINTEL(queue, configuration, fptr)
+    ccall(fptr, VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
+end
+
 function vkGetPerformanceParameterINTEL(device, parameter, pValue)
     ccall((:vkGetPerformanceParameterINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
+end
+
+function vkGetPerformanceParameterINTEL(device, parameter, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
 end
 
 struct VkPhysicalDevicePCIBusInfoPropertiesEXT
@@ -9988,6 +11456,10 @@ const PFN_vkSetLocalDimmingAMD = Ptr{Cvoid}
 
 function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable)
     ccall((:vkSetLocalDimmingAMD, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
+end
+
+function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
 end
 
 struct VkPhysicalDeviceFragmentDensityMapFeaturesEXT
@@ -10112,6 +11584,10 @@ function vkGetBufferDeviceAddressEXT(device, pInfo)
     ccall((:vkGetBufferDeviceAddressEXT, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressEXT(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 @cenum VkToolPurposeFlagBitsEXT::UInt32 begin
     VK_TOOL_PURPOSE_VALIDATION_BIT_EXT = 1
     VK_TOOL_PURPOSE_PROFILING_BIT_EXT = 2
@@ -10140,6 +11616,10 @@ const PFN_vkGetPhysicalDeviceToolPropertiesEXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties)
     ccall((:vkGetPhysicalDeviceToolPropertiesEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
+end
+
+function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
 end
 
 const VkImageStencilUsageCreateInfoEXT = VkImageStencilUsageCreateInfo
@@ -10229,6 +11709,10 @@ function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPrope
     ccall((:vkGetPhysicalDeviceCooperativeMatrixPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
+end
+
 @cenum VkCoverageReductionModeNV::UInt32 begin
     VK_COVERAGE_REDUCTION_MODE_MERGE_NV = 0
     VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV = 1
@@ -10264,6 +11748,10 @@ const PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV = Pt
 
 function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations)
     ccall((:vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
+end
+
+function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
 end
 
 struct VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT
@@ -10321,6 +11809,10 @@ function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateHeadlessSurfaceEXT, libvulkan), VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 @cenum VkLineRasterizationModeEXT::UInt32 begin
     VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT = 0
     VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT = 1
@@ -10362,6 +11854,10 @@ function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePat
     ccall((:vkCmdSetLineStippleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
 end
 
+function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
+end
+
 struct VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10386,6 +11882,10 @@ const PFN_vkResetQueryPoolEXT = Ptr{Cvoid}
 
 function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPoolEXT, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
+function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
 struct VkPhysicalDeviceIndexTypeUint8FeaturesEXT
@@ -10440,48 +11940,96 @@ function vkCmdSetCullModeEXT(commandBuffer, cullMode)
     ccall((:vkCmdSetCullModeEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
 end
 
+function vkCmdSetCullModeEXT(commandBuffer, cullMode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
+end
+
 function vkCmdSetFrontFaceEXT(commandBuffer, frontFace)
     ccall((:vkCmdSetFrontFaceEXT, libvulkan), Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
+end
+
+function vkCmdSetFrontFaceEXT(commandBuffer, frontFace, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
 end
 
 function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology)
     ccall((:vkCmdSetPrimitiveTopologyEXT, libvulkan), Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
 end
 
+function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
+end
+
 function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports)
     ccall((:vkCmdSetViewportWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
+end
+
+function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
 end
 
 function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors)
     ccall((:vkCmdSetScissorWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
 end
 
+function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
+end
+
 function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
     ccall((:vkCmdBindVertexBuffers2EXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
+end
+
+function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
 end
 
 function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable)
     ccall((:vkCmdSetDepthTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
 end
 
+function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
+end
+
 function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable)
     ccall((:vkCmdSetDepthWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
+end
+
+function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
 end
 
 function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp)
     ccall((:vkCmdSetDepthCompareOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
 end
 
+function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
+end
+
 function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable)
     ccall((:vkCmdSetDepthBoundsTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
+end
+
+function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
 end
 
 function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable)
     ccall((:vkCmdSetStencilTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
 end
 
+function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
+end
+
 function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
     ccall((:vkCmdSetStencilOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
+end
+
+function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
 end
 
 struct VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT
@@ -10663,24 +12211,48 @@ function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequir
     ccall((:vkGetGeneratedCommandsMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo)
     ccall((:vkCmdPreprocessGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
+end
+
+function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
 end
 
 function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
     ccall((:vkCmdExecuteGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
 end
 
+function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
+end
+
 function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex)
     ccall((:vkCmdBindPipelineShaderGroupNV, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
+end
+
+function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
 end
 
 function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
     ccall((:vkCreateIndirectCommandsLayoutNV, libvulkan), VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
 end
 
+function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
+end
+
 function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator)
     ccall((:vkDestroyIndirectCommandsLayoutNV, libvulkan), Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
+end
+
+function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
 end
 
 struct VkPhysicalDeviceInheritedViewportScissorFeaturesNV
@@ -10844,16 +12416,32 @@ function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDat
     ccall((:vkCreatePrivateDataSlotEXT, libvulkan), VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
 end
 
+function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDataSlot, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
+end
+
 function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator)
     ccall((:vkDestroyPrivateDataSlotEXT, libvulkan), Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
+end
+
+function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
 end
 
 function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data)
     ccall((:vkSetPrivateDataEXT, libvulkan), VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
 end
 
+function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
+end
+
 function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData)
     ccall((:vkGetPrivateDataEXT, libvulkan), Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
+end
+
+function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
 end
 
 struct VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT
@@ -10934,6 +12522,10 @@ function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerO
     ccall((:vkCmdSetFragmentShadingRateEnumNV, libvulkan), Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
 end
 
+function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
+end
+
 struct VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10984,8 +12576,16 @@ function vkAcquireWinrtDisplayNV(physicalDevice, display)
     ccall((:vkAcquireWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
+function vkAcquireWinrtDisplayNV(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
 function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay)
     ccall((:vkGetWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
+end
+
+function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
 end
 
 struct VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE
@@ -11037,6 +12637,10 @@ function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pV
     ccall((:vkCmdSetVertexInputEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
 end
 
+function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
+end
+
 struct VkPhysicalDeviceExtendedDynamicState2FeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -11064,20 +12668,40 @@ function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints)
     ccall((:vkCmdSetPatchControlPointsEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
 end
 
+function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
+end
+
 function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable)
     ccall((:vkCmdSetRasterizerDiscardEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
+end
+
+function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
 end
 
 function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable)
     ccall((:vkCmdSetDepthBiasEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
 end
 
+function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
+end
+
 function vkCmdSetLogicOpEXT(commandBuffer, logicOp)
     ccall((:vkCmdSetLogicOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
 end
 
+function vkCmdSetLogicOpEXT(commandBuffer, logicOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
+end
+
 function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable)
     ccall((:vkCmdSetPrimitiveRestartEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
+end
+
+function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
 end
 
 struct VkPhysicalDeviceColorWriteEnableFeaturesEXT
@@ -11098,6 +12722,10 @@ const PFN_vkCmdSetColorWriteEnableEXT = Ptr{Cvoid}
 
 function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables)
     ccall((:vkCmdSetColorWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
+end
+
+function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
 end
 
 const VkAccelerationStructureKHR_T = Cvoid
@@ -11386,64 +13014,128 @@ function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAcce
     ccall((:vkCreateAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkCmdBuildAccelerationStructuresKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
     ccall((:vkCmdBuildAccelerationStructuresIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
+end
+
+function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
 end
 
 function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkBuildAccelerationStructuresKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureToMemoryKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
 end
 
+function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
+end
+
 function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyMemoryToAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
     ccall((:vkWriteAccelerationStructuresPropertiesKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
 end
 
+function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
+end
+
 function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureToMemoryKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
 end
 
+function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
+end
+
 function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyMemoryToAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo)
     ccall((:vkGetAccelerationStructureDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
 end
 
+function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
+function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
 function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility)
     ccall((:vkGetDeviceAccelerationStructureCompatibilityKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
 end
 
+function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
+end
+
 function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
     ccall((:vkGetAccelerationStructureBuildSizesKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
+end
+
+function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
 end
 
 @cenum VkShaderGroupShaderKHR::UInt32 begin
@@ -11546,24 +13238,48 @@ function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShader
     ccall((:vkCmdTraceRaysKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
 end
 
+function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingCaptureReplayShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
     ccall((:vkCmdTraceRaysIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
+end
+
+function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
 end
 
 function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader)
     ccall((:vkGetRayTracingShaderGroupStackSizeKHR, libvulkan), VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
 end
 
+function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader, fptr)
+    ccall(fptr, VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
+end
+
 function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize)
     ccall((:vkCmdSetRayTracingPipelineStackSizeKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
+end
+
+function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
 end
 
 struct VkPhysicalDeviceRayQueryFeaturesKHR
@@ -11596,8 +13312,16 @@ function vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateWaylandSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkWaylandSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkWaylandSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display)
     ccall((:vkGetPhysicalDeviceWaylandPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{wl_display}), physicalDevice, queueFamilyIndex, display)
+end
+
+function vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{wl_display}), physicalDevice, queueFamilyIndex, display)
 end
 
 const VkXcbSurfaceCreateFlagsKHR = VkFlags
@@ -11620,8 +13344,16 @@ function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXcbSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id)
     ccall((:vkGetPhysicalDeviceXcbPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
+end
+
+function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
 end
 
 const VkXlibSurfaceCreateFlagsKHR = VkFlags
@@ -11644,8 +13376,16 @@ function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXlibSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID)
     ccall((:vkGetPhysicalDeviceXlibPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
+end
+
+function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
 end
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkAcquireXlibDisplayEXT ) ( VkPhysicalDevice physicalDevice , Display * dpy , VkDisplayKHR display )
@@ -11658,8 +13398,16 @@ function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display)
     ccall((:vkAcquireXlibDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
 end
 
+function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
+end
+
 function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay)
     ccall((:vkGetRandROutputDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
+end
+
+function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
 end
 
 const VULKAN_H_ = 1

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -3200,6 +3200,29 @@ function Base.setproperty!(x::Ptr{VkClearColorValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
+
+function VkClearColorValue(float32::NTuple{4, Cfloat})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkClearColorValue(int32::NTuple{4, Int32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkClearColorValue(uint32::NTuple{4, UInt32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
 struct VkClearDepthStencilValue
     depth::Cfloat
     stencil::UInt32
@@ -3224,6 +3247,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkClearValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
+
+function VkClearValue(color::VkClearColorValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.color = color
+    ref[]
+end
+
+function VkClearValue(depthStencil::VkClearDepthStencilValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.depthStencil = depthStencil
+    ref[]
 end
 
 struct VkClearAttachment
@@ -7779,6 +7818,50 @@ function Base.setproperty!(x::Ptr{VkPerformanceCounterResultKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
+
+function VkPerformanceCounterResultKHR(int32::Int32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(int64::Int64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int64 = int64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint32::UInt32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint64::UInt64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint64 = uint64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float32::Cfloat)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float64::Cdouble)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float64 = float64
+    ref[]
+end
+
 struct VkAcquireProfilingLockInfoKHR
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8468,6 +8551,36 @@ end
 
 function Base.setproperty!(x::Ptr{VkPipelineExecutableStatisticValueKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
+
+function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.b32 = b32
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(i64::Int64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.i64 = i64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.u64 = u64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.f64 = f64
+    ref[]
 end
 
 struct VkPipelineExecutableStatisticKHR
@@ -10728,6 +10841,18 @@ function Base.setproperty!(x::Ptr{VkAccelerationStructureInstanceKHR}, f::Symbol
     unsafe_store!(getproperty(x, f), v)
 end
 
+function VkAccelerationStructureInstanceKHR(transform::VkTransformMatrixKHR, instanceCustomIndex::UInt32, mask::UInt32, instanceShaderBindingTableRecordOffset::UInt32, flags::VkGeometryInstanceFlagsKHR, accelerationStructureReference::UInt64)
+    ref = Ref{VkAccelerationStructureInstanceKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureInstanceKHR}, ref)
+    ptr.transform = transform
+    ptr.instanceCustomIndex = instanceCustomIndex
+    ptr.mask = mask
+    ptr.instanceShaderBindingTableRecordOffset = instanceShaderBindingTableRecordOffset
+    ptr.flags = flags
+    ptr.accelerationStructureReference = accelerationStructureReference
+    ref[]
+end
+
 const VkAccelerationStructureInstanceNV = VkAccelerationStructureInstanceKHR
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkCreateAccelerationStructureNV ) ( VkDevice device , const VkAccelerationStructureCreateInfoNV * pCreateInfo , const VkAllocationCallbacks * pAllocator , VkAccelerationStructureNV * pAccelerationStructure )
@@ -11284,6 +11409,43 @@ end
 
 function Base.setproperty!(x::Ptr{VkPerformanceValueDataINTEL}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
+
+function VkPerformanceValueDataINTEL(value32::UInt32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value32 = value32
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(value64::UInt64)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value64 = value64
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueFloat = valueFloat
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueBool::VkBool32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueBool = valueBool
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueString = valueString
+    ref[]
 end
 
 struct VkPerformanceValueINTEL
@@ -12779,6 +12941,22 @@ function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
+end
+
 struct VkDeviceOrHostAddressConstKHR
     data::NTuple{8, UInt8}
 end
@@ -12798,6 +12976,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressConstKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
 end
 
 struct VkAccelerationStructureBuildRangeInfoKHR
@@ -12853,6 +13047,29 @@ end
 
 function Base.setproperty!(x::Ptr{VkAccelerationStructureGeometryDataKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
+
+function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.triangles = triangles
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.aabbs = aabbs
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.instances = instances
+    ref[]
 end
 
 struct VkAccelerationStructureGeometryKHR

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -3202,24 +3202,16 @@ end
 
 const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
 
-function VkClearColorValue(float32::NTuple{4, Cfloat})
+function VkClearColorValue(val::__U_VkClearColorValue)
     ref = Ref{VkClearColorValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkClearColorValue(int32::NTuple{4, Int32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkClearColorValue(uint32::NTuple{4, UInt32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.uint32 = uint32
+    if val isa NTuple{4, Cfloat}
+        ptr.float32 = val
+    elseif val isa NTuple{4, Int32}
+        ptr.int32 = val
+    elseif val isa NTuple{4, UInt32}
+        ptr.uint32 = val
+    end
     ref[]
 end
 
@@ -3251,17 +3243,14 @@ end
 
 const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
 
-function VkClearValue(color::VkClearColorValue)
+function VkClearValue(val::__U_VkClearValue)
     ref = Ref{VkClearValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.color = color
-    ref[]
-end
-
-function VkClearValue(depthStencil::VkClearDepthStencilValue)
-    ref = Ref{VkClearValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.depthStencil = depthStencil
+    if val isa VkClearColorValue
+        ptr.color = val
+    elseif val isa VkClearDepthStencilValue
+        ptr.depthStencil = val
+    end
     ref[]
 end
 
@@ -7820,45 +7809,22 @@ end
 
 const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
 
-function VkPerformanceCounterResultKHR(int32::Int32)
+function VkPerformanceCounterResultKHR(val::__U_VkPerformanceCounterResultKHR)
     ref = Ref{VkPerformanceCounterResultKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(int64::Int64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int64 = int64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint32::UInt32)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint32 = uint32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint64::UInt64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint64 = uint64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float32::Cfloat)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float64::Cdouble)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float64 = float64
+    if val isa Int32
+        ptr.int32 = val
+    elseif val isa Int64
+        ptr.int64 = val
+    elseif val isa UInt32
+        ptr.uint32 = val
+    elseif val isa UInt64
+        ptr.uint64 = val
+    elseif val isa Cfloat
+        ptr.float32 = val
+    elseif val isa Cdouble
+        ptr.float64 = val
+    end
     ref[]
 end
 
@@ -8555,31 +8521,18 @@ end
 
 const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
 
-function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+function VkPipelineExecutableStatisticValueKHR(val::__U_VkPipelineExecutableStatisticValueKHR)
     ref = Ref{VkPipelineExecutableStatisticValueKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.b32 = b32
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(i64::Int64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.i64 = i64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.u64 = u64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.f64 = f64
+    if val isa VkBool32
+        ptr.b32 = val
+    elseif val isa Int64
+        ptr.i64 = val
+    elseif val isa UInt64
+        ptr.u64 = val
+    elseif val isa Cdouble
+        ptr.f64 = val
+    end
     ref[]
 end
 
@@ -11413,38 +11366,20 @@ end
 
 const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
 
-function VkPerformanceValueDataINTEL(value32::UInt32)
+function VkPerformanceValueDataINTEL(val::__U_VkPerformanceValueDataINTEL)
     ref = Ref{VkPerformanceValueDataINTEL}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value32 = value32
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(value64::UInt64)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value64 = value64
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueFloat = valueFloat
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueBool::VkBool32)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueBool = valueBool
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueString = valueString
+    if val isa UInt32
+        ptr.value32 = val
+    elseif val isa UInt64
+        ptr.value64 = val
+    elseif val isa Cfloat
+        ptr.valueFloat = val
+    elseif val isa VkBool32
+        ptr.valueBool = val
+    elseif val isa Ptr{Cchar}
+        ptr.valueString = val
+    end
     ref[]
 end
 
@@ -12943,17 +12878,14 @@ end
 
 const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressKHR(val::__U_VkDeviceOrHostAddressKHR)
     ref = Ref{VkDeviceOrHostAddressKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -12980,17 +12912,14 @@ end
 
 const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressConstKHR(val::__U_VkDeviceOrHostAddressConstKHR)
     ref = Ref{VkDeviceOrHostAddressConstKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressConstKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -13051,24 +12980,16 @@ end
 
 const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
 
-function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+function VkAccelerationStructureGeometryDataKHR(val::__U_VkAccelerationStructureGeometryDataKHR)
     ref = Ref{VkAccelerationStructureGeometryDataKHR}()
     ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.triangles = triangles
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.aabbs = aabbs
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.instances = instances
+    if val isa VkAccelerationStructureGeometryTrianglesDataKHR
+        ptr.triangles = val
+    elseif val isa VkAccelerationStructureGeometryAabbsDataKHR
+        ptr.aabbs = val
+    elseif val isa VkAccelerationStructureGeometryInstancesDataKHR
+        ptr.instances = val
+    end
     ref[]
 end
 

--- a/lib/x86_64-unknown-freebsd11.1.jl
+++ b/lib/x86_64-unknown-freebsd11.1.jl
@@ -3686,548 +3686,1096 @@ function vkCreateInstance(pCreateInfo, pAllocator, pInstance)
     ccall((:vkCreateInstance, libvulkan), VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
 end
 
+function vkCreateInstance(pCreateInfo, pAllocator, pInstance, fptr)
+    ccall(fptr, VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
+end
+
 function vkDestroyInstance(instance, pAllocator)
     ccall((:vkDestroyInstance, libvulkan), Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
+end
+
+function vkDestroyInstance(instance, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
 end
 
 function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices)
     ccall((:vkEnumeratePhysicalDevices, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
 end
 
+function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
+end
+
 function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
+end
+
+function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
 end
 
 function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceProperties(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
 end
 
+function vkGetPhysicalDeviceProperties(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
+end
+
 function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
+function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
 function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetInstanceProcAddr(instance, pName)
     ccall((:vkGetInstanceProcAddr, libvulkan), PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
+end
+
+function vkGetInstanceProcAddr(instance, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
 end
 
 function vkGetDeviceProcAddr(device, pName)
     ccall((:vkGetDeviceProcAddr, libvulkan), PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
 end
 
+function vkGetDeviceProcAddr(device, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
+end
+
 function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice)
     ccall((:vkCreateDevice, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
+end
+
+function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
 end
 
 function vkDestroyDevice(device, pAllocator)
     ccall((:vkDestroyDevice, libvulkan), Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
 end
 
+function vkDestroyDevice(device, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
+end
+
 function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceExtensionProperties, libvulkan), VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceExtensionProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
+end
+
 function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceLayerProperties, libvulkan), VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceLayerProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue)
     ccall((:vkGetDeviceQueue, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
+end
+
+function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
 end
 
 function vkQueueSubmit(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
+function vkQueueSubmit(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
 function vkQueueWaitIdle(queue)
     ccall((:vkQueueWaitIdle, libvulkan), VkResult, (VkQueue,), queue)
+end
+
+function vkQueueWaitIdle(queue, fptr)
+    ccall(fptr, VkResult, (VkQueue,), queue)
 end
 
 function vkDeviceWaitIdle(device)
     ccall((:vkDeviceWaitIdle, libvulkan), VkResult, (VkDevice,), device)
 end
 
+function vkDeviceWaitIdle(device, fptr)
+    ccall(fptr, VkResult, (VkDevice,), device)
+end
+
 function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory)
     ccall((:vkAllocateMemory, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
+end
+
+function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
 end
 
 function vkFreeMemory(device, memory, pAllocator)
     ccall((:vkFreeMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
 end
 
+function vkFreeMemory(device, memory, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
+end
+
 function vkMapMemory(device, memory, offset, size, flags, ppData)
     ccall((:vkMapMemory, libvulkan), VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
+end
+
+function vkMapMemory(device, memory, offset, size, flags, ppData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
 end
 
 function vkUnmapMemory(device, memory)
     ccall((:vkUnmapMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory), device, memory)
 end
 
+function vkUnmapMemory(device, memory, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory), device, memory)
+end
+
 function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkFlushMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
+function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
 function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkInvalidateMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
+function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
 function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes)
     ccall((:vkGetDeviceMemoryCommitment, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
+end
+
+function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
 end
 
 function vkBindBufferMemory(device, buffer, memory, memoryOffset)
     ccall((:vkBindBufferMemory, libvulkan), VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
 end
 
+function vkBindBufferMemory(device, buffer, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
+end
+
 function vkBindImageMemory(device, image, memory, memoryOffset)
     ccall((:vkBindImageMemory, libvulkan), VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
+end
+
+function vkBindImageMemory(device, image, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
 end
 
 function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
+end
+
 function vkGetImageMemoryRequirements(device, image, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements(device, image, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
 end
 
 function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
+function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
 end
 
 function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence)
     ccall((:vkQueueBindSparse, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
 end
 
+function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
+end
+
 function vkCreateFence(device, pCreateInfo, pAllocator, pFence)
     ccall((:vkCreateFence, libvulkan), VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
+end
+
+function vkCreateFence(device, pCreateInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
 end
 
 function vkDestroyFence(device, fence, pAllocator)
     ccall((:vkDestroyFence, libvulkan), Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
 end
 
+function vkDestroyFence(device, fence, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
+end
+
 function vkResetFences(device, fenceCount, pFences)
     ccall((:vkResetFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
+end
+
+function vkResetFences(device, fenceCount, pFences, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
 end
 
 function vkGetFenceStatus(device, fence)
     ccall((:vkGetFenceStatus, libvulkan), VkResult, (VkDevice, VkFence), device, fence)
 end
 
+function vkGetFenceStatus(device, fence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkFence), device, fence)
+end
+
 function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout)
     ccall((:vkWaitForFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
+end
+
+function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
 end
 
 function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore)
     ccall((:vkCreateSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
 end
 
+function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
+end
+
 function vkDestroySemaphore(device, semaphore, pAllocator)
     ccall((:vkDestroySemaphore, libvulkan), Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
+end
+
+function vkDestroySemaphore(device, semaphore, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
 end
 
 function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent)
     ccall((:vkCreateEvent, libvulkan), VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
 end
 
+function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
+end
+
 function vkDestroyEvent(device, event, pAllocator)
     ccall((:vkDestroyEvent, libvulkan), Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
+end
+
+function vkDestroyEvent(device, event, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
 end
 
 function vkGetEventStatus(device, event)
     ccall((:vkGetEventStatus, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkGetEventStatus(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkSetEvent(device, event)
     ccall((:vkSetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
+end
+
+function vkSetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
 end
 
 function vkResetEvent(device, event)
     ccall((:vkResetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkResetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool)
     ccall((:vkCreateQueryPool, libvulkan), VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
+end
+
+function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
 end
 
 function vkDestroyQueryPool(device, queryPool, pAllocator)
     ccall((:vkDestroyQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
 end
 
+function vkDestroyQueryPool(device, queryPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
+end
+
 function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
     ccall((:vkGetQueryPoolResults, libvulkan), VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
+end
+
+function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
 end
 
 function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer)
     ccall((:vkCreateBuffer, libvulkan), VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
 end
 
+function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
+end
+
 function vkDestroyBuffer(device, buffer, pAllocator)
     ccall((:vkDestroyBuffer, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
+end
+
+function vkDestroyBuffer(device, buffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
 end
 
 function vkCreateBufferView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateBufferView, libvulkan), VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
 end
 
+function vkCreateBufferView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
+end
+
 function vkDestroyBufferView(device, bufferView, pAllocator)
     ccall((:vkDestroyBufferView, libvulkan), Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
+end
+
+function vkDestroyBufferView(device, bufferView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
 end
 
 function vkCreateImage(device, pCreateInfo, pAllocator, pImage)
     ccall((:vkCreateImage, libvulkan), VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
 end
 
+function vkCreateImage(device, pCreateInfo, pAllocator, pImage, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
+end
+
 function vkDestroyImage(device, image, pAllocator)
     ccall((:vkDestroyImage, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
+end
+
+function vkDestroyImage(device, image, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
 end
 
 function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout)
     ccall((:vkGetImageSubresourceLayout, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
 end
 
+function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
+end
+
 function vkCreateImageView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateImageView, libvulkan), VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
+end
+
+function vkCreateImageView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
 end
 
 function vkDestroyImageView(device, imageView, pAllocator)
     ccall((:vkDestroyImageView, libvulkan), Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
 end
 
+function vkDestroyImageView(device, imageView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
+end
+
 function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule)
     ccall((:vkCreateShaderModule, libvulkan), VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
+end
+
+function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
 end
 
 function vkDestroyShaderModule(device, shaderModule, pAllocator)
     ccall((:vkDestroyShaderModule, libvulkan), Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
 end
 
+function vkDestroyShaderModule(device, shaderModule, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
+end
+
 function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache)
     ccall((:vkCreatePipelineCache, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
+end
+
+function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
 end
 
 function vkDestroyPipelineCache(device, pipelineCache, pAllocator)
     ccall((:vkDestroyPipelineCache, libvulkan), Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
 end
 
+function vkDestroyPipelineCache(device, pipelineCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
+end
+
 function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData)
     ccall((:vkGetPipelineCacheData, libvulkan), VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
+end
+
+function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
 end
 
 function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergePipelineCaches, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateGraphicsPipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateComputePipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
+function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
 function vkDestroyPipeline(device, pipeline, pAllocator)
     ccall((:vkDestroyPipeline, libvulkan), Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
+end
+
+function vkDestroyPipeline(device, pipeline, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
 end
 
 function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout)
     ccall((:vkCreatePipelineLayout, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
 end
 
+function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
+end
+
 function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator)
     ccall((:vkDestroyPipelineLayout, libvulkan), Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
+end
+
+function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
 end
 
 function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler)
     ccall((:vkCreateSampler, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
 end
 
+function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
+end
+
 function vkDestroySampler(device, sampler, pAllocator)
     ccall((:vkDestroySampler, libvulkan), Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
+end
+
+function vkDestroySampler(device, sampler, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
 end
 
 function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout)
     ccall((:vkCreateDescriptorSetLayout, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
 end
 
+function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
+end
+
 function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator)
     ccall((:vkDestroyDescriptorSetLayout, libvulkan), Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
+end
+
+function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
 end
 
 function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool)
     ccall((:vkCreateDescriptorPool, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
 end
 
+function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
+end
+
 function vkDestroyDescriptorPool(device, descriptorPool, pAllocator)
     ccall((:vkDestroyDescriptorPool, libvulkan), Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
+end
+
+function vkDestroyDescriptorPool(device, descriptorPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
 end
 
 function vkResetDescriptorPool(device, descriptorPool, flags)
     ccall((:vkResetDescriptorPool, libvulkan), VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
 end
 
+function vkResetDescriptorPool(device, descriptorPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
+end
+
 function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets)
     ccall((:vkAllocateDescriptorSets, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
+end
+
+function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
 end
 
 function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets)
     ccall((:vkFreeDescriptorSets, libvulkan), VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
 end
 
+function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
+end
+
 function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
     ccall((:vkUpdateDescriptorSets, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
+end
+
+function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
 end
 
 function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer)
     ccall((:vkCreateFramebuffer, libvulkan), VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
 end
 
+function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
+end
+
 function vkDestroyFramebuffer(device, framebuffer, pAllocator)
     ccall((:vkDestroyFramebuffer, libvulkan), Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
+end
+
+function vkDestroyFramebuffer(device, framebuffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
 end
 
 function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkDestroyRenderPass(device, renderPass, pAllocator)
     ccall((:vkDestroyRenderPass, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
+end
+
+function vkDestroyRenderPass(device, renderPass, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
 end
 
 function vkGetRenderAreaGranularity(device, renderPass, pGranularity)
     ccall((:vkGetRenderAreaGranularity, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
 end
 
+function vkGetRenderAreaGranularity(device, renderPass, pGranularity, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
+end
+
 function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool)
     ccall((:vkCreateCommandPool, libvulkan), VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
+end
+
+function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
 end
 
 function vkDestroyCommandPool(device, commandPool, pAllocator)
     ccall((:vkDestroyCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
 end
 
+function vkDestroyCommandPool(device, commandPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
+end
+
 function vkResetCommandPool(device, commandPool, flags)
     ccall((:vkResetCommandPool, libvulkan), VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
+end
+
+function vkResetCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
 end
 
 function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers)
     ccall((:vkAllocateCommandBuffers, libvulkan), VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
 end
 
+function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
+end
+
 function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers)
     ccall((:vkFreeCommandBuffers, libvulkan), Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
+end
+
+function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
 end
 
 function vkBeginCommandBuffer(commandBuffer, pBeginInfo)
     ccall((:vkBeginCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
 end
 
+function vkBeginCommandBuffer(commandBuffer, pBeginInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
+end
+
 function vkEndCommandBuffer(commandBuffer)
     ccall((:vkEndCommandBuffer, libvulkan), VkResult, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkEndCommandBuffer(commandBuffer, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer,), commandBuffer)
 end
 
 function vkResetCommandBuffer(commandBuffer, flags)
     ccall((:vkResetCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
 end
 
+function vkResetCommandBuffer(commandBuffer, flags, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
+end
+
 function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline)
     ccall((:vkCmdBindPipeline, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
+end
+
+function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
 end
 
 function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports)
     ccall((:vkCmdSetViewport, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
 end
 
+function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
+end
+
 function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors)
     ccall((:vkCmdSetScissor, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
+end
+
+function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
 end
 
 function vkCmdSetLineWidth(commandBuffer, lineWidth)
     ccall((:vkCmdSetLineWidth, libvulkan), Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
 end
 
+function vkCmdSetLineWidth(commandBuffer, lineWidth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
+end
+
 function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
     ccall((:vkCmdSetDepthBias, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
+end
+
+function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
 end
 
 function vkCmdSetBlendConstants(commandBuffer, blendConstants)
     ccall((:vkCmdSetBlendConstants, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
 end
 
+function vkCmdSetBlendConstants(commandBuffer, blendConstants, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
+end
+
 function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds)
     ccall((:vkCmdSetDepthBounds, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
+end
+
+function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
 end
 
 function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask)
     ccall((:vkCmdSetStencilCompareMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
 end
 
+function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
+end
+
 function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask)
     ccall((:vkCmdSetStencilWriteMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
+end
+
+function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
 end
 
 function vkCmdSetStencilReference(commandBuffer, faceMask, reference)
     ccall((:vkCmdSetStencilReference, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
 end
 
+function vkCmdSetStencilReference(commandBuffer, faceMask, reference, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
+end
+
 function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
     ccall((:vkCmdBindDescriptorSets, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
+end
+
+function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
 end
 
 function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType)
     ccall((:vkCmdBindIndexBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
 end
 
+function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
+end
+
 function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
     ccall((:vkCmdBindVertexBuffers, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
+end
+
+function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
 end
 
 function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
     ccall((:vkCmdDraw, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
 end
 
+function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
+end
+
 function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
     ccall((:vkCmdDrawIndexed, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
+end
+
+function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
 end
 
 function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndexedIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
 function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatch, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
 end
 
+function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
+end
+
 function vkCmdDispatchIndirect(commandBuffer, buffer, offset)
     ccall((:vkCmdDispatchIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
+end
+
+function vkCmdDispatchIndirect(commandBuffer, buffer, offset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
 end
 
 function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
     ccall((:vkCmdBlitImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
 end
 
+function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
+end
+
 function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyBufferToImage, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyImageToBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData)
     ccall((:vkCmdUpdateBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
+end
+
+function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
 end
 
 function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data)
     ccall((:vkCmdFillBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
 end
 
+function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
+end
+
 function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
     ccall((:vkCmdClearColorImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
+end
+
+function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
 end
 
 function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
     ccall((:vkCmdClearDepthStencilImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
 end
 
+function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
+end
+
 function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
     ccall((:vkCmdClearAttachments, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
+end
+
+function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
 end
 
 function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdResolveImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
+function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
 function vkCmdSetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdSetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
+function vkCmdSetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
 function vkCmdResetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
+function vkCmdResetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
 function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdWaitEvents, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
+function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
 function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdPipelineBarrier, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
+function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
 function vkCmdBeginQuery(commandBuffer, queryPool, query, flags)
     ccall((:vkCmdBeginQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
+end
+
+function vkCmdBeginQuery(commandBuffer, queryPool, query, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
 end
 
 function vkCmdEndQuery(commandBuffer, queryPool, query)
     ccall((:vkCmdEndQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
 end
 
+function vkCmdEndQuery(commandBuffer, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
+end
+
 function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount)
     ccall((:vkCmdResetQueryPool, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
+end
+
+function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
 end
 
 function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query)
     ccall((:vkCmdWriteTimestamp, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
+end
+
 function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
     ccall((:vkCmdCopyQueryPoolResults, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
+end
+
+function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
 end
 
 function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues)
     ccall((:vkCmdPushConstants, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
 end
 
+function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
+end
+
 function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents)
     ccall((:vkCmdBeginRenderPass, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
+end
+
+function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
 end
 
 function vkCmdNextSubpass(commandBuffer, contents)
     ccall((:vkCmdNextSubpass, libvulkan), Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
 end
 
+function vkCmdNextSubpass(commandBuffer, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
+end
+
 function vkCmdEndRenderPass(commandBuffer)
     ccall((:vkCmdEndRenderPass, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndRenderPass(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers)
     ccall((:vkCmdExecuteCommands, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
+end
+
+function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
 end
 
 const VkSamplerYcbcrConversion_T = Cvoid
@@ -5017,112 +5565,224 @@ function vkEnumerateInstanceVersion(pApiVersion)
     ccall((:vkEnumerateInstanceVersion, libvulkan), VkResult, (Ptr{UInt32},), pApiVersion)
 end
 
+function vkEnumerateInstanceVersion(pApiVersion, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32},), pApiVersion)
+end
+
 function vkBindBufferMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindBufferMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 function vkBindImageMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindImageMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
     ccall((:vkGetDeviceGroupPeerMemoryFeatures, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
+function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
 function vkCmdSetDeviceMask(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMask, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMask(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBase, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroups, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
+function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
 function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
 function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
+function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
 function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
 function vkTrimCommandPool(device, commandPool, flags)
     ccall((:vkTrimCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
+function vkTrimCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
 function vkGetDeviceQueue2(device, pQueueInfo, pQueue)
     ccall((:vkGetDeviceQueue2, libvulkan), Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
 end
 
+function vkGetDeviceQueue2(device, pQueueInfo, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
+end
+
 function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion)
     ccall((:vkCreateSamplerYcbcrConversion, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
+function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
 function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversion, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
+function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
 function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
     ccall((:vkCreateDescriptorUpdateTemplate, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
+function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
 function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
+function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
 function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFenceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphoreProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
+function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
 function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupport, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
+function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
 @cenum VkDriverId::UInt32 begin
@@ -5822,52 +6482,104 @@ function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, coun
     ccall((:vkCmdDrawIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 function vkResetQueryPool(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
+function vkResetQueryPool(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
 function vkGetSemaphoreCounterValue(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValue, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
+function vkGetSemaphoreCounterValue(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
 function vkWaitSemaphores(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphores, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphores(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphore(device, pSignalInfo)
     ccall((:vkSignalSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphore(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 function vkGetBufferDeviceAddress(device, pInfo)
     ccall((:vkGetBufferDeviceAddress, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddress(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkSurfaceKHR_T = Cvoid
@@ -5968,20 +6680,40 @@ function vkDestroySurfaceKHR(instance, surface, pAllocator)
     ccall((:vkDestroySurfaceKHR, libvulkan), Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
 end
 
+function vkDestroySurfaceKHR(instance, surface, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
+end
+
 function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported)
     ccall((:vkGetPhysicalDeviceSurfaceSupportKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
+end
+
+function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
 end
 
 function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormatsKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
 end
 
+function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
+end
+
 function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes)
     ccall((:vkGetPhysicalDeviceSurfacePresentModesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
+end
+
+function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
 end
 
 const VkSwapchainKHR_T = Cvoid
@@ -6114,36 +6846,72 @@ function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain)
     ccall((:vkCreateSwapchainKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
 end
 
+function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
+end
+
 function vkDestroySwapchainKHR(device, swapchain, pAllocator)
     ccall((:vkDestroySwapchainKHR, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
+end
+
+function vkDestroySwapchainKHR(device, swapchain, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
 end
 
 function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages)
     ccall((:vkGetSwapchainImagesKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
 end
 
+function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
+end
+
 function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex)
     ccall((:vkAcquireNextImageKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
+end
+
+function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
 end
 
 function vkQueuePresentKHR(queue, pPresentInfo)
     ccall((:vkQueuePresentKHR, libvulkan), VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
 end
 
+function vkQueuePresentKHR(queue, pPresentInfo, fptr)
+    ccall(fptr, VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
+end
+
 function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities)
     ccall((:vkGetDeviceGroupPresentCapabilitiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
+end
+
+function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
 end
 
 function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes)
     ccall((:vkGetDeviceGroupSurfacePresentModesKHR, libvulkan), VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
 end
 
+function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
+end
+
 function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects)
     ccall((:vkGetPhysicalDevicePresentRectanglesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
 end
 
+function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
+end
+
 function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex)
     ccall((:vkAcquireNextImage2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
+end
+
+function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
 end
 
 const VkDisplayKHR_T = Cvoid
@@ -6250,28 +7018,56 @@ function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount,
     ccall((:vkGetPhysicalDeviceDisplayPropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlanePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays)
     ccall((:vkGetDisplayPlaneSupportedDisplaysKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
 end
 
+function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
+end
+
 function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
+function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
 function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode)
     ccall((:vkCreateDisplayModeKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
 end
 
+function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
+end
+
 function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
 end
 
+function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
+end
+
 function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateDisplayPlaneSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
+function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
 struct VkDisplayPresentInfoKHR
@@ -6287,6 +7083,10 @@ const PFN_vkCreateSharedSwapchainsKHR = Ptr{Cvoid}
 
 function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
     ccall((:vkCreateSharedSwapchainsKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
+end
+
+function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
 end
 
 const VkRenderPassMultiviewCreateInfoKHR = VkRenderPassMultiviewCreateInfo
@@ -6338,28 +7138,56 @@ function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
 const VkPeerMemoryFeatureFlagsKHR = VkPeerMemoryFeatureFlags
@@ -6397,12 +7225,24 @@ function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceInd
     ccall((:vkGetDeviceGroupPeerMemoryFeaturesKHR, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
+function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
 function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMaskKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBaseKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 const VkCommandPoolTrimFlagsKHR = VkCommandPoolTrimFlags
@@ -6414,6 +7254,10 @@ function vkTrimCommandPoolKHR(device, commandPool, flags)
     ccall((:vkTrimCommandPoolKHR, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
+function vkTrimCommandPoolKHR(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
 const VkPhysicalDeviceGroupPropertiesKHR = VkPhysicalDeviceGroupProperties
 
 const VkDeviceGroupDeviceCreateInfoKHR = VkDeviceGroupDeviceCreateInfo
@@ -6423,6 +7267,10 @@ const PFN_vkEnumeratePhysicalDeviceGroupsKHR = Ptr{Cvoid}
 
 function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroupsKHR, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
+function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
 const VkExternalMemoryHandleTypeFlagsKHR = VkExternalMemoryHandleTypeFlags
@@ -6450,6 +7298,10 @@ const PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferPropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
+function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
 const VkExternalMemoryImageCreateInfoKHR = VkExternalMemoryImageCreateInfo
@@ -6488,8 +7340,16 @@ function vkGetMemoryFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetMemoryFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
+function vkGetMemoryFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
 function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties)
     ccall((:vkGetMemoryFdPropertiesKHR, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
+end
+
+function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
 end
 
 const VkExternalSemaphoreHandleTypeFlagsKHR = VkExternalSemaphoreHandleTypeFlags
@@ -6509,6 +7369,10 @@ const PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphorePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
+function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
 const VkSemaphoreImportFlagsKHR = VkSemaphoreImportFlags
@@ -6543,8 +7407,16 @@ function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo)
     ccall((:vkImportSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
 end
 
+function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
+end
+
 function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 struct VkPhysicalDevicePushDescriptorPropertiesKHR
@@ -6563,8 +7435,16 @@ function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set
     ccall((:vkCmdPushDescriptorSetKHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
 end
 
+function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
+end
+
 function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData)
     ccall((:vkCmdPushDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
+end
+
+function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
 end
 
 const VkPhysicalDeviceShaderFloat16Int8FeaturesKHR = VkPhysicalDeviceShaderFloat16Int8Features
@@ -6614,12 +7494,24 @@ function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pD
     ccall((:vkCreateDescriptorUpdateTemplateKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
+function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
 function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 const VkPhysicalDeviceImagelessFramebufferFeaturesKHR = VkPhysicalDeviceImagelessFramebufferFeatures
@@ -6660,16 +7552,32 @@ function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 struct VkSharedPresentSurfaceCapabilitiesKHR
@@ -6683,6 +7591,10 @@ const PFN_vkGetSwapchainStatusKHR = Ptr{Cvoid}
 
 function vkGetSwapchainStatusKHR(device, swapchain)
     ccall((:vkGetSwapchainStatusKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
+end
+
+function vkGetSwapchainStatusKHR(device, swapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
 end
 
 const VkExternalFenceHandleTypeFlagsKHR = VkExternalFenceHandleTypeFlags
@@ -6702,6 +7614,10 @@ const PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFencePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 const VkFenceImportFlagsKHR = VkFenceImportFlags
@@ -6736,8 +7652,16 @@ function vkImportFenceFdKHR(device, pImportFenceFdInfo)
     ccall((:vkImportFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
 end
 
+function vkImportFenceFdKHR(device, pImportFenceFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
+end
+
 function vkGetFenceFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetFenceFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 @cenum VkPerformanceCounterUnitKHR::UInt32 begin
@@ -6884,16 +7808,32 @@ function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physica
     ccall((:vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
 end
 
+function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
+end
+
 function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
     ccall((:vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
+end
+
+function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
 end
 
 function vkAcquireProfilingLockKHR(device, pInfo)
     ccall((:vkAcquireProfilingLockKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
 end
 
+function vkAcquireProfilingLockKHR(device, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
+end
+
 function vkReleaseProfilingLockKHR(device)
     ccall((:vkReleaseProfilingLockKHR, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkReleaseProfilingLockKHR(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 const VkPointClippingBehaviorKHR = VkPointClippingBehavior
@@ -6938,8 +7878,16 @@ function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormats2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
+end
+
+function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
 end
 
 const VkPhysicalDeviceVariablePointerFeaturesKHR = VkPhysicalDeviceVariablePointersFeatures
@@ -6993,16 +7941,32 @@ function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount
     ccall((:vkGetPhysicalDeviceDisplayProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlaneProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModeProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
+function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
 function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
+end
+
+function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
 end
 
 const VkMemoryDedicatedRequirementsKHR = VkMemoryDedicatedRequirements
@@ -7032,12 +7996,24 @@ function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 const VkImageFormatListCreateInfoKHR = VkImageFormatListCreateInfo
@@ -7072,8 +8048,16 @@ function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcb
     ccall((:vkCreateSamplerYcbcrConversionKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
+function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
 function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversionKHR, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
+function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
 const VkBindBufferMemoryInfoKHR = VkBindBufferMemoryInfo
@@ -7090,8 +8074,16 @@ function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 const VkPhysicalDeviceMaintenance3PropertiesKHR = VkPhysicalDeviceMaintenance3Properties
@@ -7105,6 +8097,10 @@ function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupportKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
+function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountKHR ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
 const PFN_vkCmdDrawIndirectCountKHR = Ptr{Cvoid}
 
@@ -7115,8 +8111,16 @@ function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 const VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR = VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures
@@ -7181,12 +8185,24 @@ function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValueKHR, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
+function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
 function vkWaitSemaphoresKHR(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphoresKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphoresKHR(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphoreKHR(device, pSignalInfo)
     ccall((:vkSignalSemaphoreKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphoreKHR(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR = VkPhysicalDeviceVulkanMemoryModelFeatures
@@ -7267,8 +8283,16 @@ function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentSha
     ccall((:vkGetPhysicalDeviceFragmentShadingRatesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
 end
 
+function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
+end
+
 function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps)
     ccall((:vkCmdSetFragmentShadingRateKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
+end
+
+function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
 end
 
 struct VkSurfaceProtectedCapabilitiesKHR
@@ -7308,12 +8332,24 @@ function vkGetBufferDeviceAddressKHR(device, pInfo)
     ccall((:vkGetBufferDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkDeferredOperationKHR_T = Cvoid
@@ -7339,20 +8375,40 @@ function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation)
     ccall((:vkCreateDeferredOperationKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
 end
 
+function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
+end
+
 function vkDestroyDeferredOperationKHR(device, operation, pAllocator)
     ccall((:vkDestroyDeferredOperationKHR, libvulkan), Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
+end
+
+function vkDestroyDeferredOperationKHR(device, operation, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
 end
 
 function vkGetDeferredOperationMaxConcurrencyKHR(device, operation)
     ccall((:vkGetDeferredOperationMaxConcurrencyKHR, libvulkan), UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationMaxConcurrencyKHR(device, operation, fptr)
+    ccall(fptr, UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkGetDeferredOperationResultKHR(device, operation)
     ccall((:vkGetDeferredOperationResultKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationResultKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkDeferredOperationJoinKHR(device, operation)
     ccall((:vkDeferredOperationJoinKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
+function vkDeferredOperationJoinKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
 @cenum VkPipelineExecutableStatisticFormatKHR::UInt32 begin
@@ -7446,12 +8502,24 @@ function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutable
     ccall((:vkGetPipelineExecutablePropertiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
 end
 
+function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutableCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
+end
+
 function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics)
     ccall((:vkGetPipelineExecutableStatisticsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
 end
 
+function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
+end
+
 function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
     ccall((:vkGetPipelineExecutableInternalRepresentationsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
+end
+
+function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
 end
 
 struct VkPipelineLibraryCreateInfoKHR
@@ -7603,32 +8671,64 @@ function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo)
     ccall((:vkCmdSetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
 end
 
+function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
+end
+
 function vkCmdResetEvent2KHR(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
+end
+
+function vkCmdResetEvent2KHR(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
 end
 
 function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos)
     ccall((:vkCmdWaitEvents2KHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
 end
 
+function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
+end
+
 function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo)
     ccall((:vkCmdPipelineBarrier2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
+end
+
+function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
 end
 
 function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query)
     ccall((:vkCmdWriteTimestamp2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
+end
+
 function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit2KHR, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
+function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
 function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarker2AMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
 end
 
+function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
+end
+
 function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointData2NV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR
@@ -7779,24 +8879,48 @@ function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo)
     ccall((:vkCmdCopyBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
 end
 
+function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
+end
+
 function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo)
     ccall((:vkCmdCopyImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
+end
+
+function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
 end
 
 function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo)
     ccall((:vkCmdCopyBufferToImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
 end
 
+function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
+end
+
 function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo)
     ccall((:vkCmdCopyImageToBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
+end
+
+function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
 end
 
 function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo)
     ccall((:vkCmdBlitImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
 end
 
+function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
+end
+
 function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo)
     ccall((:vkCmdResolveImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
+end
+
+function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
 end
 
 const VkDebugReportCallbackEXT_T = Cvoid
@@ -7882,12 +9006,24 @@ function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCall
     ccall((:vkCreateDebugReportCallbackEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
 end
 
+function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
+end
+
 function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator)
     ccall((:vkDestroyDebugReportCallbackEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
 end
 
+function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
+end
+
 function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
     ccall((:vkDebugReportMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
+end
+
+function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
 end
 
 @cenum VkRasterizationOrderAMD::UInt32 begin
@@ -7946,20 +9082,40 @@ function vkDebugMarkerSetObjectTagEXT(device, pTagInfo)
     ccall((:vkDebugMarkerSetObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
 end
 
+function vkDebugMarkerSetObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
+end
+
 function vkDebugMarkerSetObjectNameEXT(device, pNameInfo)
     ccall((:vkDebugMarkerSetObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
+end
+
+function vkDebugMarkerSetObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
 end
 
 function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerBeginEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdDebugMarkerEndEXT(commandBuffer)
     ccall((:vkCmdDebugMarkerEndEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdDebugMarkerEndEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerInsertEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
 struct VkDedicatedAllocationImageCreateInfoNV
@@ -8034,24 +9190,48 @@ function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindi
     ccall((:vkCmdBindTransformFeedbackBuffersEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
 end
 
+function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
+end
+
 function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdBeginTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
+function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
 function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdEndTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
+function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
 function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index)
     ccall((:vkCmdBeginQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
+end
+
+function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
 end
 
 function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index)
     ccall((:vkCmdEndQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
 end
 
+function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
+end
+
 function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
     ccall((:vkCmdDrawIndirectByteCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
+end
+
+function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
 end
 
 struct VkImageViewHandleInfoNVX
@@ -8079,8 +9259,16 @@ function vkGetImageViewHandleNVX(device, pInfo)
     ccall((:vkGetImageViewHandleNVX, libvulkan), UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
 end
 
+function vkGetImageViewHandleNVX(device, pInfo, fptr)
+    ccall(fptr, UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
+end
+
 function vkGetImageViewAddressNVX(device, imageView, pProperties)
     ccall((:vkGetImageViewAddressNVX, libvulkan), VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
+end
+
+function vkGetImageViewAddressNVX(device, imageView, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
 end
 
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountAMD ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
@@ -8093,8 +9281,16 @@ function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkTextureLODGatherFormatPropertiesAMD
@@ -8135,6 +9331,10 @@ function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, 
     ccall((:vkGetShaderInfoAMD, libvulkan), VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
 end
 
+function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
+end
+
 struct VkPhysicalDeviceCornerSampledImageFeaturesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8172,6 +9372,10 @@ const PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
     ccall((:vkGetPhysicalDeviceExternalImageFormatPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
 end
 
 struct VkExternalMemoryImageCreateInfoNV
@@ -8255,8 +9459,16 @@ function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingB
     ccall((:vkCmdBeginConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
 end
 
+function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
+end
+
 function vkCmdEndConditionalRenderingEXT(commandBuffer)
     ccall((:vkCmdEndConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkCmdEndConditionalRenderingEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
 struct VkViewportWScalingNV
@@ -8279,11 +9491,19 @@ function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount,
     ccall((:vkCmdSetViewportWScalingNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
 end
 
+function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
+end
+
 # typedef VkResult ( VKAPI_PTR * PFN_vkReleaseDisplayEXT ) ( VkPhysicalDevice physicalDevice , VkDisplayKHR display )
 const PFN_vkReleaseDisplayEXT = Ptr{Cvoid}
 
 function vkReleaseDisplayEXT(physicalDevice, display)
     ccall((:vkReleaseDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
+function vkReleaseDisplayEXT(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
 @cenum VkSurfaceCounterFlagBitsEXT::UInt32 begin
@@ -8315,6 +9535,10 @@ const PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2EXT, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
+function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
 @cenum VkDisplayPowerStateEXT::UInt32 begin
@@ -8374,16 +9598,32 @@ function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo)
     ccall((:vkDisplayPowerControlEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
 end
 
+function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
+end
+
 function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDeviceEventEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
+end
+
+function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
 end
 
 function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDisplayEventEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
 end
 
+function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
+end
+
 function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue)
     ccall((:vkGetSwapchainCounterEXT, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
+end
+
+function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
 end
 
 struct VkRefreshCycleDurationGOOGLE
@@ -8420,8 +9660,16 @@ function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProper
     ccall((:vkGetRefreshCycleDurationGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
 end
 
+function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
+end
+
 function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings)
     ccall((:vkGetPastPresentationTimingGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
+end
+
+function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
 end
 
 struct VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX
@@ -8487,6 +9735,10 @@ const PFN_vkCmdSetDiscardRectangleEXT = Ptr{Cvoid}
 
 function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
     ccall((:vkCmdSetDiscardRectangleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
+end
+
+function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
 end
 
 @cenum VkConservativeRasterizationModeEXT::UInt32 begin
@@ -8558,6 +9810,10 @@ const PFN_vkSetHdrMetadataEXT = Ptr{Cvoid}
 
 function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata)
     ccall((:vkSetHdrMetadataEXT, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
+end
+
+function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
 end
 
 const VkDebugUtilsMessengerEXT_T = Cvoid
@@ -8677,44 +9933,88 @@ function vkSetDebugUtilsObjectNameEXT(device, pNameInfo)
     ccall((:vkSetDebugUtilsObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
 end
 
+function vkSetDebugUtilsObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
+end
+
 function vkSetDebugUtilsObjectTagEXT(device, pTagInfo)
     ccall((:vkSetDebugUtilsObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
+end
+
+function vkSetDebugUtilsObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
 end
 
 function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkQueueEndDebugUtilsLabelEXT(queue)
     ccall((:vkQueueEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue,), queue)
+end
+
+function vkQueueEndDebugUtilsLabelEXT(queue, fptr)
+    ccall(fptr, Cvoid, (VkQueue,), queue)
 end
 
 function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCmdEndDebugUtilsLabelEXT(commandBuffer)
     ccall((:vkCmdEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndDebugUtilsLabelEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger)
     ccall((:vkCreateDebugUtilsMessengerEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
 end
 
+function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
+end
+
 function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator)
     ccall((:vkDestroyDebugUtilsMessengerEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
 end
 
+function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
+end
+
 function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData)
     ccall((:vkSubmitDebugUtilsMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
+end
+
+function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
 end
 
 const VkSamplerReductionModeEXT = VkSamplerReductionMode
@@ -8819,8 +10119,16 @@ function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo)
     ccall((:vkCmdSetSampleLocationsEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
 end
 
+function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
+end
+
 function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties)
     ccall((:vkGetPhysicalDeviceMultisamplePropertiesEXT, libvulkan), Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
+end
+
+function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
 end
 
 @cenum VkBlendOverlapEXT::UInt32 begin
@@ -8948,6 +10256,10 @@ function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties)
     ccall((:vkGetImageDrmFormatModifierPropertiesEXT, libvulkan), VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
 end
 
+function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
+end
+
 const VkValidationCacheEXT_T = Cvoid
 
 const VkValidationCacheEXT = Ptr{VkValidationCacheEXT_T}
@@ -8989,16 +10301,32 @@ function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidation
     ccall((:vkCreateValidationCacheEXT, libvulkan), VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
 end
 
+function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
+end
+
 function vkDestroyValidationCacheEXT(device, validationCache, pAllocator)
     ccall((:vkDestroyValidationCacheEXT, libvulkan), Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
+end
+
+function vkDestroyValidationCacheEXT(device, validationCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
 end
 
 function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergeValidationCachesEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData)
     ccall((:vkGetValidationCacheDataEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
+end
+
+function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
 end
 
 const VkDescriptorBindingFlagBitsEXT = VkDescriptorBindingFlagBits
@@ -9101,12 +10429,24 @@ function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout)
     ccall((:vkCmdBindShadingRateImageNV, libvulkan), Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
 end
 
+function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
+end
+
 function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
     ccall((:vkCmdSetViewportShadingRatePaletteNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
 end
 
+function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
+end
+
 function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
     ccall((:vkCmdSetCoarseSampleOrderNV, libvulkan), Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
+end
+
+function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
 end
 
 const VkAccelerationStructureNV_T = Cvoid
@@ -9433,52 +10773,104 @@ function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccel
     ccall((:vkCreateAccelerationStructureNV, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureNV, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements)
     ccall((:vkGetAccelerationStructureMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
+end
+
 function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos)
     ccall((:vkBindAccelerationStructureMemoryNV, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
 end
 
 function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
     ccall((:vkCmdBuildAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
 end
 
+function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
+end
+
 function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode)
     ccall((:vkCmdCopyAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
+end
+
+function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
 end
 
 function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
     ccall((:vkCmdTraceRaysNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
 end
 
+function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesNV, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
+function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
 function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData)
     ccall((:vkGetAccelerationStructureHandleNV, libvulkan), VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
 end
 
+function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
+function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
 function vkCompileDeferredNV(device, pipeline, shader)
     ccall((:vkCompileDeferredNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
+end
+
+function vkCompileDeferredNV(device, pipeline, shader, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
 end
 
 struct VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV
@@ -9546,11 +10938,19 @@ function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, p
     ccall((:vkGetMemoryHostPointerPropertiesEXT, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
 end
 
+function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, pMemoryHostPointerProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdWriteBufferMarkerAMD ) ( VkCommandBuffer commandBuffer , VkPipelineStageFlagBits pipelineStage , VkBuffer dstBuffer , VkDeviceSize dstOffset , uint32_t marker )
 const PFN_vkCmdWriteBufferMarkerAMD = Ptr{Cvoid}
 
 function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarkerAMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
+end
+
+function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
 end
 
 @cenum VkPipelineCompilerControlFlagBitsAMD::UInt32 begin
@@ -9589,8 +10989,16 @@ function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDom
     ccall((:vkGetPhysicalDeviceCalibrateableTimeDomainsEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
 end
 
+function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDomainCount, pTimeDomains, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
+end
+
 function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
     ccall((:vkGetCalibratedTimestampsEXT, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
+end
+
+function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
 end
 
 struct VkPhysicalDeviceShaderCorePropertiesAMD
@@ -9722,12 +11130,24 @@ function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask)
     ccall((:vkCmdDrawMeshTasksNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
 end
 
+function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
+end
+
 function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectCountNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV
@@ -9762,6 +11182,10 @@ function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclus
     ccall((:vkCmdSetExclusiveScissorNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
 end
 
+function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
+end
+
 struct VkQueueFamilyCheckpointPropertiesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -9785,8 +11209,16 @@ function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker)
     ccall((:vkCmdSetCheckpointNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
 end
 
+function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
+end
+
 function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointDataNV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL
@@ -9930,36 +11362,72 @@ function vkInitializePerformanceApiINTEL(device, pInitializeInfo)
     ccall((:vkInitializePerformanceApiINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
 end
 
+function vkInitializePerformanceApiINTEL(device, pInitializeInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
+end
+
 function vkUninitializePerformanceApiINTEL(device)
     ccall((:vkUninitializePerformanceApiINTEL, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkUninitializePerformanceApiINTEL(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceStreamMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
 function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo)
     ccall((:vkCmdSetPerformanceOverrideINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
 end
 
+function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
+end
+
 function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration)
     ccall((:vkAcquirePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
+end
+
+function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
 end
 
 function vkReleasePerformanceConfigurationINTEL(device, configuration)
     ccall((:vkReleasePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
 end
 
+function vkReleasePerformanceConfigurationINTEL(device, configuration, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
+end
+
 function vkQueueSetPerformanceConfigurationINTEL(queue, configuration)
     ccall((:vkQueueSetPerformanceConfigurationINTEL, libvulkan), VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
 end
 
+function vkQueueSetPerformanceConfigurationINTEL(queue, configuration, fptr)
+    ccall(fptr, VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
+end
+
 function vkGetPerformanceParameterINTEL(device, parameter, pValue)
     ccall((:vkGetPerformanceParameterINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
+end
+
+function vkGetPerformanceParameterINTEL(device, parameter, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
 end
 
 struct VkPhysicalDevicePCIBusInfoPropertiesEXT
@@ -9988,6 +11456,10 @@ const PFN_vkSetLocalDimmingAMD = Ptr{Cvoid}
 
 function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable)
     ccall((:vkSetLocalDimmingAMD, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
+end
+
+function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
 end
 
 struct VkPhysicalDeviceFragmentDensityMapFeaturesEXT
@@ -10112,6 +11584,10 @@ function vkGetBufferDeviceAddressEXT(device, pInfo)
     ccall((:vkGetBufferDeviceAddressEXT, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressEXT(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 @cenum VkToolPurposeFlagBitsEXT::UInt32 begin
     VK_TOOL_PURPOSE_VALIDATION_BIT_EXT = 1
     VK_TOOL_PURPOSE_PROFILING_BIT_EXT = 2
@@ -10140,6 +11616,10 @@ const PFN_vkGetPhysicalDeviceToolPropertiesEXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties)
     ccall((:vkGetPhysicalDeviceToolPropertiesEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
+end
+
+function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
 end
 
 const VkImageStencilUsageCreateInfoEXT = VkImageStencilUsageCreateInfo
@@ -10229,6 +11709,10 @@ function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPrope
     ccall((:vkGetPhysicalDeviceCooperativeMatrixPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
+end
+
 @cenum VkCoverageReductionModeNV::UInt32 begin
     VK_COVERAGE_REDUCTION_MODE_MERGE_NV = 0
     VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV = 1
@@ -10264,6 +11748,10 @@ const PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV = Pt
 
 function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations)
     ccall((:vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
+end
+
+function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
 end
 
 struct VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT
@@ -10321,6 +11809,10 @@ function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateHeadlessSurfaceEXT, libvulkan), VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 @cenum VkLineRasterizationModeEXT::UInt32 begin
     VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT = 0
     VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT = 1
@@ -10362,6 +11854,10 @@ function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePat
     ccall((:vkCmdSetLineStippleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
 end
 
+function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
+end
+
 struct VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10386,6 +11882,10 @@ const PFN_vkResetQueryPoolEXT = Ptr{Cvoid}
 
 function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPoolEXT, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
+function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
 struct VkPhysicalDeviceIndexTypeUint8FeaturesEXT
@@ -10440,48 +11940,96 @@ function vkCmdSetCullModeEXT(commandBuffer, cullMode)
     ccall((:vkCmdSetCullModeEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
 end
 
+function vkCmdSetCullModeEXT(commandBuffer, cullMode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
+end
+
 function vkCmdSetFrontFaceEXT(commandBuffer, frontFace)
     ccall((:vkCmdSetFrontFaceEXT, libvulkan), Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
+end
+
+function vkCmdSetFrontFaceEXT(commandBuffer, frontFace, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
 end
 
 function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology)
     ccall((:vkCmdSetPrimitiveTopologyEXT, libvulkan), Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
 end
 
+function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
+end
+
 function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports)
     ccall((:vkCmdSetViewportWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
+end
+
+function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
 end
 
 function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors)
     ccall((:vkCmdSetScissorWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
 end
 
+function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
+end
+
 function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
     ccall((:vkCmdBindVertexBuffers2EXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
+end
+
+function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
 end
 
 function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable)
     ccall((:vkCmdSetDepthTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
 end
 
+function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
+end
+
 function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable)
     ccall((:vkCmdSetDepthWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
+end
+
+function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
 end
 
 function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp)
     ccall((:vkCmdSetDepthCompareOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
 end
 
+function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
+end
+
 function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable)
     ccall((:vkCmdSetDepthBoundsTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
+end
+
+function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
 end
 
 function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable)
     ccall((:vkCmdSetStencilTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
 end
 
+function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
+end
+
 function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
     ccall((:vkCmdSetStencilOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
+end
+
+function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
 end
 
 struct VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT
@@ -10663,24 +12211,48 @@ function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequir
     ccall((:vkGetGeneratedCommandsMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo)
     ccall((:vkCmdPreprocessGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
+end
+
+function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
 end
 
 function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
     ccall((:vkCmdExecuteGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
 end
 
+function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
+end
+
 function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex)
     ccall((:vkCmdBindPipelineShaderGroupNV, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
+end
+
+function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
 end
 
 function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
     ccall((:vkCreateIndirectCommandsLayoutNV, libvulkan), VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
 end
 
+function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
+end
+
 function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator)
     ccall((:vkDestroyIndirectCommandsLayoutNV, libvulkan), Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
+end
+
+function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
 end
 
 struct VkPhysicalDeviceInheritedViewportScissorFeaturesNV
@@ -10844,16 +12416,32 @@ function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDat
     ccall((:vkCreatePrivateDataSlotEXT, libvulkan), VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
 end
 
+function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDataSlot, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
+end
+
 function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator)
     ccall((:vkDestroyPrivateDataSlotEXT, libvulkan), Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
+end
+
+function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
 end
 
 function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data)
     ccall((:vkSetPrivateDataEXT, libvulkan), VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
 end
 
+function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
+end
+
 function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData)
     ccall((:vkGetPrivateDataEXT, libvulkan), Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
+end
+
+function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
 end
 
 struct VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT
@@ -10934,6 +12522,10 @@ function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerO
     ccall((:vkCmdSetFragmentShadingRateEnumNV, libvulkan), Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
 end
 
+function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
+end
+
 struct VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10984,8 +12576,16 @@ function vkAcquireWinrtDisplayNV(physicalDevice, display)
     ccall((:vkAcquireWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
+function vkAcquireWinrtDisplayNV(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
 function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay)
     ccall((:vkGetWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
+end
+
+function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
 end
 
 struct VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE
@@ -11037,6 +12637,10 @@ function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pV
     ccall((:vkCmdSetVertexInputEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
 end
 
+function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
+end
+
 struct VkPhysicalDeviceExtendedDynamicState2FeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -11064,20 +12668,40 @@ function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints)
     ccall((:vkCmdSetPatchControlPointsEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
 end
 
+function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
+end
+
 function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable)
     ccall((:vkCmdSetRasterizerDiscardEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
+end
+
+function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
 end
 
 function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable)
     ccall((:vkCmdSetDepthBiasEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
 end
 
+function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
+end
+
 function vkCmdSetLogicOpEXT(commandBuffer, logicOp)
     ccall((:vkCmdSetLogicOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
 end
 
+function vkCmdSetLogicOpEXT(commandBuffer, logicOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
+end
+
 function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable)
     ccall((:vkCmdSetPrimitiveRestartEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
+end
+
+function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
 end
 
 struct VkPhysicalDeviceColorWriteEnableFeaturesEXT
@@ -11098,6 +12722,10 @@ const PFN_vkCmdSetColorWriteEnableEXT = Ptr{Cvoid}
 
 function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables)
     ccall((:vkCmdSetColorWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
+end
+
+function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
 end
 
 const VkAccelerationStructureKHR_T = Cvoid
@@ -11386,64 +13014,128 @@ function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAcce
     ccall((:vkCreateAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkCmdBuildAccelerationStructuresKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
     ccall((:vkCmdBuildAccelerationStructuresIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
+end
+
+function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
 end
 
 function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkBuildAccelerationStructuresKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureToMemoryKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
 end
 
+function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
+end
+
 function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyMemoryToAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
     ccall((:vkWriteAccelerationStructuresPropertiesKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
 end
 
+function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
+end
+
 function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureToMemoryKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
 end
 
+function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
+end
+
 function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyMemoryToAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo)
     ccall((:vkGetAccelerationStructureDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
 end
 
+function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
+function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
 function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility)
     ccall((:vkGetDeviceAccelerationStructureCompatibilityKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
 end
 
+function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
+end
+
 function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
     ccall((:vkGetAccelerationStructureBuildSizesKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
+end
+
+function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
 end
 
 @cenum VkShaderGroupShaderKHR::UInt32 begin
@@ -11546,24 +13238,48 @@ function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShader
     ccall((:vkCmdTraceRaysKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
 end
 
+function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingCaptureReplayShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
     ccall((:vkCmdTraceRaysIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
+end
+
+function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
 end
 
 function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader)
     ccall((:vkGetRayTracingShaderGroupStackSizeKHR, libvulkan), VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
 end
 
+function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader, fptr)
+    ccall(fptr, VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
+end
+
 function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize)
     ccall((:vkCmdSetRayTracingPipelineStackSizeKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
+end
+
+function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
 end
 
 struct VkPhysicalDeviceRayQueryFeaturesKHR
@@ -11592,8 +13308,16 @@ function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXcbSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXcbSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id)
     ccall((:vkGetPhysicalDeviceXcbPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
+end
+
+function vkGetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{xcb_connection_t}, xcb_visualid_t), physicalDevice, queueFamilyIndex, connection, visual_id)
 end
 
 const VkXlibSurfaceCreateFlagsKHR = VkFlags
@@ -11616,8 +13340,16 @@ function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateXlibSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkXlibSurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID)
     ccall((:vkGetPhysicalDeviceXlibPresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
+end
+
+function vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32, Ptr{Display}, VisualID), physicalDevice, queueFamilyIndex, dpy, visualID)
 end
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkAcquireXlibDisplayEXT ) ( VkPhysicalDevice physicalDevice , Display * dpy , VkDisplayKHR display )
@@ -11630,8 +13362,16 @@ function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display)
     ccall((:vkAcquireXlibDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
 end
 
+function vkAcquireXlibDisplayEXT(physicalDevice, dpy, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, VkDisplayKHR), physicalDevice, dpy, display)
+end
+
 function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay)
     ccall((:vkGetRandROutputDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
+end
+
+function vkGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Display}, RROutput, Ptr{VkDisplayKHR}), physicalDevice, dpy, rrOutput, pDisplay)
 end
 
 const VULKAN_H_ = 1

--- a/lib/x86_64-unknown-freebsd11.1.jl
+++ b/lib/x86_64-unknown-freebsd11.1.jl
@@ -3200,6 +3200,29 @@ function Base.setproperty!(x::Ptr{VkClearColorValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
+
+function VkClearColorValue(float32::NTuple{4, Cfloat})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkClearColorValue(int32::NTuple{4, Int32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkClearColorValue(uint32::NTuple{4, UInt32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
 struct VkClearDepthStencilValue
     depth::Cfloat
     stencil::UInt32
@@ -3224,6 +3247,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkClearValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
+
+function VkClearValue(color::VkClearColorValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.color = color
+    ref[]
+end
+
+function VkClearValue(depthStencil::VkClearDepthStencilValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.depthStencil = depthStencil
+    ref[]
 end
 
 struct VkClearAttachment
@@ -7779,6 +7818,50 @@ function Base.setproperty!(x::Ptr{VkPerformanceCounterResultKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
+
+function VkPerformanceCounterResultKHR(int32::Int32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(int64::Int64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int64 = int64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint32::UInt32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint64::UInt64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint64 = uint64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float32::Cfloat)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float64::Cdouble)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float64 = float64
+    ref[]
+end
+
 struct VkAcquireProfilingLockInfoKHR
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8468,6 +8551,36 @@ end
 
 function Base.setproperty!(x::Ptr{VkPipelineExecutableStatisticValueKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
+
+function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.b32 = b32
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(i64::Int64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.i64 = i64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.u64 = u64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.f64 = f64
+    ref[]
 end
 
 struct VkPipelineExecutableStatisticKHR
@@ -10728,6 +10841,18 @@ function Base.setproperty!(x::Ptr{VkAccelerationStructureInstanceKHR}, f::Symbol
     unsafe_store!(getproperty(x, f), v)
 end
 
+function VkAccelerationStructureInstanceKHR(transform::VkTransformMatrixKHR, instanceCustomIndex::UInt32, mask::UInt32, instanceShaderBindingTableRecordOffset::UInt32, flags::VkGeometryInstanceFlagsKHR, accelerationStructureReference::UInt64)
+    ref = Ref{VkAccelerationStructureInstanceKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureInstanceKHR}, ref)
+    ptr.transform = transform
+    ptr.instanceCustomIndex = instanceCustomIndex
+    ptr.mask = mask
+    ptr.instanceShaderBindingTableRecordOffset = instanceShaderBindingTableRecordOffset
+    ptr.flags = flags
+    ptr.accelerationStructureReference = accelerationStructureReference
+    ref[]
+end
+
 const VkAccelerationStructureInstanceNV = VkAccelerationStructureInstanceKHR
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkCreateAccelerationStructureNV ) ( VkDevice device , const VkAccelerationStructureCreateInfoNV * pCreateInfo , const VkAllocationCallbacks * pAllocator , VkAccelerationStructureNV * pAccelerationStructure )
@@ -11284,6 +11409,43 @@ end
 
 function Base.setproperty!(x::Ptr{VkPerformanceValueDataINTEL}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
+
+function VkPerformanceValueDataINTEL(value32::UInt32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value32 = value32
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(value64::UInt64)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value64 = value64
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueFloat = valueFloat
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueBool::VkBool32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueBool = valueBool
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueString = valueString
+    ref[]
 end
 
 struct VkPerformanceValueINTEL
@@ -12779,6 +12941,22 @@ function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
+end
+
 struct VkDeviceOrHostAddressConstKHR
     data::NTuple{8, UInt8}
 end
@@ -12798,6 +12976,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressConstKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
 end
 
 struct VkAccelerationStructureBuildRangeInfoKHR
@@ -12853,6 +13047,29 @@ end
 
 function Base.setproperty!(x::Ptr{VkAccelerationStructureGeometryDataKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
+
+function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.triangles = triangles
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.aabbs = aabbs
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.instances = instances
+    ref[]
 end
 
 struct VkAccelerationStructureGeometryKHR

--- a/lib/x86_64-unknown-freebsd11.1.jl
+++ b/lib/x86_64-unknown-freebsd11.1.jl
@@ -3202,24 +3202,16 @@ end
 
 const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
 
-function VkClearColorValue(float32::NTuple{4, Cfloat})
+function VkClearColorValue(val::__U_VkClearColorValue)
     ref = Ref{VkClearColorValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkClearColorValue(int32::NTuple{4, Int32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkClearColorValue(uint32::NTuple{4, UInt32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.uint32 = uint32
+    if val isa NTuple{4, Cfloat}
+        ptr.float32 = val
+    elseif val isa NTuple{4, Int32}
+        ptr.int32 = val
+    elseif val isa NTuple{4, UInt32}
+        ptr.uint32 = val
+    end
     ref[]
 end
 
@@ -3251,17 +3243,14 @@ end
 
 const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
 
-function VkClearValue(color::VkClearColorValue)
+function VkClearValue(val::__U_VkClearValue)
     ref = Ref{VkClearValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.color = color
-    ref[]
-end
-
-function VkClearValue(depthStencil::VkClearDepthStencilValue)
-    ref = Ref{VkClearValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.depthStencil = depthStencil
+    if val isa VkClearColorValue
+        ptr.color = val
+    elseif val isa VkClearDepthStencilValue
+        ptr.depthStencil = val
+    end
     ref[]
 end
 
@@ -7820,45 +7809,22 @@ end
 
 const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
 
-function VkPerformanceCounterResultKHR(int32::Int32)
+function VkPerformanceCounterResultKHR(val::__U_VkPerformanceCounterResultKHR)
     ref = Ref{VkPerformanceCounterResultKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(int64::Int64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int64 = int64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint32::UInt32)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint32 = uint32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint64::UInt64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint64 = uint64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float32::Cfloat)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float64::Cdouble)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float64 = float64
+    if val isa Int32
+        ptr.int32 = val
+    elseif val isa Int64
+        ptr.int64 = val
+    elseif val isa UInt32
+        ptr.uint32 = val
+    elseif val isa UInt64
+        ptr.uint64 = val
+    elseif val isa Cfloat
+        ptr.float32 = val
+    elseif val isa Cdouble
+        ptr.float64 = val
+    end
     ref[]
 end
 
@@ -8555,31 +8521,18 @@ end
 
 const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
 
-function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+function VkPipelineExecutableStatisticValueKHR(val::__U_VkPipelineExecutableStatisticValueKHR)
     ref = Ref{VkPipelineExecutableStatisticValueKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.b32 = b32
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(i64::Int64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.i64 = i64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.u64 = u64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.f64 = f64
+    if val isa VkBool32
+        ptr.b32 = val
+    elseif val isa Int64
+        ptr.i64 = val
+    elseif val isa UInt64
+        ptr.u64 = val
+    elseif val isa Cdouble
+        ptr.f64 = val
+    end
     ref[]
 end
 
@@ -11413,38 +11366,20 @@ end
 
 const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
 
-function VkPerformanceValueDataINTEL(value32::UInt32)
+function VkPerformanceValueDataINTEL(val::__U_VkPerformanceValueDataINTEL)
     ref = Ref{VkPerformanceValueDataINTEL}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value32 = value32
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(value64::UInt64)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value64 = value64
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueFloat = valueFloat
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueBool::VkBool32)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueBool = valueBool
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueString = valueString
+    if val isa UInt32
+        ptr.value32 = val
+    elseif val isa UInt64
+        ptr.value64 = val
+    elseif val isa Cfloat
+        ptr.valueFloat = val
+    elseif val isa VkBool32
+        ptr.valueBool = val
+    elseif val isa Ptr{Cchar}
+        ptr.valueString = val
+    end
     ref[]
 end
 
@@ -12943,17 +12878,14 @@ end
 
 const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressKHR(val::__U_VkDeviceOrHostAddressKHR)
     ref = Ref{VkDeviceOrHostAddressKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -12980,17 +12912,14 @@ end
 
 const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressConstKHR(val::__U_VkDeviceOrHostAddressConstKHR)
     ref = Ref{VkDeviceOrHostAddressConstKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressConstKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -13051,24 +12980,16 @@ end
 
 const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
 
-function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+function VkAccelerationStructureGeometryDataKHR(val::__U_VkAccelerationStructureGeometryDataKHR)
     ref = Ref{VkAccelerationStructureGeometryDataKHR}()
     ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.triangles = triangles
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.aabbs = aabbs
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.instances = instances
+    if val isa VkAccelerationStructureGeometryTrianglesDataKHR
+        ptr.triangles = val
+    elseif val isa VkAccelerationStructureGeometryAabbsDataKHR
+        ptr.aabbs = val
+    elseif val isa VkAccelerationStructureGeometryInstancesDataKHR
+        ptr.instances = val
+    end
     ref[]
 end
 

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -3220,6 +3220,29 @@ function Base.setproperty!(x::Ptr{VkClearColorValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
+
+function VkClearColorValue(float32::NTuple{4, Cfloat})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkClearColorValue(int32::NTuple{4, Int32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkClearColorValue(uint32::NTuple{4, UInt32})
+    ref = Ref{VkClearColorValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
 struct VkClearDepthStencilValue
     depth::Cfloat
     stencil::UInt32
@@ -3244,6 +3267,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkClearValue}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
+
+function VkClearValue(color::VkClearColorValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.color = color
+    ref[]
+end
+
+function VkClearValue(depthStencil::VkClearDepthStencilValue)
+    ref = Ref{VkClearValue}()
+    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
+    ptr.depthStencil = depthStencil
+    ref[]
 end
 
 struct VkClearAttachment
@@ -7799,6 +7838,50 @@ function Base.setproperty!(x::Ptr{VkPerformanceCounterResultKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
+
+function VkPerformanceCounterResultKHR(int32::Int32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int32 = int32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(int64::Int64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.int64 = int64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint32::UInt32)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint32 = uint32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(uint64::UInt64)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.uint64 = uint64
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float32::Cfloat)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float32 = float32
+    ref[]
+end
+
+function VkPerformanceCounterResultKHR(float64::Cdouble)
+    ref = Ref{VkPerformanceCounterResultKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
+    ptr.float64 = float64
+    ref[]
+end
+
 struct VkAcquireProfilingLockInfoKHR
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8488,6 +8571,36 @@ end
 
 function Base.setproperty!(x::Ptr{VkPipelineExecutableStatisticValueKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
+
+function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.b32 = b32
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(i64::Int64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.i64 = i64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.u64 = u64
+    ref[]
+end
+
+function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
+    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
+    ptr.f64 = f64
+    ref[]
 end
 
 struct VkPipelineExecutableStatisticKHR
@@ -10748,6 +10861,18 @@ function Base.setproperty!(x::Ptr{VkAccelerationStructureInstanceKHR}, f::Symbol
     unsafe_store!(getproperty(x, f), v)
 end
 
+function VkAccelerationStructureInstanceKHR(transform::VkTransformMatrixKHR, instanceCustomIndex::UInt32, mask::UInt32, instanceShaderBindingTableRecordOffset::UInt32, flags::VkGeometryInstanceFlagsKHR, accelerationStructureReference::UInt64)
+    ref = Ref{VkAccelerationStructureInstanceKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureInstanceKHR}, ref)
+    ptr.transform = transform
+    ptr.instanceCustomIndex = instanceCustomIndex
+    ptr.mask = mask
+    ptr.instanceShaderBindingTableRecordOffset = instanceShaderBindingTableRecordOffset
+    ptr.flags = flags
+    ptr.accelerationStructureReference = accelerationStructureReference
+    ref[]
+end
+
 const VkAccelerationStructureInstanceNV = VkAccelerationStructureInstanceKHR
 
 # typedef VkResult ( VKAPI_PTR * PFN_vkCreateAccelerationStructureNV ) ( VkDevice device , const VkAccelerationStructureCreateInfoNV * pCreateInfo , const VkAllocationCallbacks * pAllocator , VkAccelerationStructureNV * pAccelerationStructure )
@@ -11304,6 +11429,43 @@ end
 
 function Base.setproperty!(x::Ptr{VkPerformanceValueDataINTEL}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
+
+function VkPerformanceValueDataINTEL(value32::UInt32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value32 = value32
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(value64::UInt64)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.value64 = value64
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueFloat = valueFloat
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueBool::VkBool32)
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueBool = valueBool
+    ref[]
+end
+
+function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
+    ref = Ref{VkPerformanceValueDataINTEL}()
+    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
+    ptr.valueString = valueString
+    ref[]
 end
 
 struct VkPerformanceValueINTEL
@@ -12799,6 +12961,22 @@ function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
+end
+
 struct VkDeviceOrHostAddressConstKHR
     data::NTuple{8, UInt8}
 end
@@ -12818,6 +12996,22 @@ end
 
 function Base.setproperty!(x::Ptr{VkDeviceOrHostAddressConstKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
+
+function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.deviceAddress = deviceAddress
+    ref[]
+end
+
+function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
+    ref = Ref{VkDeviceOrHostAddressConstKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
+    ptr.hostAddress = hostAddress
+    ref[]
 end
 
 struct VkAccelerationStructureBuildRangeInfoKHR
@@ -12873,6 +13067,29 @@ end
 
 function Base.setproperty!(x::Ptr{VkAccelerationStructureGeometryDataKHR}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
+
+function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.triangles = triangles
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.aabbs = aabbs
+    ref[]
+end
+
+function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
+    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
+    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
+    ptr.instances = instances
+    ref[]
 end
 
 struct VkAccelerationStructureGeometryKHR

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -3706,548 +3706,1096 @@ function vkCreateInstance(pCreateInfo, pAllocator, pInstance)
     ccall((:vkCreateInstance, libvulkan), VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
 end
 
+function vkCreateInstance(pCreateInfo, pAllocator, pInstance, fptr)
+    ccall(fptr, VkResult, (Ptr{VkInstanceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkInstance}), pCreateInfo, pAllocator, pInstance)
+end
+
 function vkDestroyInstance(instance, pAllocator)
     ccall((:vkDestroyInstance, libvulkan), Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
+end
+
+function vkDestroyInstance(instance, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, Ptr{VkAllocationCallbacks}), instance, pAllocator)
 end
 
 function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices)
     ccall((:vkEnumeratePhysicalDevices, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
 end
 
+function vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDevice}), instance, pPhysicalDeviceCount, pPhysicalDevices)
+end
+
 function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
+end
+
+function vkGetPhysicalDeviceFeatures(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures}), physicalDevice, pFeatures)
 end
 
 function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, Ptr{VkImageFormatProperties}), physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceProperties(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
 end
 
+function vkGetPhysicalDeviceProperties(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties}), physicalDevice, pProperties)
+end
+
 function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
+function vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
 function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetInstanceProcAddr(instance, pName)
     ccall((:vkGetInstanceProcAddr, libvulkan), PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
+end
+
+function vkGetInstanceProcAddr(instance, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkInstance, Ptr{Cchar}), instance, pName)
 end
 
 function vkGetDeviceProcAddr(device, pName)
     ccall((:vkGetDeviceProcAddr, libvulkan), PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
 end
 
+function vkGetDeviceProcAddr(device, pName, fptr)
+    ccall(fptr, PFN_vkVoidFunction, (VkDevice, Ptr{Cchar}), device, pName)
+end
+
 function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice)
     ccall((:vkCreateDevice, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
+end
+
+function vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDeviceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDevice}), physicalDevice, pCreateInfo, pAllocator, pDevice)
 end
 
 function vkDestroyDevice(device, pAllocator)
     ccall((:vkDestroyDevice, libvulkan), Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
 end
 
+function vkDestroyDevice(device, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAllocationCallbacks}), device, pAllocator)
+end
+
 function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceExtensionProperties, libvulkan), VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), pLayerName, pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceExtensionProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{Cchar}, Ptr{UInt32}, Ptr{VkExtensionProperties}), physicalDevice, pLayerName, pPropertyCount, pProperties)
+end
+
 function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties)
     ccall((:vkEnumerateInstanceLayerProperties, libvulkan), VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
+end
+
+function vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32}, Ptr{VkLayerProperties}), pPropertyCount, pProperties)
 end
 
 function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkEnumerateDeviceLayerProperties, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkLayerProperties}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue)
     ccall((:vkGetDeviceQueue, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
+end
+
+function vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, Ptr{VkQueue}), device, queueFamilyIndex, queueIndex, pQueue)
 end
 
 function vkQueueSubmit(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
+function vkQueueSubmit(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
 function vkQueueWaitIdle(queue)
     ccall((:vkQueueWaitIdle, libvulkan), VkResult, (VkQueue,), queue)
+end
+
+function vkQueueWaitIdle(queue, fptr)
+    ccall(fptr, VkResult, (VkQueue,), queue)
 end
 
 function vkDeviceWaitIdle(device)
     ccall((:vkDeviceWaitIdle, libvulkan), VkResult, (VkDevice,), device)
 end
 
+function vkDeviceWaitIdle(device, fptr)
+    ccall(fptr, VkResult, (VkDevice,), device)
+end
+
 function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory)
     ccall((:vkAllocateMemory, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
+end
+
+function vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryAllocateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDeviceMemory}), device, pAllocateInfo, pAllocator, pMemory)
 end
 
 function vkFreeMemory(device, memory, pAllocator)
     ccall((:vkFreeMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
 end
 
+function vkFreeMemory(device, memory, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkAllocationCallbacks}), device, memory, pAllocator)
+end
+
 function vkMapMemory(device, memory, offset, size, flags, ppData)
     ccall((:vkMapMemory, libvulkan), VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
+end
+
+function vkMapMemory(device, memory, offset, size, flags, ppData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeviceMemory, VkDeviceSize, VkDeviceSize, VkMemoryMapFlags, Ptr{Ptr{Cvoid}}), device, memory, offset, size, flags, ppData)
 end
 
 function vkUnmapMemory(device, memory)
     ccall((:vkUnmapMemory, libvulkan), Cvoid, (VkDevice, VkDeviceMemory), device, memory)
 end
 
+function vkUnmapMemory(device, memory, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory), device, memory)
+end
+
 function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkFlushMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
+function vkFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
 function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges)
     ccall((:vkInvalidateMappedMemoryRanges, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
 end
 
+function vkInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkMappedMemoryRange}), device, memoryRangeCount, pMemoryRanges)
+end
+
 function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes)
     ccall((:vkGetDeviceMemoryCommitment, libvulkan), Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
+end
+
+function vkGetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeviceMemory, Ptr{VkDeviceSize}), device, memory, pCommittedMemoryInBytes)
 end
 
 function vkBindBufferMemory(device, buffer, memory, memoryOffset)
     ccall((:vkBindBufferMemory, libvulkan), VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
 end
 
+function vkBindBufferMemory(device, buffer, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkBuffer, VkDeviceMemory, VkDeviceSize), device, buffer, memory, memoryOffset)
+end
+
 function vkBindImageMemory(device, image, memory, memoryOffset)
     ccall((:vkBindImageMemory, libvulkan), VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
+end
+
+function vkBindImageMemory(device, image, memory, memoryOffset, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, VkDeviceMemory, VkDeviceSize), device, image, memory, memoryOffset)
 end
 
 function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements(device, buffer, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkMemoryRequirements}), device, buffer, pMemoryRequirements)
+end
+
 function vkGetImageMemoryRequirements(device, image, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements(device, image, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkMemoryRequirements}), device, image, pMemoryRequirements)
 end
 
 function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
+function vkGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements}), device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, VkImageType, VkSampleCountFlagBits, VkImageUsageFlags, VkImageTiling, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties}), physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties)
 end
 
 function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence)
     ccall((:vkQueueBindSparse, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
 end
 
+function vkQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkBindSparseInfo}, VkFence), queue, bindInfoCount, pBindInfo, fence)
+end
+
 function vkCreateFence(device, pCreateInfo, pAllocator, pFence)
     ccall((:vkCreateFence, libvulkan), VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
+end
+
+function vkCreateFence(device, pCreateInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pCreateInfo, pAllocator, pFence)
 end
 
 function vkDestroyFence(device, fence, pAllocator)
     ccall((:vkDestroyFence, libvulkan), Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
 end
 
+function vkDestroyFence(device, fence, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFence, Ptr{VkAllocationCallbacks}), device, fence, pAllocator)
+end
+
 function vkResetFences(device, fenceCount, pFences)
     ccall((:vkResetFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
+end
+
+function vkResetFences(device, fenceCount, pFences, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}), device, fenceCount, pFences)
 end
 
 function vkGetFenceStatus(device, fence)
     ccall((:vkGetFenceStatus, libvulkan), VkResult, (VkDevice, VkFence), device, fence)
 end
 
+function vkGetFenceStatus(device, fence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkFence), device, fence)
+end
+
 function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout)
     ccall((:vkWaitForFences, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
+end
+
+function vkWaitForFences(device, fenceCount, pFences, waitAll, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkFence}, VkBool32, UInt64), device, fenceCount, pFences, waitAll, timeout)
 end
 
 function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore)
     ccall((:vkCreateSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
 end
 
+function vkCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSemaphore}), device, pCreateInfo, pAllocator, pSemaphore)
+end
+
 function vkDestroySemaphore(device, semaphore, pAllocator)
     ccall((:vkDestroySemaphore, libvulkan), Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
+end
+
+function vkDestroySemaphore(device, semaphore, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSemaphore, Ptr{VkAllocationCallbacks}), device, semaphore, pAllocator)
 end
 
 function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent)
     ccall((:vkCreateEvent, libvulkan), VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
 end
 
+function vkCreateEvent(device, pCreateInfo, pAllocator, pEvent, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkEventCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkEvent}), device, pCreateInfo, pAllocator, pEvent)
+end
+
 function vkDestroyEvent(device, event, pAllocator)
     ccall((:vkDestroyEvent, libvulkan), Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
+end
+
+function vkDestroyEvent(device, event, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkEvent, Ptr{VkAllocationCallbacks}), device, event, pAllocator)
 end
 
 function vkGetEventStatus(device, event)
     ccall((:vkGetEventStatus, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkGetEventStatus(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkSetEvent(device, event)
     ccall((:vkSetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
+end
+
+function vkSetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
 end
 
 function vkResetEvent(device, event)
     ccall((:vkResetEvent, libvulkan), VkResult, (VkDevice, VkEvent), device, event)
 end
 
+function vkResetEvent(device, event, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkEvent), device, event)
+end
+
 function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool)
     ccall((:vkCreateQueryPool, libvulkan), VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
+end
+
+function vkCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkQueryPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkQueryPool}), device, pCreateInfo, pAllocator, pQueryPool)
 end
 
 function vkDestroyQueryPool(device, queryPool, pAllocator)
     ccall((:vkDestroyQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
 end
 
+function vkDestroyQueryPool(device, queryPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, Ptr{VkAllocationCallbacks}), device, queryPool, pAllocator)
+end
+
 function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
     ccall((:vkGetQueryPoolResults, libvulkan), VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
+end
+
+function vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkQueryPool, UInt32, UInt32, Csize_t, Ptr{Cvoid}, VkDeviceSize, VkQueryResultFlags), device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags)
 end
 
 function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer)
     ccall((:vkCreateBuffer, libvulkan), VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
 end
 
+function vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBuffer}), device, pCreateInfo, pAllocator, pBuffer)
+end
+
 function vkDestroyBuffer(device, buffer, pAllocator)
     ccall((:vkDestroyBuffer, libvulkan), Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
+end
+
+function vkDestroyBuffer(device, buffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBuffer, Ptr{VkAllocationCallbacks}), device, buffer, pAllocator)
 end
 
 function vkCreateBufferView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateBufferView, libvulkan), VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
 end
 
+function vkCreateBufferView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkBufferViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkBufferView}), device, pCreateInfo, pAllocator, pView)
+end
+
 function vkDestroyBufferView(device, bufferView, pAllocator)
     ccall((:vkDestroyBufferView, libvulkan), Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
+end
+
+function vkDestroyBufferView(device, bufferView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkBufferView, Ptr{VkAllocationCallbacks}), device, bufferView, pAllocator)
 end
 
 function vkCreateImage(device, pCreateInfo, pAllocator, pImage)
     ccall((:vkCreateImage, libvulkan), VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
 end
 
+function vkCreateImage(device, pCreateInfo, pAllocator, pImage, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImage}), device, pCreateInfo, pAllocator, pImage)
+end
+
 function vkDestroyImage(device, image, pAllocator)
     ccall((:vkDestroyImage, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
+end
+
+function vkDestroyImage(device, image, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkAllocationCallbacks}), device, image, pAllocator)
 end
 
 function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout)
     ccall((:vkGetImageSubresourceLayout, libvulkan), Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
 end
 
+function vkGetImageSubresourceLayout(device, image, pSubresource, pLayout, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImage, Ptr{VkImageSubresource}, Ptr{VkSubresourceLayout}), device, image, pSubresource, pLayout)
+end
+
 function vkCreateImageView(device, pCreateInfo, pAllocator, pView)
     ccall((:vkCreateImageView, libvulkan), VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
+end
+
+function vkCreateImageView(device, pCreateInfo, pAllocator, pView, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImageViewCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkImageView}), device, pCreateInfo, pAllocator, pView)
 end
 
 function vkDestroyImageView(device, imageView, pAllocator)
     ccall((:vkDestroyImageView, libvulkan), Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
 end
 
+function vkDestroyImageView(device, imageView, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkImageView, Ptr{VkAllocationCallbacks}), device, imageView, pAllocator)
+end
+
 function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule)
     ccall((:vkCreateShaderModule, libvulkan), VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
+end
+
+function vkCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkShaderModuleCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkShaderModule}), device, pCreateInfo, pAllocator, pShaderModule)
 end
 
 function vkDestroyShaderModule(device, shaderModule, pAllocator)
     ccall((:vkDestroyShaderModule, libvulkan), Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
 end
 
+function vkDestroyShaderModule(device, shaderModule, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkShaderModule, Ptr{VkAllocationCallbacks}), device, shaderModule, pAllocator)
+end
+
 function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache)
     ccall((:vkCreatePipelineCache, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
+end
+
+function vkCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineCacheCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineCache}), device, pCreateInfo, pAllocator, pPipelineCache)
 end
 
 function vkDestroyPipelineCache(device, pipelineCache, pAllocator)
     ccall((:vkDestroyPipelineCache, libvulkan), Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
 end
 
+function vkDestroyPipelineCache(device, pipelineCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineCache, Ptr{VkAllocationCallbacks}), device, pipelineCache, pAllocator)
+end
+
 function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData)
     ccall((:vkGetPipelineCacheData, libvulkan), VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
+end
+
+function vkGetPipelineCacheData(device, pipelineCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, Ptr{Csize_t}, Ptr{Cvoid}), device, pipelineCache, pDataSize, pData)
 end
 
 function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergePipelineCaches, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkPipelineCache}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateGraphicsPipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkGraphicsPipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateComputePipelines, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
+function vkCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkComputePipelineCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
 function vkDestroyPipeline(device, pipeline, pAllocator)
     ccall((:vkDestroyPipeline, libvulkan), Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
+end
+
+function vkDestroyPipeline(device, pipeline, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipeline, Ptr{VkAllocationCallbacks}), device, pipeline, pAllocator)
 end
 
 function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout)
     ccall((:vkCreatePipelineLayout, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
 end
 
+function vkCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkPipelineLayout}), device, pCreateInfo, pAllocator, pPipelineLayout)
+end
+
 function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator)
     ccall((:vkDestroyPipelineLayout, libvulkan), Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
+end
+
+function vkDestroyPipelineLayout(device, pipelineLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPipelineLayout, Ptr{VkAllocationCallbacks}), device, pipelineLayout, pAllocator)
 end
 
 function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler)
     ccall((:vkCreateSampler, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
 end
 
+function vkCreateSampler(device, pCreateInfo, pAllocator, pSampler, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSampler}), device, pCreateInfo, pAllocator, pSampler)
+end
+
 function vkDestroySampler(device, sampler, pAllocator)
     ccall((:vkDestroySampler, libvulkan), Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
+end
+
+function vkDestroySampler(device, sampler, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSampler, Ptr{VkAllocationCallbacks}), device, sampler, pAllocator)
 end
 
 function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout)
     ccall((:vkCreateDescriptorSetLayout, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
 end
 
+function vkCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorSetLayout}), device, pCreateInfo, pAllocator, pSetLayout)
+end
+
 function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator)
     ccall((:vkDestroyDescriptorSetLayout, libvulkan), Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
+end
+
+function vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSetLayout, Ptr{VkAllocationCallbacks}), device, descriptorSetLayout, pAllocator)
 end
 
 function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool)
     ccall((:vkCreateDescriptorPool, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
 end
 
+function vkCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorPool}), device, pCreateInfo, pAllocator, pDescriptorPool)
+end
+
 function vkDestroyDescriptorPool(device, descriptorPool, pAllocator)
     ccall((:vkDestroyDescriptorPool, libvulkan), Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
+end
+
+function vkDestroyDescriptorPool(device, descriptorPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorPool, Ptr{VkAllocationCallbacks}), device, descriptorPool, pAllocator)
 end
 
 function vkResetDescriptorPool(device, descriptorPool, flags)
     ccall((:vkResetDescriptorPool, libvulkan), VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
 end
 
+function vkResetDescriptorPool(device, descriptorPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, VkDescriptorPoolResetFlags), device, descriptorPool, flags)
+end
+
 function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets)
     ccall((:vkAllocateDescriptorSets, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
+end
+
+function vkAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorSetAllocateInfo}, Ptr{VkDescriptorSet}), device, pAllocateInfo, pDescriptorSets)
 end
 
 function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets)
     ccall((:vkFreeDescriptorSets, libvulkan), VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
 end
 
+function vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDescriptorPool, UInt32, Ptr{VkDescriptorSet}), device, descriptorPool, descriptorSetCount, pDescriptorSets)
+end
+
 function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
     ccall((:vkUpdateDescriptorSets, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
+end
+
+function vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkWriteDescriptorSet}, UInt32, Ptr{VkCopyDescriptorSet}), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies)
 end
 
 function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer)
     ccall((:vkCreateFramebuffer, libvulkan), VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
 end
 
+function vkCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFramebufferCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkFramebuffer}), device, pCreateInfo, pAllocator, pFramebuffer)
+end
+
 function vkDestroyFramebuffer(device, framebuffer, pAllocator)
     ccall((:vkDestroyFramebuffer, libvulkan), Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
+end
+
+function vkDestroyFramebuffer(device, framebuffer, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkFramebuffer, Ptr{VkAllocationCallbacks}), device, framebuffer, pAllocator)
 end
 
 function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkDestroyRenderPass(device, renderPass, pAllocator)
     ccall((:vkDestroyRenderPass, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
+end
+
+function vkDestroyRenderPass(device, renderPass, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkAllocationCallbacks}), device, renderPass, pAllocator)
 end
 
 function vkGetRenderAreaGranularity(device, renderPass, pGranularity)
     ccall((:vkGetRenderAreaGranularity, libvulkan), Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
 end
 
+function vkGetRenderAreaGranularity(device, renderPass, pGranularity, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkRenderPass, Ptr{VkExtent2D}), device, renderPass, pGranularity)
+end
+
 function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool)
     ccall((:vkCreateCommandPool, libvulkan), VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
+end
+
+function vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandPoolCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkCommandPool}), device, pCreateInfo, pAllocator, pCommandPool)
 end
 
 function vkDestroyCommandPool(device, commandPool, pAllocator)
     ccall((:vkDestroyCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
 end
 
+function vkDestroyCommandPool(device, commandPool, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, Ptr{VkAllocationCallbacks}), device, commandPool, pAllocator)
+end
+
 function vkResetCommandPool(device, commandPool, flags)
     ccall((:vkResetCommandPool, libvulkan), VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
+end
+
+function vkResetCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkCommandPool, VkCommandPoolResetFlags), device, commandPool, flags)
 end
 
 function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers)
     ccall((:vkAllocateCommandBuffers, libvulkan), VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
 end
 
+function vkAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkCommandBufferAllocateInfo}, Ptr{VkCommandBuffer}), device, pAllocateInfo, pCommandBuffers)
+end
+
 function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers)
     ccall((:vkFreeCommandBuffers, libvulkan), Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
+end
+
+function vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, UInt32, Ptr{VkCommandBuffer}), device, commandPool, commandBufferCount, pCommandBuffers)
 end
 
 function vkBeginCommandBuffer(commandBuffer, pBeginInfo)
     ccall((:vkBeginCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
 end
 
+function vkBeginCommandBuffer(commandBuffer, pBeginInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkCommandBufferBeginInfo}), commandBuffer, pBeginInfo)
+end
+
 function vkEndCommandBuffer(commandBuffer)
     ccall((:vkEndCommandBuffer, libvulkan), VkResult, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkEndCommandBuffer(commandBuffer, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer,), commandBuffer)
 end
 
 function vkResetCommandBuffer(commandBuffer, flags)
     ccall((:vkResetCommandBuffer, libvulkan), VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
 end
 
+function vkResetCommandBuffer(commandBuffer, flags, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, VkCommandBufferResetFlags), commandBuffer, flags)
+end
+
 function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline)
     ccall((:vkCmdBindPipeline, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
+end
+
+function vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline), commandBuffer, pipelineBindPoint, pipeline)
 end
 
 function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports)
     ccall((:vkCmdSetViewport, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
 end
 
+function vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewport}), commandBuffer, firstViewport, viewportCount, pViewports)
+end
+
 function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors)
     ccall((:vkCmdSetScissor, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
+end
+
+function vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstScissor, scissorCount, pScissors)
 end
 
 function vkCmdSetLineWidth(commandBuffer, lineWidth)
     ccall((:vkCmdSetLineWidth, libvulkan), Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
 end
 
+function vkCmdSetLineWidth(commandBuffer, lineWidth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat), commandBuffer, lineWidth)
+end
+
 function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
     ccall((:vkCmdSetDepthBias, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
+end
+
+function vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat, Cfloat), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor)
 end
 
 function vkCmdSetBlendConstants(commandBuffer, blendConstants)
     ccall((:vkCmdSetBlendConstants, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
 end
 
+function vkCmdSetBlendConstants(commandBuffer, blendConstants, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cfloat}), commandBuffer, blendConstants)
+end
+
 function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds)
     ccall((:vkCmdSetDepthBounds, libvulkan), Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
+end
+
+function vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Cfloat, Cfloat), commandBuffer, minDepthBounds, maxDepthBounds)
 end
 
 function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask)
     ccall((:vkCmdSetStencilCompareMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
 end
 
+function vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, compareMask)
+end
+
 function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask)
     ccall((:vkCmdSetStencilWriteMask, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
+end
+
+function vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, writeMask)
 end
 
 function vkCmdSetStencilReference(commandBuffer, faceMask, reference)
     ccall((:vkCmdSetStencilReference, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
 end
 
+function vkCmdSetStencilReference(commandBuffer, faceMask, reference, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, UInt32), commandBuffer, faceMask, reference)
+end
+
 function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
     ccall((:vkCmdBindDescriptorSets, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
+end
+
+function vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkDescriptorSet}, UInt32, Ptr{UInt32}), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets)
 end
 
 function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType)
     ccall((:vkCmdBindIndexBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
 end
 
+function vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType), commandBuffer, buffer, offset, indexType)
+end
+
 function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
     ccall((:vkCmdBindVertexBuffers, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
+end
+
+function vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets)
 end
 
 function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
     ccall((:vkCmdDraw, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
 end
 
+function vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
+end
+
 function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
     ccall((:vkCmdDrawIndexed, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
+end
+
+function vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, Int32, UInt32), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
 end
 
 function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawIndexedIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
 function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatch, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
 end
 
+function vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32), commandBuffer, groupCountX, groupCountY, groupCountZ)
+end
+
 function vkCmdDispatchIndirect(commandBuffer, buffer, offset)
     ccall((:vkCmdDispatchIndirect, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
+end
+
+function vkCmdDispatchIndirect(commandBuffer, buffer, offset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize), commandBuffer, buffer, offset)
 end
 
 function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkBuffer, UInt32, Ptr{VkBufferCopy}), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageCopy}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
     ccall((:vkCmdBlitImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
 end
 
+function vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageBlit}, VkFilter), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter)
+end
+
 function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdCopyBufferToImage, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
+function vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkImage, VkImageLayout, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
 function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
     ccall((:vkCmdCopyImageToBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
 end
 
+function vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkBuffer, UInt32, Ptr{VkBufferImageCopy}), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions)
+end
+
 function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData)
     ccall((:vkCmdUpdateBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
+end
+
+function vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, Ptr{Cvoid}), commandBuffer, dstBuffer, dstOffset, dataSize, pData)
 end
 
 function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data)
     ccall((:vkCmdFillBuffer, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
 end
 
+function vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32), commandBuffer, dstBuffer, dstOffset, size, data)
+end
+
 function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
     ccall((:vkCmdClearColorImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
+end
+
+function vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearColorValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges)
 end
 
 function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
     ccall((:vkCmdClearDepthStencilImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
 end
 
+function vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, Ptr{VkClearDepthStencilValue}, UInt32, Ptr{VkImageSubresourceRange}), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges)
+end
+
 function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
     ccall((:vkCmdClearAttachments, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
+end
+
+function vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkClearAttachment}, UInt32, Ptr{VkClearRect}), commandBuffer, attachmentCount, pAttachments, rectCount, pRects)
 end
 
 function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
     ccall((:vkCmdResolveImage, libvulkan), Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
 end
 
+function vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImage, VkImageLayout, VkImage, VkImageLayout, UInt32, Ptr{VkImageResolve}), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions)
+end
+
 function vkCmdSetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdSetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
+function vkCmdSetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
 function vkCmdResetEvent(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
 end
 
+function vkCmdResetEvent(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags), commandBuffer, event, stageMask)
+end
+
 function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdWaitEvents, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
+function vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, VkPipelineStageFlags, VkPipelineStageFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
 function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
     ccall((:vkCmdPipelineBarrier, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
 end
 
+function vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkDependencyFlags, UInt32, Ptr{VkMemoryBarrier}, UInt32, Ptr{VkBufferMemoryBarrier}, UInt32, Ptr{VkImageMemoryBarrier}), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers)
+end
+
 function vkCmdBeginQuery(commandBuffer, queryPool, query, flags)
     ccall((:vkCmdBeginQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
+end
+
+function vkCmdBeginQuery(commandBuffer, queryPool, query, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags), commandBuffer, queryPool, query, flags)
 end
 
 function vkCmdEndQuery(commandBuffer, queryPool, query)
     ccall((:vkCmdEndQuery, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
 end
 
+function vkCmdEndQuery(commandBuffer, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32), commandBuffer, queryPool, query)
+end
+
 function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount)
     ccall((:vkCmdResetQueryPool, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
+end
+
+function vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, firstQuery, queryCount)
 end
 
 function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query)
     ccall((:vkCmdWriteTimestamp, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkQueryPool, UInt32), commandBuffer, pipelineStage, queryPool, query)
+end
+
 function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
     ccall((:vkCmdCopyQueryPoolResults, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
+end
+
+function vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32, VkBuffer, VkDeviceSize, VkDeviceSize, VkQueryResultFlags), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags)
 end
 
 function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues)
     ccall((:vkCmdPushConstants, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
 end
 
+function vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineLayout, VkShaderStageFlags, UInt32, UInt32, Ptr{Cvoid}), commandBuffer, layout, stageFlags, offset, size, pValues)
+end
+
 function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents)
     ccall((:vkCmdBeginRenderPass, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
+end
+
+function vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, VkSubpassContents), commandBuffer, pRenderPassBegin, contents)
 end
 
 function vkCmdNextSubpass(commandBuffer, contents)
     ccall((:vkCmdNextSubpass, libvulkan), Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
 end
 
+function vkCmdNextSubpass(commandBuffer, contents, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkSubpassContents), commandBuffer, contents)
+end
+
 function vkCmdEndRenderPass(commandBuffer)
     ccall((:vkCmdEndRenderPass, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndRenderPass(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers)
     ccall((:vkCmdExecuteCommands, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
+end
+
+function vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkCommandBuffer}), commandBuffer, commandBufferCount, pCommandBuffers)
 end
 
 const VkSamplerYcbcrConversion_T = Cvoid
@@ -5037,112 +5585,224 @@ function vkEnumerateInstanceVersion(pApiVersion)
     ccall((:vkEnumerateInstanceVersion, libvulkan), VkResult, (Ptr{UInt32},), pApiVersion)
 end
 
+function vkEnumerateInstanceVersion(pApiVersion, fptr)
+    ccall(fptr, VkResult, (Ptr{UInt32},), pApiVersion)
+end
+
 function vkBindBufferMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindBufferMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 function vkBindImageMemory2(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindImageMemory2(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
     ccall((:vkGetDeviceGroupPeerMemoryFeatures, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
+function vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
 function vkCmdSetDeviceMask(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMask, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMask(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBase, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroups, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
+function vkEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
 function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
+function vkGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
 function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
+function vkGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
 function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
 function vkTrimCommandPool(device, commandPool, flags)
     ccall((:vkTrimCommandPool, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
+function vkTrimCommandPool(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
 function vkGetDeviceQueue2(device, pQueueInfo, pQueue)
     ccall((:vkGetDeviceQueue2, libvulkan), Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
 end
 
+function vkGetDeviceQueue2(device, pQueueInfo, pQueue, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDeviceQueueInfo2}, Ptr{VkQueue}), device, pQueueInfo, pQueue)
+end
+
 function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion)
     ccall((:vkCreateSamplerYcbcrConversion, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
+function vkCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
 function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversion, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
+function vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
 function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
     ccall((:vkCreateDescriptorUpdateTemplate, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
+function vkCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
 function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplate, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
+function vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
 function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFenceProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphoreProperties, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
+function vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
 function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupport, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
+function vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
 @cenum VkDriverId::UInt32 begin
@@ -5842,52 +6502,104 @@ function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, coun
     ccall((:vkCmdDrawIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCount, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 function vkResetQueryPool(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPool, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
+function vkResetQueryPool(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
 function vkGetSemaphoreCounterValue(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValue, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
+function vkGetSemaphoreCounterValue(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
 function vkWaitSemaphores(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphores, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphores(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphore(device, pSignalInfo)
     ccall((:vkSignalSemaphore, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphore(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 function vkGetBufferDeviceAddress(device, pInfo)
     ccall((:vkGetBufferDeviceAddress, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddress(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddress, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkSurfaceKHR_T = Cvoid
@@ -5988,20 +6700,40 @@ function vkDestroySurfaceKHR(instance, surface, pAllocator)
     ccall((:vkDestroySurfaceKHR, libvulkan), Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
 end
 
+function vkDestroySurfaceKHR(instance, surface, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkSurfaceKHR, Ptr{VkAllocationCallbacks}), instance, surface, pAllocator)
+end
+
 function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported)
     ccall((:vkGetPhysicalDeviceSurfaceSupportKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
+end
+
+function vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, VkSurfaceKHR, Ptr{VkBool32}), physicalDevice, queueFamilyIndex, surface, pSupported)
 end
 
 function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilitiesKHR}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormatsKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
 end
 
+function vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkSurfaceFormatKHR}), physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats)
+end
+
 function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes)
     ccall((:vkGetPhysicalDeviceSurfacePresentModesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
+end
+
+function vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, surface, pPresentModeCount, pPresentModes)
 end
 
 const VkSwapchainKHR_T = Cvoid
@@ -6134,36 +6866,72 @@ function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain)
     ccall((:vkCreateSwapchainKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
 end
 
+function vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, pCreateInfo, pAllocator, pSwapchain)
+end
+
 function vkDestroySwapchainKHR(device, swapchain, pAllocator)
     ccall((:vkDestroySwapchainKHR, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
+end
+
+function vkDestroySwapchainKHR(device, swapchain, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, Ptr{VkAllocationCallbacks}), device, swapchain, pAllocator)
 end
 
 function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages)
     ccall((:vkGetSwapchainImagesKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
 end
 
+function vkGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkImage}), device, swapchain, pSwapchainImageCount, pSwapchainImages)
+end
+
 function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex)
     ccall((:vkAcquireNextImageKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
+end
+
+function vkAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, UInt64, VkSemaphore, VkFence, Ptr{UInt32}), device, swapchain, timeout, semaphore, fence, pImageIndex)
 end
 
 function vkQueuePresentKHR(queue, pPresentInfo)
     ccall((:vkQueuePresentKHR, libvulkan), VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
 end
 
+function vkQueuePresentKHR(queue, pPresentInfo, fptr)
+    ccall(fptr, VkResult, (VkQueue, Ptr{VkPresentInfoKHR}), queue, pPresentInfo)
+end
+
 function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities)
     ccall((:vkGetDeviceGroupPresentCapabilitiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
+end
+
+function vkGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceGroupPresentCapabilitiesKHR}), device, pDeviceGroupPresentCapabilities)
 end
 
 function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes)
     ccall((:vkGetDeviceGroupSurfacePresentModesKHR, libvulkan), VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
 end
 
+function vkGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSurfaceKHR, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, surface, pModes)
+end
+
 function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects)
     ccall((:vkGetPhysicalDevicePresentRectanglesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
 end
 
+function vkGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{UInt32}, Ptr{VkRect2D}), physicalDevice, surface, pRectCount, pRects)
+end
+
 function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex)
     ccall((:vkAcquireNextImage2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
+end
+
+function vkAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireNextImageInfoKHR}, Ptr{UInt32}), device, pAcquireInfo, pImageIndex)
 end
 
 const VkDisplayKHR_T = Cvoid
@@ -6270,28 +7038,56 @@ function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount,
     ccall((:vkGetPhysicalDeviceDisplayPropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlanePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlanePropertiesKHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays)
     ccall((:vkGetDisplayPlaneSupportedDisplaysKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
 end
 
+function vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkDisplayKHR}), physicalDevice, planeIndex, pDisplayCount, pDisplays)
+end
+
 function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModePropertiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
+function vkGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModePropertiesKHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
 function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode)
     ccall((:vkCreateDisplayModeKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
 end
 
+function vkCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{VkDisplayModeCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkDisplayModeKHR}), physicalDevice, display, pCreateInfo, pAllocator, pMode)
+end
+
 function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilitiesKHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
 end
 
+function vkGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayModeKHR, UInt32, Ptr{VkDisplayPlaneCapabilitiesKHR}), physicalDevice, mode, planeIndex, pCapabilities)
+end
+
 function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateDisplayPlaneSurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
+function vkCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDisplaySurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
 struct VkDisplayPresentInfoKHR
@@ -6307,6 +7103,10 @@ const PFN_vkCreateSharedSwapchainsKHR = Ptr{Cvoid}
 
 function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
     ccall((:vkCreateSharedSwapchainsKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
+end
+
+function vkCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkSwapchainCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSwapchainKHR}), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains)
 end
 
 const VkRenderPassMultiviewCreateInfoKHR = VkRenderPassMultiviewCreateInfo
@@ -6358,28 +7158,56 @@ function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures)
     ccall((:vkGetPhysicalDeviceFeatures2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
 end
 
+function vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceFeatures2}), physicalDevice, pFeatures)
+end
+
 function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties)
     ccall((:vkGetPhysicalDeviceProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
+end
+
+function vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceProperties2}), physicalDevice, pProperties)
 end
 
 function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties)
     ccall((:vkGetPhysicalDeviceFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
 end
 
+function vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkFormat, Ptr{VkFormatProperties2}), physicalDevice, format, pFormatProperties)
+end
+
 function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties)
     ccall((:vkGetPhysicalDeviceImageFormatProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceImageFormatInfo2}, Ptr{VkImageFormatProperties2}), physicalDevice, pImageFormatInfo, pImageFormatProperties)
 end
 
 function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
     ccall((:vkGetPhysicalDeviceQueueFamilyProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
 end
 
+function vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkQueueFamilyProperties2}), physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties)
+end
+
 function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties)
     ccall((:vkGetPhysicalDeviceMemoryProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
 end
 
+function vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceMemoryProperties2}), physicalDevice, pMemoryProperties)
+end
+
 function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceSparseImageFormatProperties2KHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSparseImageFormatInfo2}, Ptr{UInt32}, Ptr{VkSparseImageFormatProperties2}), physicalDevice, pFormatInfo, pPropertyCount, pProperties)
 end
 
 const VkPeerMemoryFeatureFlagsKHR = VkPeerMemoryFeatureFlags
@@ -6417,12 +7245,24 @@ function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceInd
     ccall((:vkGetDeviceGroupPeerMemoryFeaturesKHR, libvulkan), Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
 end
 
+function vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, UInt32, UInt32, Ptr{VkPeerMemoryFeatureFlags}), device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures)
+end
+
 function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask)
     ccall((:vkCmdSetDeviceMaskKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
 end
 
+function vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, deviceMask)
+end
+
 function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
     ccall((:vkCmdDispatchBaseKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
+end
+
+function vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ)
 end
 
 const VkCommandPoolTrimFlagsKHR = VkCommandPoolTrimFlags
@@ -6434,6 +7274,10 @@ function vkTrimCommandPoolKHR(device, commandPool, flags)
     ccall((:vkTrimCommandPoolKHR, libvulkan), Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
 end
 
+function vkTrimCommandPoolKHR(device, commandPool, flags, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkCommandPool, VkCommandPoolTrimFlags), device, commandPool, flags)
+end
+
 const VkPhysicalDeviceGroupPropertiesKHR = VkPhysicalDeviceGroupProperties
 
 const VkDeviceGroupDeviceCreateInfoKHR = VkDeviceGroupDeviceCreateInfo
@@ -6443,6 +7287,10 @@ const PFN_vkEnumeratePhysicalDeviceGroupsKHR = Ptr{Cvoid}
 
 function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
     ccall((:vkEnumeratePhysicalDeviceGroupsKHR, libvulkan), VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+end
+
+function vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{UInt32}, Ptr{VkPhysicalDeviceGroupProperties}), instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
 end
 
 const VkExternalMemoryHandleTypeFlagsKHR = VkExternalMemoryHandleTypeFlags
@@ -6470,6 +7318,10 @@ const PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
     ccall((:vkGetPhysicalDeviceExternalBufferPropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
+end
+
+function vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalBufferInfo}, Ptr{VkExternalBufferProperties}), physicalDevice, pExternalBufferInfo, pExternalBufferProperties)
 end
 
 const VkExternalMemoryImageCreateInfoKHR = VkExternalMemoryImageCreateInfo
@@ -6508,8 +7360,16 @@ function vkGetMemoryFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetMemoryFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
+function vkGetMemoryFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
 function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties)
     ccall((:vkGetMemoryFdPropertiesKHR, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
+end
+
+function vkGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Cint, Ptr{VkMemoryFdPropertiesKHR}), device, handleType, fd, pMemoryFdProperties)
 end
 
 const VkExternalSemaphoreHandleTypeFlagsKHR = VkExternalSemaphoreHandleTypeFlags
@@ -6529,6 +7389,10 @@ const PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
     ccall((:vkGetPhysicalDeviceExternalSemaphorePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
+end
+
+function vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalSemaphoreInfo}, Ptr{VkExternalSemaphoreProperties}), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties)
 end
 
 const VkSemaphoreImportFlagsKHR = VkSemaphoreImportFlags
@@ -6563,8 +7427,16 @@ function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo)
     ccall((:vkImportSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
 end
 
+function vkImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportSemaphoreFdInfoKHR}), device, pImportSemaphoreFdInfo)
+end
+
 function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetSemaphoreFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetSemaphoreFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 struct VkPhysicalDevicePushDescriptorPropertiesKHR
@@ -6583,8 +7455,16 @@ function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set
     ccall((:vkCmdPushDescriptorSetKHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
 end
 
+function vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipelineLayout, UInt32, UInt32, Ptr{VkWriteDescriptorSet}), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites)
+end
+
 function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData)
     ccall((:vkCmdPushDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
+end
+
+function vkCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkDescriptorUpdateTemplate, VkPipelineLayout, UInt32, Ptr{Cvoid}), commandBuffer, descriptorUpdateTemplate, layout, set, pData)
 end
 
 const VkPhysicalDeviceShaderFloat16Int8FeaturesKHR = VkPhysicalDeviceShaderFloat16Int8Features
@@ -6634,12 +7514,24 @@ function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pD
     ccall((:vkCreateDescriptorUpdateTemplateKHR, libvulkan), VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
 end
 
+function vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDescriptorUpdateTemplateCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkDescriptorUpdateTemplate}), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate)
+end
+
 function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator)
     ccall((:vkDestroyDescriptorUpdateTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
 end
 
+function vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorUpdateTemplate, Ptr{VkAllocationCallbacks}), device, descriptorUpdateTemplate, pAllocator)
+end
+
 function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData)
     ccall((:vkUpdateDescriptorSetWithTemplateKHR, libvulkan), Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
+end
+
+function vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDescriptorSet, VkDescriptorUpdateTemplate, Ptr{Cvoid}), device, descriptorSet, descriptorUpdateTemplate, pData)
 end
 
 const VkPhysicalDeviceImagelessFramebufferFeaturesKHR = VkPhysicalDeviceImagelessFramebufferFeatures
@@ -6680,16 +7572,32 @@ function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass)
     ccall((:vkCreateRenderPass2KHR, libvulkan), VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
 end
 
+function vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkRenderPassCreateInfo2}, Ptr{VkAllocationCallbacks}, Ptr{VkRenderPass}), device, pCreateInfo, pAllocator, pRenderPass)
+end
+
 function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
     ccall((:vkCmdBeginRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
+end
+
+function vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkRenderPassBeginInfo}, Ptr{VkSubpassBeginInfo}), commandBuffer, pRenderPassBegin, pSubpassBeginInfo)
 end
 
 function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
     ccall((:vkCmdNextSubpass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
 end
 
+function vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassBeginInfo}, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo)
+end
+
 function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo)
     ccall((:vkCmdEndRenderPass2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
+end
+
+function vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSubpassEndInfo}), commandBuffer, pSubpassEndInfo)
 end
 
 struct VkSharedPresentSurfaceCapabilitiesKHR
@@ -6703,6 +7611,10 @@ const PFN_vkGetSwapchainStatusKHR = Ptr{Cvoid}
 
 function vkGetSwapchainStatusKHR(device, swapchain)
     ccall((:vkGetSwapchainStatusKHR, libvulkan), VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
+end
+
+function vkGetSwapchainStatusKHR(device, swapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
 end
 
 const VkExternalFenceHandleTypeFlagsKHR = VkExternalFenceHandleTypeFlags
@@ -6722,6 +7634,10 @@ const PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
     ccall((:vkGetPhysicalDeviceExternalFencePropertiesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
+end
+
+function vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkPhysicalDeviceExternalFenceInfo}, Ptr{VkExternalFenceProperties}), physicalDevice, pExternalFenceInfo, pExternalFenceProperties)
 end
 
 const VkFenceImportFlagsKHR = VkFenceImportFlags
@@ -6756,8 +7672,16 @@ function vkImportFenceFdKHR(device, pImportFenceFdInfo)
     ccall((:vkImportFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
 end
 
+function vkImportFenceFdKHR(device, pImportFenceFdInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportFenceFdInfoKHR}), device, pImportFenceFdInfo)
+end
+
 function vkGetFenceFdKHR(device, pGetFdInfo, pFd)
     ccall((:vkGetFenceFdKHR, libvulkan), VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
+end
+
+function vkGetFenceFdKHR(device, pGetFdInfo, pFd, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceGetFdInfoKHR}, Ptr{Cint}), device, pGetFdInfo, pFd)
 end
 
 @cenum VkPerformanceCounterUnitKHR::UInt32 begin
@@ -6904,16 +7828,32 @@ function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physica
     ccall((:vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
 end
 
+function vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{UInt32}, Ptr{VkPerformanceCounterKHR}, Ptr{VkPerformanceCounterDescriptionKHR}), physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions)
+end
+
 function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
     ccall((:vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR, libvulkan), Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
+end
+
+function vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, Ptr{VkQueryPoolPerformanceCreateInfoKHR}, Ptr{UInt32}), physicalDevice, pPerformanceQueryCreateInfo, pNumPasses)
 end
 
 function vkAcquireProfilingLockKHR(device, pInfo)
     ccall((:vkAcquireProfilingLockKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
 end
 
+function vkAcquireProfilingLockKHR(device, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAcquireProfilingLockInfoKHR}), device, pInfo)
+end
+
 function vkReleaseProfilingLockKHR(device)
     ccall((:vkReleaseProfilingLockKHR, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkReleaseProfilingLockKHR(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 const VkPointClippingBehaviorKHR = VkPointClippingBehavior
@@ -6958,8 +7898,16 @@ function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
 end
 
+function vkGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkSurfaceCapabilities2KHR}), physicalDevice, pSurfaceInfo, pSurfaceCapabilities)
+end
+
 function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
     ccall((:vkGetPhysicalDeviceSurfaceFormats2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
+end
+
+function vkGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkSurfaceFormat2KHR}), physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats)
 end
 
 const VkPhysicalDeviceVariablePointerFeaturesKHR = VkPhysicalDeviceVariablePointersFeatures
@@ -7013,16 +7961,32 @@ function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount
     ccall((:vkGetPhysicalDeviceDisplayProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
 function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties)
     ccall((:vkGetPhysicalDeviceDisplayPlaneProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
+end
+
+function vkGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkDisplayPlaneProperties2KHR}), physicalDevice, pPropertyCount, pProperties)
 end
 
 function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties)
     ccall((:vkGetDisplayModeProperties2KHR, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
 end
 
+function vkGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR, Ptr{UInt32}, Ptr{VkDisplayModeProperties2KHR}), physicalDevice, display, pPropertyCount, pProperties)
+end
+
 function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities)
     ccall((:vkGetDisplayPlaneCapabilities2KHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
+end
+
+function vkGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkDisplayPlaneInfo2KHR}, Ptr{VkDisplayPlaneCapabilities2KHR}), physicalDevice, pDisplayPlaneInfo, pCapabilities)
 end
 
 const VkMemoryDedicatedRequirementsKHR = VkMemoryDedicatedRequirements
@@ -7052,12 +8016,24 @@ function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetImageMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements)
     ccall((:vkGetBufferMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkBufferMemoryRequirementsInfo2}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
     ccall((:vkGetImageSparseMemoryRequirements2KHR, libvulkan), Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
+end
+
+function vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkImageSparseMemoryRequirementsInfo2}, Ptr{UInt32}, Ptr{VkSparseImageMemoryRequirements2}), device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements)
 end
 
 const VkImageFormatListCreateInfoKHR = VkImageFormatListCreateInfo
@@ -7092,8 +8068,16 @@ function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcb
     ccall((:vkCreateSamplerYcbcrConversionKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
 end
 
+function vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSamplerYcbcrConversionCreateInfo}, Ptr{VkAllocationCallbacks}, Ptr{VkSamplerYcbcrConversion}), device, pCreateInfo, pAllocator, pYcbcrConversion)
+end
+
 function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator)
     ccall((:vkDestroySamplerYcbcrConversionKHR, libvulkan), Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
+end
+
+function vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSamplerYcbcrConversion, Ptr{VkAllocationCallbacks}), device, ycbcrConversion, pAllocator)
 end
 
 const VkBindBufferMemoryInfoKHR = VkBindBufferMemoryInfo
@@ -7110,8 +8094,16 @@ function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindBufferMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
+function vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindBufferMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
 function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos)
     ccall((:vkBindImageMemory2KHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindImageMemoryInfo}), device, bindInfoCount, pBindInfos)
 end
 
 const VkPhysicalDeviceMaintenance3PropertiesKHR = VkPhysicalDeviceMaintenance3Properties
@@ -7125,6 +8117,10 @@ function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport)
     ccall((:vkGetDescriptorSetLayoutSupportKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
 end
 
+function vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkDescriptorSetLayoutCreateInfo}, Ptr{VkDescriptorSetLayoutSupport}), device, pCreateInfo, pSupport)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountKHR ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
 const PFN_vkCmdDrawIndirectCountKHR = Ptr{Cvoid}
 
@@ -7135,8 +8131,16 @@ function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountKHR, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 const VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR = VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures
@@ -7201,12 +8205,24 @@ function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue)
     ccall((:vkGetSemaphoreCounterValueKHR, libvulkan), VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
 end
 
+function vkGetSemaphoreCounterValueKHR(device, semaphore, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSemaphore, Ptr{UInt64}), device, semaphore, pValue)
+end
+
 function vkWaitSemaphoresKHR(device, pWaitInfo, timeout)
     ccall((:vkWaitSemaphoresKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
 end
 
+function vkWaitSemaphoresKHR(device, pWaitInfo, timeout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreWaitInfo}, UInt64), device, pWaitInfo, timeout)
+end
+
 function vkSignalSemaphoreKHR(device, pSignalInfo)
     ccall((:vkSignalSemaphoreKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
+end
+
+function vkSignalSemaphoreKHR(device, pSignalInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreSignalInfo}), device, pSignalInfo)
 end
 
 const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR = VkPhysicalDeviceVulkanMemoryModelFeatures
@@ -7287,8 +8303,16 @@ function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentSha
     ccall((:vkGetPhysicalDeviceFragmentShadingRatesKHR, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
 end
 
+function vkGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceFragmentShadingRateKHR}), physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates)
+end
+
 function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps)
     ccall((:vkCmdSetFragmentShadingRateKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
+end
+
+function vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkExtent2D}, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, pFragmentSize, combinerOps)
 end
 
 struct VkSurfaceProtectedCapabilitiesKHR
@@ -7328,12 +8352,24 @@ function vkGetBufferDeviceAddressKHR(device, pInfo)
     ccall((:vkGetBufferDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetBufferOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo)
     ccall((:vkGetDeviceMemoryOpaqueCaptureAddressKHR, libvulkan), UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
+end
+
+function vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo, fptr)
+    ccall(fptr, UInt64, (VkDevice, Ptr{VkDeviceMemoryOpaqueCaptureAddressInfo}), device, pInfo)
 end
 
 const VkDeferredOperationKHR_T = Cvoid
@@ -7359,20 +8395,40 @@ function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation)
     ccall((:vkCreateDeferredOperationKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
 end
 
+function vkCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAllocationCallbacks}, Ptr{VkDeferredOperationKHR}), device, pAllocator, pDeferredOperation)
+end
+
 function vkDestroyDeferredOperationKHR(device, operation, pAllocator)
     ccall((:vkDestroyDeferredOperationKHR, libvulkan), Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
+end
+
+function vkDestroyDeferredOperationKHR(device, operation, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkDeferredOperationKHR, Ptr{VkAllocationCallbacks}), device, operation, pAllocator)
 end
 
 function vkGetDeferredOperationMaxConcurrencyKHR(device, operation)
     ccall((:vkGetDeferredOperationMaxConcurrencyKHR, libvulkan), UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationMaxConcurrencyKHR(device, operation, fptr)
+    ccall(fptr, UInt32, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkGetDeferredOperationResultKHR(device, operation)
     ccall((:vkGetDeferredOperationResultKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
+function vkGetDeferredOperationResultKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
 function vkDeferredOperationJoinKHR(device, operation)
     ccall((:vkDeferredOperationJoinKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
+end
+
+function vkDeferredOperationJoinKHR(device, operation, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR), device, operation)
 end
 
 @cenum VkPipelineExecutableStatisticFormatKHR::UInt32 begin
@@ -7466,12 +8522,24 @@ function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutable
     ccall((:vkGetPipelineExecutablePropertiesKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
 end
 
+function vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutableCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutablePropertiesKHR}), device, pPipelineInfo, pExecutableCount, pProperties)
+end
+
 function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics)
     ccall((:vkGetPipelineExecutableStatisticsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
 end
 
+function vkGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableStatisticKHR}), device, pExecutableInfo, pStatisticCount, pStatistics)
+end
+
 function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
     ccall((:vkGetPipelineExecutableInternalRepresentationsKHR, libvulkan), VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
+end
+
+function vkGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPipelineExecutableInfoKHR}, Ptr{UInt32}, Ptr{VkPipelineExecutableInternalRepresentationKHR}), device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations)
 end
 
 struct VkPipelineLibraryCreateInfoKHR
@@ -7623,32 +8691,64 @@ function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo)
     ccall((:vkCmdSetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
 end
 
+function vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, Ptr{VkDependencyInfoKHR}), commandBuffer, event, pDependencyInfo)
+end
+
 function vkCmdResetEvent2KHR(commandBuffer, event, stageMask)
     ccall((:vkCmdResetEvent2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
+end
+
+function vkCmdResetEvent2KHR(commandBuffer, event, stageMask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkEvent, VkPipelineStageFlags2KHR), commandBuffer, event, stageMask)
 end
 
 function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos)
     ccall((:vkCmdWaitEvents2KHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
 end
 
+function vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkEvent}, Ptr{VkDependencyInfoKHR}), commandBuffer, eventCount, pEvents, pDependencyInfos)
+end
+
 function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo)
     ccall((:vkCmdPipelineBarrier2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
+end
+
+function vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDependencyInfoKHR}), commandBuffer, pDependencyInfo)
 end
 
 function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query)
     ccall((:vkCmdWriteTimestamp2KHR, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
 end
 
+function vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkQueryPool, UInt32), commandBuffer, stage, queryPool, query)
+end
+
 function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence)
     ccall((:vkQueueSubmit2KHR, libvulkan), VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
+end
+
+function vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence, fptr)
+    ccall(fptr, VkResult, (VkQueue, UInt32, Ptr{VkSubmitInfo2KHR}, VkFence), queue, submitCount, pSubmits, fence)
 end
 
 function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarker2AMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
 end
 
+function vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlags2KHR, VkBuffer, VkDeviceSize, UInt32), commandBuffer, stage, dstBuffer, dstOffset, marker)
+end
+
 function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointData2NV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointData2NV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR
@@ -7799,24 +8899,48 @@ function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo)
     ccall((:vkCmdCopyBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
 end
 
+function vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferInfo2KHR}), commandBuffer, pCopyBufferInfo)
+end
+
 function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo)
     ccall((:vkCmdCopyImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
+end
+
+function vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageInfo2KHR}), commandBuffer, pCopyImageInfo)
 end
 
 function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo)
     ccall((:vkCmdCopyBufferToImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
 end
 
+function vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyBufferToImageInfo2KHR}), commandBuffer, pCopyBufferToImageInfo)
+end
+
 function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo)
     ccall((:vkCmdCopyImageToBuffer2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
+end
+
+function vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyImageToBufferInfo2KHR}), commandBuffer, pCopyImageToBufferInfo)
 end
 
 function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo)
     ccall((:vkCmdBlitImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
 end
 
+function vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkBlitImageInfo2KHR}), commandBuffer, pBlitImageInfo)
+end
+
 function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo)
     ccall((:vkCmdResolveImage2KHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
+end
+
+function vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkResolveImageInfo2KHR}), commandBuffer, pResolveImageInfo)
 end
 
 const VkDebugReportCallbackEXT_T = Cvoid
@@ -7902,12 +9026,24 @@ function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCall
     ccall((:vkCreateDebugReportCallbackEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
 end
 
+function vkCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugReportCallbackCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugReportCallbackEXT}), instance, pCreateInfo, pAllocator, pCallback)
+end
+
 function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator)
     ccall((:vkDestroyDebugReportCallbackEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
 end
 
+function vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportCallbackEXT, Ptr{VkAllocationCallbacks}), instance, callback, pAllocator)
+end
+
 function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
     ccall((:vkDebugReportMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
+end
+
+function vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, UInt64, Csize_t, Int32, Ptr{Cchar}, Ptr{Cchar}), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage)
 end
 
 @cenum VkRasterizationOrderAMD::UInt32 begin
@@ -7966,20 +9102,40 @@ function vkDebugMarkerSetObjectTagEXT(device, pTagInfo)
     ccall((:vkDebugMarkerSetObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
 end
 
+function vkDebugMarkerSetObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectTagInfoEXT}), device, pTagInfo)
+end
+
 function vkDebugMarkerSetObjectNameEXT(device, pNameInfo)
     ccall((:vkDebugMarkerSetObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
+end
+
+function vkDebugMarkerSetObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugMarkerObjectNameInfoEXT}), device, pNameInfo)
 end
 
 function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerBeginEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdDebugMarkerEndEXT(commandBuffer)
     ccall((:vkCmdDebugMarkerEndEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdDebugMarkerEndEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo)
     ccall((:vkCmdDebugMarkerInsertEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugMarkerMarkerInfoEXT}), commandBuffer, pMarkerInfo)
 end
 
 struct VkDedicatedAllocationImageCreateInfoNV
@@ -8054,24 +9210,48 @@ function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindi
     ccall((:vkCmdBindTransformFeedbackBuffersEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
 end
 
+function vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes)
+end
+
 function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdBeginTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
+function vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
 function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
     ccall((:vkCmdEndTransformFeedbackEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
 end
 
+function vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}), commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets)
+end
+
 function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index)
     ccall((:vkCmdBeginQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
+end
+
+function vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, VkQueryControlFlags, UInt32), commandBuffer, queryPool, query, flags, index)
 end
 
 function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index)
     ccall((:vkCmdEndQueryIndexedEXT, libvulkan), Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
 end
 
+function vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkQueryPool, UInt32, UInt32), commandBuffer, queryPool, query, index)
+end
+
 function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
     ccall((:vkCmdDrawIndirectByteCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
+end
+
+function vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride)
 end
 
 struct VkImageViewHandleInfoNVX
@@ -8099,8 +9279,16 @@ function vkGetImageViewHandleNVX(device, pInfo)
     ccall((:vkGetImageViewHandleNVX, libvulkan), UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
 end
 
+function vkGetImageViewHandleNVX(device, pInfo, fptr)
+    ccall(fptr, UInt32, (VkDevice, Ptr{VkImageViewHandleInfoNVX}), device, pInfo)
+end
+
 function vkGetImageViewAddressNVX(device, imageView, pProperties)
     ccall((:vkGetImageViewAddressNVX, libvulkan), VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
+end
+
+function vkGetImageViewAddressNVX(device, imageView, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImageView, Ptr{VkImageViewAddressPropertiesNVX}), device, imageView, pProperties)
 end
 
 # typedef void ( VKAPI_PTR * PFN_vkCmdDrawIndirectCountAMD ) ( VkCommandBuffer commandBuffer , VkBuffer buffer , VkDeviceSize offset , VkBuffer countBuffer , VkDeviceSize countBufferOffset , uint32_t maxDrawCount , uint32_t stride )
@@ -8113,8 +9301,16 @@ function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, c
     ccall((:vkCmdDrawIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
+function vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
 function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawIndexedIndirectCountAMD, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkTextureLODGatherFormatPropertiesAMD
@@ -8155,6 +9351,10 @@ function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, 
     ccall((:vkGetShaderInfoAMD, libvulkan), VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
 end
 
+function vkGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, Ptr{Csize_t}, Ptr{Cvoid}), device, pipeline, shaderStage, infoType, pInfoSize, pInfo)
+end
+
 struct VkPhysicalDeviceCornerSampledImageFeaturesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -8192,6 +9392,10 @@ const PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
     ccall((:vkGetPhysicalDeviceExternalImageFormatPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
+end
+
+function vkGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkFormat, VkImageType, VkImageTiling, VkImageUsageFlags, VkImageCreateFlags, VkExternalMemoryHandleTypeFlagsNV, Ptr{VkExternalImageFormatPropertiesNV}), physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties)
 end
 
 struct VkExternalMemoryImageCreateInfoNV
@@ -8275,8 +9479,16 @@ function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingB
     ccall((:vkCmdBeginConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
 end
 
+function vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkConditionalRenderingBeginInfoEXT}), commandBuffer, pConditionalRenderingBegin)
+end
+
 function vkCmdEndConditionalRenderingEXT(commandBuffer)
     ccall((:vkCmdEndConditionalRenderingEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
+function vkCmdEndConditionalRenderingEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
 struct VkViewportWScalingNV
@@ -8299,11 +9511,19 @@ function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount,
     ccall((:vkCmdSetViewportWScalingNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
 end
 
+function vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkViewportWScalingNV}), commandBuffer, firstViewport, viewportCount, pViewportWScalings)
+end
+
 # typedef VkResult ( VKAPI_PTR * PFN_vkReleaseDisplayEXT ) ( VkPhysicalDevice physicalDevice , VkDisplayKHR display )
 const PFN_vkReleaseDisplayEXT = Ptr{Cvoid}
 
 function vkReleaseDisplayEXT(physicalDevice, display)
     ccall((:vkReleaseDisplayEXT, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
+function vkReleaseDisplayEXT(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
 @cenum VkSurfaceCounterFlagBitsEXT::UInt32 begin
@@ -8335,6 +9555,10 @@ const PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities)
     ccall((:vkGetPhysicalDeviceSurfaceCapabilities2EXT, libvulkan), VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
+end
+
+function vkGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkSurfaceKHR, Ptr{VkSurfaceCapabilities2EXT}), physicalDevice, surface, pSurfaceCapabilities)
 end
 
 @cenum VkDisplayPowerStateEXT::UInt32 begin
@@ -8394,16 +9618,32 @@ function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo)
     ccall((:vkDisplayPowerControlEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
 end
 
+function vkDisplayPowerControlEXT(device, display, pDisplayPowerInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayPowerInfoEXT}), device, display, pDisplayPowerInfo)
+end
+
 function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDeviceEventEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
+end
+
+function vkRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDeviceEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, pDeviceEventInfo, pAllocator, pFence)
 end
 
 function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence)
     ccall((:vkRegisterDisplayEventEXT, libvulkan), VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
 end
 
+function vkRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDisplayKHR, Ptr{VkDisplayEventInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkFence}), device, display, pDisplayEventInfo, pAllocator, pFence)
+end
+
 function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue)
     ccall((:vkGetSwapchainCounterEXT, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
+end
+
+function vkGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, VkSurfaceCounterFlagBitsEXT, Ptr{UInt64}), device, swapchain, counter, pCounterValue)
 end
 
 struct VkRefreshCycleDurationGOOGLE
@@ -8440,8 +9680,16 @@ function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProper
     ccall((:vkGetRefreshCycleDurationGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
 end
 
+function vkGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{VkRefreshCycleDurationGOOGLE}), device, swapchain, pDisplayTimingProperties)
+end
+
 function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings)
     ccall((:vkGetPastPresentationTimingGOOGLE, libvulkan), VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
+end
+
+function vkGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR, Ptr{UInt32}, Ptr{VkPastPresentationTimingGOOGLE}), device, swapchain, pPresentationTimingCount, pPresentationTimings)
 end
 
 struct VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX
@@ -8507,6 +9755,10 @@ const PFN_vkCmdSetDiscardRectangleEXT = Ptr{Cvoid}
 
 function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
     ccall((:vkCmdSetDiscardRectangleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
+end
+
+function vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles)
 end
 
 @cenum VkConservativeRasterizationModeEXT::UInt32 begin
@@ -8578,6 +9830,10 @@ const PFN_vkSetHdrMetadataEXT = Ptr{Cvoid}
 
 function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata)
     ccall((:vkSetHdrMetadataEXT, libvulkan), Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
+end
+
+function vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata, fptr)
+    ccall(fptr, Cvoid, (VkDevice, UInt32, Ptr{VkSwapchainKHR}, Ptr{VkHdrMetadataEXT}), device, swapchainCount, pSwapchains, pMetadata)
 end
 
 const VkDebugUtilsMessengerEXT_T = Cvoid
@@ -8697,44 +9953,88 @@ function vkSetDebugUtilsObjectNameEXT(device, pNameInfo)
     ccall((:vkSetDebugUtilsObjectNameEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
 end
 
+function vkSetDebugUtilsObjectNameEXT(device, pNameInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectNameInfoEXT}), device, pNameInfo)
+end
+
 function vkSetDebugUtilsObjectTagEXT(device, pTagInfo)
     ccall((:vkSetDebugUtilsObjectTagEXT, libvulkan), VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
+end
+
+function vkSetDebugUtilsObjectTagEXT(device, pTagInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkDebugUtilsObjectTagInfoEXT}), device, pTagInfo)
 end
 
 function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkQueueEndDebugUtilsLabelEXT(queue)
     ccall((:vkQueueEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue,), queue)
+end
+
+function vkQueueEndDebugUtilsLabelEXT(queue, fptr)
+    ccall(fptr, Cvoid, (VkQueue,), queue)
 end
 
 function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo)
     ccall((:vkQueueInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
 end
 
+function vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{VkDebugUtilsLabelEXT}), queue, pLabelInfo)
+end
+
 function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdBeginDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCmdEndDebugUtilsLabelEXT(commandBuffer)
     ccall((:vkCmdEndDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer,), commandBuffer)
 end
 
+function vkCmdEndDebugUtilsLabelEXT(commandBuffer, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer,), commandBuffer)
+end
+
 function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo)
     ccall((:vkCmdInsertDebugUtilsLabelEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
+end
+
+function vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkDebugUtilsLabelEXT}), commandBuffer, pLabelInfo)
 end
 
 function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger)
     ccall((:vkCreateDebugUtilsMessengerEXT, libvulkan), VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
 end
 
+function vkCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkDebugUtilsMessengerCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkDebugUtilsMessengerEXT}), instance, pCreateInfo, pAllocator, pMessenger)
+end
+
 function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator)
     ccall((:vkDestroyDebugUtilsMessengerEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
 end
 
+function vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessengerEXT, Ptr{VkAllocationCallbacks}), instance, messenger, pAllocator)
+end
+
 function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData)
     ccall((:vkSubmitDebugUtilsMessageEXT, libvulkan), Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
+end
+
+function vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData, fptr)
+    ccall(fptr, Cvoid, (VkInstance, VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT, Ptr{VkDebugUtilsMessengerCallbackDataEXT}), instance, messageSeverity, messageTypes, pCallbackData)
 end
 
 const VkSamplerReductionModeEXT = VkSamplerReductionMode
@@ -8839,8 +10139,16 @@ function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo)
     ccall((:vkCmdSetSampleLocationsEXT, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
 end
 
+function vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkSampleLocationsInfoEXT}), commandBuffer, pSampleLocationsInfo)
+end
+
 function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties)
     ccall((:vkGetPhysicalDeviceMultisamplePropertiesEXT, libvulkan), Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
+end
+
+function vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties, fptr)
+    ccall(fptr, Cvoid, (VkPhysicalDevice, VkSampleCountFlagBits, Ptr{VkMultisamplePropertiesEXT}), physicalDevice, samples, pMultisampleProperties)
 end
 
 @cenum VkBlendOverlapEXT::UInt32 begin
@@ -8968,6 +10276,10 @@ function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties)
     ccall((:vkGetImageDrmFormatModifierPropertiesEXT, libvulkan), VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
 end
 
+function vkGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkImage, Ptr{VkImageDrmFormatModifierPropertiesEXT}), device, image, pProperties)
+end
+
 const VkValidationCacheEXT_T = Cvoid
 
 const VkValidationCacheEXT = Ptr{VkValidationCacheEXT_T}
@@ -9009,16 +10321,32 @@ function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidation
     ccall((:vkCreateValidationCacheEXT, libvulkan), VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
 end
 
+function vkCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkValidationCacheCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkValidationCacheEXT}), device, pCreateInfo, pAllocator, pValidationCache)
+end
+
 function vkDestroyValidationCacheEXT(device, validationCache, pAllocator)
     ccall((:vkDestroyValidationCacheEXT, libvulkan), Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
+end
+
+function vkDestroyValidationCacheEXT(device, validationCache, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkValidationCacheEXT, Ptr{VkAllocationCallbacks}), device, validationCache, pAllocator)
 end
 
 function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches)
     ccall((:vkMergeValidationCachesEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
 end
 
+function vkMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, UInt32, Ptr{VkValidationCacheEXT}), device, dstCache, srcCacheCount, pSrcCaches)
+end
+
 function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData)
     ccall((:vkGetValidationCacheDataEXT, libvulkan), VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
+end
+
+function vkGetValidationCacheDataEXT(device, validationCache, pDataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkValidationCacheEXT, Ptr{Csize_t}, Ptr{Cvoid}), device, validationCache, pDataSize, pData)
 end
 
 const VkDescriptorBindingFlagBitsEXT = VkDescriptorBindingFlagBits
@@ -9121,12 +10449,24 @@ function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout)
     ccall((:vkCmdBindShadingRateImageNV, libvulkan), Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
 end
 
+function vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkImageView, VkImageLayout), commandBuffer, imageView, imageLayout)
+end
+
 function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
     ccall((:vkCmdSetViewportShadingRatePaletteNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
 end
 
+function vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkShadingRatePaletteNV}), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes)
+end
+
 function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
     ccall((:vkCmdSetCoarseSampleOrderNV, libvulkan), Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
+end
+
+function vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCoarseSampleOrderTypeNV, UInt32, Ptr{VkCoarseSampleOrderCustomNV}), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders)
 end
 
 const VkAccelerationStructureNV_T = Cvoid
@@ -9453,52 +10793,104 @@ function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccel
     ccall((:vkCreateAccelerationStructureNV, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureNV}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureNV, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureNV, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements)
     ccall((:vkGetAccelerationStructureMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2KHR}), device, pInfo, pMemoryRequirements)
+end
+
 function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos)
     ccall((:vkBindAccelerationStructureMemoryNV, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
+end
+
+function vkBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkBindAccelerationStructureMemoryInfoNV}), device, bindInfoCount, pBindInfos)
 end
 
 function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
     ccall((:vkCmdBuildAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
 end
 
+function vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkAccelerationStructureInfoNV}, VkBuffer, VkDeviceSize, VkBool32, VkAccelerationStructureNV, VkAccelerationStructureNV, VkBuffer, VkDeviceSize), commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset)
+end
+
 function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode)
     ccall((:vkCmdCopyAccelerationStructureNV, libvulkan), Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
+end
+
+function vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkAccelerationStructureNV, VkAccelerationStructureNV, VkCopyAccelerationStructureModeKHR), commandBuffer, dst, src, mode)
 end
 
 function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
     ccall((:vkCmdTraceRaysNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
 end
 
+function vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, VkBuffer, VkDeviceSize, VkDeviceSize, UInt32, UInt32, UInt32), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesNV, libvulkan), VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingShaderGroupHandlesNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
+function vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
 function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData)
     ccall((:vkGetAccelerationStructureHandleNV, libvulkan), VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
 end
 
+function vkGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkAccelerationStructureNV, Csize_t, Ptr{Cvoid}), device, accelerationStructure, dataSize, pData)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
+function vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureNV}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
 function vkCompileDeferredNV(device, pipeline, shader)
     ccall((:vkCompileDeferredNV, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
+end
+
+function vkCompileDeferredNV(device, pipeline, shader, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32), device, pipeline, shader)
 end
 
 struct VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV
@@ -9566,11 +10958,19 @@ function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, p
     ccall((:vkGetMemoryHostPointerPropertiesEXT, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
 end
 
+function vkGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, pMemoryHostPointerProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, Ptr{Cvoid}, Ptr{VkMemoryHostPointerPropertiesEXT}), device, handleType, pHostPointer, pMemoryHostPointerProperties)
+end
+
 # typedef void ( VKAPI_PTR * PFN_vkCmdWriteBufferMarkerAMD ) ( VkCommandBuffer commandBuffer , VkPipelineStageFlagBits pipelineStage , VkBuffer dstBuffer , VkDeviceSize dstOffset , uint32_t marker )
 const PFN_vkCmdWriteBufferMarkerAMD = Ptr{Cvoid}
 
 function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
     ccall((:vkCmdWriteBufferMarkerAMD, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
+end
+
+function vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineStageFlagBits, VkBuffer, VkDeviceSize, UInt32), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker)
 end
 
 @cenum VkPipelineCompilerControlFlagBitsAMD::UInt32 begin
@@ -9609,8 +11009,16 @@ function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDom
     ccall((:vkGetPhysicalDeviceCalibrateableTimeDomainsEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
 end
 
+function vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDomainCount, pTimeDomains, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkTimeDomainEXT}), physicalDevice, pTimeDomainCount, pTimeDomains)
+end
+
 function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
     ccall((:vkGetCalibratedTimestampsEXT, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
+end
+
+function vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkCalibratedTimestampInfoEXT}, Ptr{UInt64}, Ptr{UInt64}), device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation)
 end
 
 struct VkPhysicalDeviceShaderCorePropertiesAMD
@@ -9742,12 +11150,24 @@ function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask)
     ccall((:vkCmdDrawMeshTasksNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
 end
 
+function vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32), commandBuffer, taskCount, firstTask)
+end
+
 function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
 end
 
+function vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, drawCount, stride)
+end
+
 function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
     ccall((:vkCmdDrawMeshTasksIndirectCountNV, libvulkan), Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
+end
+
+function vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, UInt32, UInt32), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride)
 end
 
 struct VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV
@@ -9782,6 +11202,10 @@ function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclus
     ccall((:vkCmdSetExclusiveScissorNV, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
 end
 
+function vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkRect2D}), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors)
+end
+
 struct VkQueueFamilyCheckpointPropertiesNV
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -9805,8 +11229,16 @@ function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker)
     ccall((:vkCmdSetCheckpointNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
 end
 
+function vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{Cvoid}), commandBuffer, pCheckpointMarker)
+end
+
 function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData)
     ccall((:vkGetQueueCheckpointDataNV, libvulkan), Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
+end
+
+function vkGetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData, fptr)
+    ccall(fptr, Cvoid, (VkQueue, Ptr{UInt32}, Ptr{VkCheckpointDataNV}), queue, pCheckpointDataCount, pCheckpointData)
 end
 
 struct VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL
@@ -9950,36 +11382,72 @@ function vkInitializePerformanceApiINTEL(device, pInitializeInfo)
     ccall((:vkInitializePerformanceApiINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
 end
 
+function vkInitializePerformanceApiINTEL(device, pInitializeInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkInitializePerformanceApiInfoINTEL}), device, pInitializeInfo)
+end
+
 function vkUninitializePerformanceApiINTEL(device)
     ccall((:vkUninitializePerformanceApiINTEL, libvulkan), Cvoid, (VkDevice,), device)
+end
+
+function vkUninitializePerformanceApiINTEL(device, fptr)
+    ccall(fptr, Cvoid, (VkDevice,), device)
 end
 
 function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
+function vkCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
 function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo)
     ccall((:vkCmdSetPerformanceStreamMarkerINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
+end
+
+function vkCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceStreamMarkerInfoINTEL}), commandBuffer, pMarkerInfo)
 end
 
 function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo)
     ccall((:vkCmdSetPerformanceOverrideINTEL, libvulkan), VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
 end
 
+function vkCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo, fptr)
+    ccall(fptr, VkResult, (VkCommandBuffer, Ptr{VkPerformanceOverrideInfoINTEL}), commandBuffer, pOverrideInfo)
+end
+
 function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration)
     ccall((:vkAcquirePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
+end
+
+function vkAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPerformanceConfigurationAcquireInfoINTEL}, Ptr{VkPerformanceConfigurationINTEL}), device, pAcquireInfo, pConfiguration)
 end
 
 function vkReleasePerformanceConfigurationINTEL(device, configuration)
     ccall((:vkReleasePerformanceConfigurationINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
 end
 
+function vkReleasePerformanceConfigurationINTEL(device, configuration, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceConfigurationINTEL), device, configuration)
+end
+
 function vkQueueSetPerformanceConfigurationINTEL(queue, configuration)
     ccall((:vkQueueSetPerformanceConfigurationINTEL, libvulkan), VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
 end
 
+function vkQueueSetPerformanceConfigurationINTEL(queue, configuration, fptr)
+    ccall(fptr, VkResult, (VkQueue, VkPerformanceConfigurationINTEL), queue, configuration)
+end
+
 function vkGetPerformanceParameterINTEL(device, parameter, pValue)
     ccall((:vkGetPerformanceParameterINTEL, libvulkan), VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
+end
+
+function vkGetPerformanceParameterINTEL(device, parameter, pValue, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPerformanceParameterTypeINTEL, Ptr{VkPerformanceValueINTEL}), device, parameter, pValue)
 end
 
 struct VkPhysicalDevicePCIBusInfoPropertiesEXT
@@ -10008,6 +11476,10 @@ const PFN_vkSetLocalDimmingAMD = Ptr{Cvoid}
 
 function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable)
     ccall((:vkSetLocalDimmingAMD, libvulkan), Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
+end
+
+function vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkSwapchainKHR, VkBool32), device, swapChain, localDimmingEnable)
 end
 
 struct VkPhysicalDeviceFragmentDensityMapFeaturesEXT
@@ -10132,6 +11604,10 @@ function vkGetBufferDeviceAddressEXT(device, pInfo)
     ccall((:vkGetBufferDeviceAddressEXT, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
 end
 
+function vkGetBufferDeviceAddressEXT(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkBufferDeviceAddressInfo}), device, pInfo)
+end
+
 @cenum VkToolPurposeFlagBitsEXT::UInt32 begin
     VK_TOOL_PURPOSE_VALIDATION_BIT_EXT = 1
     VK_TOOL_PURPOSE_PROFILING_BIT_EXT = 2
@@ -10160,6 +11636,10 @@ const PFN_vkGetPhysicalDeviceToolPropertiesEXT = Ptr{Cvoid}
 
 function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties)
     ccall((:vkGetPhysicalDeviceToolPropertiesEXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
+end
+
+function vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkPhysicalDeviceToolPropertiesEXT}), physicalDevice, pToolCount, pToolProperties)
 end
 
 const VkImageStencilUsageCreateInfoEXT = VkImageStencilUsageCreateInfo
@@ -10249,6 +11729,10 @@ function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPrope
     ccall((:vkGetPhysicalDeviceCooperativeMatrixPropertiesNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
 end
 
+function vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPropertyCount, pProperties, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkCooperativeMatrixPropertiesNV}), physicalDevice, pPropertyCount, pProperties)
+end
+
 @cenum VkCoverageReductionModeNV::UInt32 begin
     VK_COVERAGE_REDUCTION_MODE_MERGE_NV = 0
     VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV = 1
@@ -10284,6 +11768,10 @@ const PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV = Pt
 
 function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations)
     ccall((:vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, libvulkan), VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
+end
+
+function vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{UInt32}, Ptr{VkFramebufferMixedSamplesCombinationNV}), physicalDevice, pCombinationCount, pCombinations)
 end
 
 struct VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT
@@ -10341,6 +11829,10 @@ function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateHeadlessSurfaceEXT, libvulkan), VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkHeadlessSurfaceCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 @cenum VkLineRasterizationModeEXT::UInt32 begin
     VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT = 0
     VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT = 1
@@ -10382,6 +11874,10 @@ function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePat
     ccall((:vkCmdSetLineStippleEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
 end
 
+function vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt16), commandBuffer, lineStippleFactor, lineStipplePattern)
+end
+
 struct VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -10406,6 +11902,10 @@ const PFN_vkResetQueryPoolEXT = Ptr{Cvoid}
 
 function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount)
     ccall((:vkResetQueryPoolEXT, libvulkan), Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
+end
+
+function vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkQueryPool, UInt32, UInt32), device, queryPool, firstQuery, queryCount)
 end
 
 struct VkPhysicalDeviceIndexTypeUint8FeaturesEXT
@@ -10460,48 +11960,96 @@ function vkCmdSetCullModeEXT(commandBuffer, cullMode)
     ccall((:vkCmdSetCullModeEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
 end
 
+function vkCmdSetCullModeEXT(commandBuffer, cullMode, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCullModeFlags), commandBuffer, cullMode)
+end
+
 function vkCmdSetFrontFaceEXT(commandBuffer, frontFace)
     ccall((:vkCmdSetFrontFaceEXT, libvulkan), Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
+end
+
+function vkCmdSetFrontFaceEXT(commandBuffer, frontFace, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFrontFace), commandBuffer, frontFace)
 end
 
 function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology)
     ccall((:vkCmdSetPrimitiveTopologyEXT, libvulkan), Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
 end
 
+function vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPrimitiveTopology), commandBuffer, primitiveTopology)
+end
+
 function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports)
     ccall((:vkCmdSetViewportWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
+end
+
+function vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkViewport}), commandBuffer, viewportCount, pViewports)
 end
 
 function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors)
     ccall((:vkCmdSetScissorWithCountEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
 end
 
+function vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkRect2D}), commandBuffer, scissorCount, pScissors)
+end
+
 function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
     ccall((:vkCmdBindVertexBuffers2EXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
+end
+
+function vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, UInt32, Ptr{VkBuffer}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}, Ptr{VkDeviceSize}), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides)
 end
 
 function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable)
     ccall((:vkCmdSetDepthTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
 end
 
+function vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthTestEnable)
+end
+
 function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable)
     ccall((:vkCmdSetDepthWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
+end
+
+function vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthWriteEnable)
 end
 
 function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp)
     ccall((:vkCmdSetDepthCompareOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
 end
 
+function vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkCompareOp), commandBuffer, depthCompareOp)
+end
+
 function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable)
     ccall((:vkCmdSetDepthBoundsTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
+end
+
+function vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBoundsTestEnable)
 end
 
 function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable)
     ccall((:vkCmdSetStencilTestEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
 end
 
+function vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, stencilTestEnable)
+end
+
 function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
     ccall((:vkCmdSetStencilOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
+end
+
+function vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp), commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp)
 end
 
 struct VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT
@@ -10683,24 +12231,48 @@ function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequir
     ccall((:vkGetGeneratedCommandsMemoryRequirementsNV, libvulkan), Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
 end
 
+function vkGetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequirements, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkGeneratedCommandsMemoryRequirementsInfoNV}, Ptr{VkMemoryRequirements2}), device, pInfo, pMemoryRequirements)
+end
+
 function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo)
     ccall((:vkCmdPreprocessGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
+end
+
+function vkCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, pGeneratedCommandsInfo)
 end
 
 function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
     ccall((:vkCmdExecuteGeneratedCommandsNV, libvulkan), Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
 end
 
+function vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32, Ptr{VkGeneratedCommandsInfoNV}), commandBuffer, isPreprocessed, pGeneratedCommandsInfo)
+end
+
 function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex)
     ccall((:vkCmdBindPipelineShaderGroupNV, libvulkan), Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
+end
+
+function vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkPipelineBindPoint, VkPipeline, UInt32), commandBuffer, pipelineBindPoint, pipeline, groupIndex)
 end
 
 function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
     ccall((:vkCreateIndirectCommandsLayoutNV, libvulkan), VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
 end
 
+function vkCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkIndirectCommandsLayoutCreateInfoNV}, Ptr{VkAllocationCallbacks}, Ptr{VkIndirectCommandsLayoutNV}), device, pCreateInfo, pAllocator, pIndirectCommandsLayout)
+end
+
 function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator)
     ccall((:vkDestroyIndirectCommandsLayoutNV, libvulkan), Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
+end
+
+function vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkIndirectCommandsLayoutNV, Ptr{VkAllocationCallbacks}), device, indirectCommandsLayout, pAllocator)
 end
 
 struct VkPhysicalDeviceInheritedViewportScissorFeaturesNV
@@ -10864,16 +12436,32 @@ function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDat
     ccall((:vkCreatePrivateDataSlotEXT, libvulkan), VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
 end
 
+function vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDataSlot, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPrivateDataSlotCreateInfoEXT}, Ptr{VkAllocationCallbacks}, Ptr{VkPrivateDataSlotEXT}), device, pCreateInfo, pAllocator, pPrivateDataSlot)
+end
+
 function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator)
     ccall((:vkDestroyPrivateDataSlotEXT, libvulkan), Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
+end
+
+function vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkPrivateDataSlotEXT, Ptr{VkAllocationCallbacks}), device, privateDataSlot, pAllocator)
 end
 
 function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data)
     ccall((:vkSetPrivateDataEXT, libvulkan), VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
 end
 
+function vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, UInt64), device, objectType, objectHandle, privateDataSlot, data)
+end
+
 function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData)
     ccall((:vkGetPrivateDataEXT, libvulkan), Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
+end
+
+function vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkObjectType, UInt64, VkPrivateDataSlotEXT, Ptr{UInt64}), device, objectType, objectHandle, privateDataSlot, pData)
 end
 
 struct VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT
@@ -10954,6 +12542,10 @@ function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerO
     ccall((:vkCmdSetFragmentShadingRateEnumNV, libvulkan), Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
 end
 
+function vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkFragmentShadingRateNV, Ptr{VkFragmentShadingRateCombinerOpKHR}), commandBuffer, shadingRate, combinerOps)
+end
+
 struct VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -11004,8 +12596,16 @@ function vkAcquireWinrtDisplayNV(physicalDevice, display)
     ccall((:vkAcquireWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
 end
 
+function vkAcquireWinrtDisplayNV(physicalDevice, display, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, VkDisplayKHR), physicalDevice, display)
+end
+
 function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay)
     ccall((:vkGetWinrtDisplayNV, libvulkan), VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
+end
+
+function vkGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, UInt32, Ptr{VkDisplayKHR}), physicalDevice, deviceRelativeId, pDisplay)
 end
 
 struct VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE
@@ -11057,6 +12657,10 @@ function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pV
     ccall((:vkCmdSetVertexInputEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
 end
 
+function vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkVertexInputBindingDescription2EXT}, UInt32, Ptr{VkVertexInputAttributeDescription2EXT}), commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions)
+end
+
 struct VkPhysicalDeviceExtendedDynamicState2FeaturesEXT
     sType::VkStructureType
     pNext::Ptr{Cvoid}
@@ -11084,20 +12688,40 @@ function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints)
     ccall((:vkCmdSetPatchControlPointsEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
 end
 
+function vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, patchControlPoints)
+end
+
 function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable)
     ccall((:vkCmdSetRasterizerDiscardEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
+end
+
+function vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, rasterizerDiscardEnable)
 end
 
 function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable)
     ccall((:vkCmdSetDepthBiasEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
 end
 
+function vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, depthBiasEnable)
+end
+
 function vkCmdSetLogicOpEXT(commandBuffer, logicOp)
     ccall((:vkCmdSetLogicOpEXT, libvulkan), Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
 end
 
+function vkCmdSetLogicOpEXT(commandBuffer, logicOp, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkLogicOp), commandBuffer, logicOp)
+end
+
 function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable)
     ccall((:vkCmdSetPrimitiveRestartEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
+end
+
+function vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, VkBool32), commandBuffer, primitiveRestartEnable)
 end
 
 struct VkPhysicalDeviceColorWriteEnableFeaturesEXT
@@ -11118,6 +12742,10 @@ const PFN_vkCmdSetColorWriteEnableEXT = Ptr{Cvoid}
 
 function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables)
     ccall((:vkCmdSetColorWriteEnableEXT, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
+end
+
+function vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkBool32}), commandBuffer, attachmentCount, pColorWriteEnables)
 end
 
 const VkAccelerationStructureKHR_T = Cvoid
@@ -11406,64 +13034,128 @@ function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAcce
     ccall((:vkCreateAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
 end
 
+function vkCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAccelerationStructure, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkAccelerationStructureCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkAccelerationStructureKHR}), device, pCreateInfo, pAllocator, pAccelerationStructure)
+end
+
 function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator)
     ccall((:vkDestroyAccelerationStructureKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
+end
+
+function vkDestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureKHR, Ptr{VkAllocationCallbacks}), device, accelerationStructure, pAllocator)
 end
 
 function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkCmdBuildAccelerationStructuresKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), commandBuffer, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
     ccall((:vkCmdBuildAccelerationStructuresIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
+end
+
+function vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{VkDeviceAddress}, Ptr{UInt32}, Ptr{Ptr{UInt32}}), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts)
 end
 
 function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
     ccall((:vkBuildAccelerationStructuresKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
 end
 
+function vkBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, UInt32, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{Ptr{VkAccelerationStructureBuildRangeInfoKHR}}), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos)
+end
+
 function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyAccelerationStructureToMemoryKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
 end
 
+function vkCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), device, deferredOperation, pInfo)
+end
+
 function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo)
     ccall((:vkCopyMemoryToAccelerationStructureKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
+end
+
+function vkCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), device, deferredOperation, pInfo)
 end
 
 function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
     ccall((:vkWriteAccelerationStructuresPropertiesKHR, libvulkan), VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
 end
 
+function vkWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride, fptr)
+    ccall(fptr, VkResult, (VkDevice, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, Csize_t, Ptr{Cvoid}, Csize_t), device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride)
+end
+
 function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyAccelerationStructureToMemoryKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
 end
 
+function vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyAccelerationStructureToMemoryInfoKHR}), commandBuffer, pInfo)
+end
+
 function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo)
     ccall((:vkCmdCopyMemoryToAccelerationStructureKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
+end
+
+function vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkCopyMemoryToAccelerationStructureInfoKHR}), commandBuffer, pInfo)
 end
 
 function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo)
     ccall((:vkGetAccelerationStructureDeviceAddressKHR, libvulkan), VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
 end
 
+function vkGetAccelerationStructureDeviceAddressKHR(device, pInfo, fptr)
+    ccall(fptr, VkDeviceAddress, (VkDevice, Ptr{VkAccelerationStructureDeviceAddressInfoKHR}), device, pInfo)
+end
+
 function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
     ccall((:vkCmdWriteAccelerationStructuresPropertiesKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
+end
+
+function vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32, Ptr{VkAccelerationStructureKHR}, VkQueryType, VkQueryPool, UInt32), commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery)
 end
 
 function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility)
     ccall((:vkGetDeviceAccelerationStructureCompatibilityKHR, libvulkan), Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
 end
 
+function vkGetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility, fptr)
+    ccall(fptr, Cvoid, (VkDevice, Ptr{VkAccelerationStructureVersionInfoKHR}, Ptr{VkAccelerationStructureCompatibilityKHR}), device, pVersionInfo, pCompatibility)
+end
+
 function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
     ccall((:vkGetAccelerationStructureBuildSizesKHR, libvulkan), Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
+end
+
+function vkGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo, fptr)
+    ccall(fptr, Cvoid, (VkDevice, VkAccelerationStructureBuildTypeKHR, Ptr{VkAccelerationStructureBuildGeometryInfoKHR}, Ptr{UInt32}, Ptr{VkAccelerationStructureBuildSizesInfoKHR}), device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo)
 end
 
 @cenum VkShaderGroupShaderKHR::UInt32 begin
@@ -11566,24 +13258,48 @@ function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShader
     ccall((:vkCmdTraceRaysKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
 end
 
+function vkCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, UInt32, UInt32, UInt32), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth)
+end
+
 function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
     ccall((:vkCreateRayTracingPipelinesKHR, libvulkan), VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
+end
+
+function vkCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeferredOperationKHR, VkPipelineCache, UInt32, Ptr{VkRayTracingPipelineCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkPipeline}), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines)
 end
 
 function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData)
     ccall((:vkGetRayTracingCaptureReplayShaderGroupHandlesKHR, libvulkan), VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
 end
 
+function vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkPipeline, UInt32, UInt32, Csize_t, Ptr{Cvoid}), device, pipeline, firstGroup, groupCount, dataSize, pData)
+end
+
 function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
     ccall((:vkCmdTraceRaysIndirectKHR, libvulkan), Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
+end
+
+function vkCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, Ptr{VkStridedDeviceAddressRegionKHR}, VkDeviceAddress), commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress)
 end
 
 function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader)
     ccall((:vkGetRayTracingShaderGroupStackSizeKHR, libvulkan), VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
 end
 
+function vkGetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader, fptr)
+    ccall(fptr, VkDeviceSize, (VkDevice, VkPipeline, UInt32, VkShaderGroupShaderKHR), device, pipeline, group, groupShader)
+end
+
 function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize)
     ccall((:vkCmdSetRayTracingPipelineStackSizeKHR, libvulkan), Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
+end
+
+function vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize, fptr)
+    ccall(fptr, Cvoid, (VkCommandBuffer, UInt32), commandBuffer, pipelineStackSize)
 end
 
 struct VkPhysicalDeviceRayQueryFeaturesKHR
@@ -11612,8 +13328,16 @@ function vkCreateWin32SurfaceKHR(instance, pCreateInfo, pAllocator, pSurface)
     ccall((:vkCreateWin32SurfaceKHR, libvulkan), VkResult, (VkInstance, Ptr{VkWin32SurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
 end
 
+function vkCreateWin32SurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, fptr)
+    ccall(fptr, VkResult, (VkInstance, Ptr{VkWin32SurfaceCreateInfoKHR}, Ptr{VkAllocationCallbacks}, Ptr{VkSurfaceKHR}), instance, pCreateInfo, pAllocator, pSurface)
+end
+
 function vkGetPhysicalDeviceWin32PresentationSupportKHR(physicalDevice, queueFamilyIndex)
     ccall((:vkGetPhysicalDeviceWin32PresentationSupportKHR, libvulkan), VkBool32, (VkPhysicalDevice, UInt32), physicalDevice, queueFamilyIndex)
+end
+
+function vkGetPhysicalDeviceWin32PresentationSupportKHR(physicalDevice, queueFamilyIndex, fptr)
+    ccall(fptr, VkBool32, (VkPhysicalDevice, UInt32), physicalDevice, queueFamilyIndex)
 end
 
 struct VkImportMemoryWin32HandleInfoKHR
@@ -11655,8 +13379,16 @@ function vkGetMemoryWin32HandleKHR(device, pGetWin32HandleInfo, pHandle)
     ccall((:vkGetMemoryWin32HandleKHR, libvulkan), VkResult, (VkDevice, Ptr{VkMemoryGetWin32HandleInfoKHR}, Ptr{HANDLE}), device, pGetWin32HandleInfo, pHandle)
 end
 
+function vkGetMemoryWin32HandleKHR(device, pGetWin32HandleInfo, pHandle, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkMemoryGetWin32HandleInfoKHR}, Ptr{HANDLE}), device, pGetWin32HandleInfo, pHandle)
+end
+
 function vkGetMemoryWin32HandlePropertiesKHR(device, handleType, handle, pMemoryWin32HandleProperties)
     ccall((:vkGetMemoryWin32HandlePropertiesKHR, libvulkan), VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, HANDLE, Ptr{VkMemoryWin32HandlePropertiesKHR}), device, handleType, handle, pMemoryWin32HandleProperties)
+end
+
+function vkGetMemoryWin32HandlePropertiesKHR(device, handleType, handle, pMemoryWin32HandleProperties, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkExternalMemoryHandleTypeFlagBits, HANDLE, Ptr{VkMemoryWin32HandlePropertiesKHR}), device, handleType, handle, pMemoryWin32HandleProperties)
 end
 
 struct VkWin32KeyedMutexAcquireReleaseInfoKHR
@@ -11715,8 +13447,16 @@ function vkImportSemaphoreWin32HandleKHR(device, pImportSemaphoreWin32HandleInfo
     ccall((:vkImportSemaphoreWin32HandleKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportSemaphoreWin32HandleInfoKHR}), device, pImportSemaphoreWin32HandleInfo)
 end
 
+function vkImportSemaphoreWin32HandleKHR(device, pImportSemaphoreWin32HandleInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportSemaphoreWin32HandleInfoKHR}), device, pImportSemaphoreWin32HandleInfo)
+end
+
 function vkGetSemaphoreWin32HandleKHR(device, pGetWin32HandleInfo, pHandle)
     ccall((:vkGetSemaphoreWin32HandleKHR, libvulkan), VkResult, (VkDevice, Ptr{VkSemaphoreGetWin32HandleInfoKHR}, Ptr{HANDLE}), device, pGetWin32HandleInfo, pHandle)
+end
+
+function vkGetSemaphoreWin32HandleKHR(device, pGetWin32HandleInfo, pHandle, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkSemaphoreGetWin32HandleInfoKHR}, Ptr{HANDLE}), device, pGetWin32HandleInfo, pHandle)
 end
 
 struct VkImportFenceWin32HandleInfoKHR
@@ -11754,8 +13494,16 @@ function vkImportFenceWin32HandleKHR(device, pImportFenceWin32HandleInfo)
     ccall((:vkImportFenceWin32HandleKHR, libvulkan), VkResult, (VkDevice, Ptr{VkImportFenceWin32HandleInfoKHR}), device, pImportFenceWin32HandleInfo)
 end
 
+function vkImportFenceWin32HandleKHR(device, pImportFenceWin32HandleInfo, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkImportFenceWin32HandleInfoKHR}), device, pImportFenceWin32HandleInfo)
+end
+
 function vkGetFenceWin32HandleKHR(device, pGetWin32HandleInfo, pHandle)
     ccall((:vkGetFenceWin32HandleKHR, libvulkan), VkResult, (VkDevice, Ptr{VkFenceGetWin32HandleInfoKHR}, Ptr{HANDLE}), device, pGetWin32HandleInfo, pHandle)
+end
+
+function vkGetFenceWin32HandleKHR(device, pGetWin32HandleInfo, pHandle, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkFenceGetWin32HandleInfoKHR}, Ptr{HANDLE}), device, pGetWin32HandleInfo, pHandle)
 end
 
 struct VkImportMemoryWin32HandleInfoNV
@@ -11777,6 +13525,10 @@ const PFN_vkGetMemoryWin32HandleNV = Ptr{Cvoid}
 
 function vkGetMemoryWin32HandleNV(device, memory, handleType, pHandle)
     ccall((:vkGetMemoryWin32HandleNV, libvulkan), VkResult, (VkDevice, VkDeviceMemory, VkExternalMemoryHandleTypeFlagsNV, Ptr{HANDLE}), device, memory, handleType, pHandle)
+end
+
+function vkGetMemoryWin32HandleNV(device, memory, handleType, pHandle, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkDeviceMemory, VkExternalMemoryHandleTypeFlagsNV, Ptr{HANDLE}), device, memory, handleType, pHandle)
 end
 
 struct VkWin32KeyedMutexAcquireReleaseInfoNV
@@ -11833,16 +13585,32 @@ function vkGetPhysicalDeviceSurfacePresentModes2EXT(physicalDevice, pSurfaceInfo
     ccall((:vkGetPhysicalDeviceSurfacePresentModes2EXT, libvulkan), VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, pSurfaceInfo, pPresentModeCount, pPresentModes)
 end
 
+function vkGetPhysicalDeviceSurfacePresentModes2EXT(physicalDevice, pSurfaceInfo, pPresentModeCount, pPresentModes, fptr)
+    ccall(fptr, VkResult, (VkPhysicalDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{UInt32}, Ptr{VkPresentModeKHR}), physicalDevice, pSurfaceInfo, pPresentModeCount, pPresentModes)
+end
+
 function vkAcquireFullScreenExclusiveModeEXT(device, swapchain)
     ccall((:vkAcquireFullScreenExclusiveModeEXT, libvulkan), VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
+end
+
+function vkAcquireFullScreenExclusiveModeEXT(device, swapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
 end
 
 function vkReleaseFullScreenExclusiveModeEXT(device, swapchain)
     ccall((:vkReleaseFullScreenExclusiveModeEXT, libvulkan), VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
 end
 
+function vkReleaseFullScreenExclusiveModeEXT(device, swapchain, fptr)
+    ccall(fptr, VkResult, (VkDevice, VkSwapchainKHR), device, swapchain)
+end
+
 function vkGetDeviceGroupSurfacePresentModes2EXT(device, pSurfaceInfo, pModes)
     ccall((:vkGetDeviceGroupSurfacePresentModes2EXT, libvulkan), VkResult, (VkDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, pSurfaceInfo, pModes)
+end
+
+function vkGetDeviceGroupSurfacePresentModes2EXT(device, pSurfaceInfo, pModes, fptr)
+    ccall(fptr, VkResult, (VkDevice, Ptr{VkPhysicalDeviceSurfaceInfo2KHR}, Ptr{VkDeviceGroupPresentModeFlagsKHR}), device, pSurfaceInfo, pModes)
 end
 
 const VULKAN_H_ = 1

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -3222,24 +3222,16 @@ end
 
 const __U_VkClearColorValue = Union{NTuple{4, Cfloat}, NTuple{4, Int32}, NTuple{4, UInt32}}
 
-function VkClearColorValue(float32::NTuple{4, Cfloat})
+function VkClearColorValue(val::__U_VkClearColorValue)
     ref = Ref{VkClearColorValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkClearColorValue(int32::NTuple{4, Int32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkClearColorValue(uint32::NTuple{4, UInt32})
-    ref = Ref{VkClearColorValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearColorValue}, ref)
-    ptr.uint32 = uint32
+    if val isa NTuple{4, Cfloat}
+        ptr.float32 = val
+    elseif val isa NTuple{4, Int32}
+        ptr.int32 = val
+    elseif val isa NTuple{4, UInt32}
+        ptr.uint32 = val
+    end
     ref[]
 end
 
@@ -3271,17 +3263,14 @@ end
 
 const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}
 
-function VkClearValue(color::VkClearColorValue)
+function VkClearValue(val::__U_VkClearValue)
     ref = Ref{VkClearValue}()
     ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.color = color
-    ref[]
-end
-
-function VkClearValue(depthStencil::VkClearDepthStencilValue)
-    ref = Ref{VkClearValue}()
-    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
-    ptr.depthStencil = depthStencil
+    if val isa VkClearColorValue
+        ptr.color = val
+    elseif val isa VkClearDepthStencilValue
+        ptr.depthStencil = val
+    end
     ref[]
 end
 
@@ -7840,45 +7829,22 @@ end
 
 const __U_VkPerformanceCounterResultKHR = Union{Int32, Int64, UInt32, UInt64, Cfloat, Cdouble}
 
-function VkPerformanceCounterResultKHR(int32::Int32)
+function VkPerformanceCounterResultKHR(val::__U_VkPerformanceCounterResultKHR)
     ref = Ref{VkPerformanceCounterResultKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int32 = int32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(int64::Int64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.int64 = int64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint32::UInt32)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint32 = uint32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(uint64::UInt64)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.uint64 = uint64
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float32::Cfloat)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float32 = float32
-    ref[]
-end
-
-function VkPerformanceCounterResultKHR(float64::Cdouble)
-    ref = Ref{VkPerformanceCounterResultKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceCounterResultKHR}, ref)
-    ptr.float64 = float64
+    if val isa Int32
+        ptr.int32 = val
+    elseif val isa Int64
+        ptr.int64 = val
+    elseif val isa UInt32
+        ptr.uint32 = val
+    elseif val isa UInt64
+        ptr.uint64 = val
+    elseif val isa Cfloat
+        ptr.float32 = val
+    elseif val isa Cdouble
+        ptr.float64 = val
+    end
     ref[]
 end
 
@@ -8575,31 +8541,18 @@ end
 
 const __U_VkPipelineExecutableStatisticValueKHR = Union{VkBool32, Int64, UInt64, Cdouble}
 
-function VkPipelineExecutableStatisticValueKHR(b32::VkBool32)
+function VkPipelineExecutableStatisticValueKHR(val::__U_VkPipelineExecutableStatisticValueKHR)
     ref = Ref{VkPipelineExecutableStatisticValueKHR}()
     ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.b32 = b32
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(i64::Int64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.i64 = i64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(u64::UInt64)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.u64 = u64
-    ref[]
-end
-
-function VkPipelineExecutableStatisticValueKHR(f64::Cdouble)
-    ref = Ref{VkPipelineExecutableStatisticValueKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkPipelineExecutableStatisticValueKHR}, ref)
-    ptr.f64 = f64
+    if val isa VkBool32
+        ptr.b32 = val
+    elseif val isa Int64
+        ptr.i64 = val
+    elseif val isa UInt64
+        ptr.u64 = val
+    elseif val isa Cdouble
+        ptr.f64 = val
+    end
     ref[]
 end
 
@@ -11433,38 +11386,20 @@ end
 
 const __U_VkPerformanceValueDataINTEL = Union{UInt32, UInt64, Cfloat, VkBool32, Ptr{Cchar}}
 
-function VkPerformanceValueDataINTEL(value32::UInt32)
+function VkPerformanceValueDataINTEL(val::__U_VkPerformanceValueDataINTEL)
     ref = Ref{VkPerformanceValueDataINTEL}()
     ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value32 = value32
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(value64::UInt64)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.value64 = value64
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueFloat::Cfloat)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueFloat = valueFloat
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueBool::VkBool32)
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueBool = valueBool
-    ref[]
-end
-
-function VkPerformanceValueDataINTEL(valueString::Ptr{Cchar})
-    ref = Ref{VkPerformanceValueDataINTEL}()
-    ptr = Base.unsafe_convert(Ptr{VkPerformanceValueDataINTEL}, ref)
-    ptr.valueString = valueString
+    if val isa UInt32
+        ptr.value32 = val
+    elseif val isa UInt64
+        ptr.value64 = val
+    elseif val isa Cfloat
+        ptr.valueFloat = val
+    elseif val isa VkBool32
+        ptr.valueBool = val
+    elseif val isa Ptr{Cchar}
+        ptr.valueString = val
+    end
     ref[]
 end
 
@@ -12963,17 +12898,14 @@ end
 
 const __U_VkDeviceOrHostAddressKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressKHR(val::__U_VkDeviceOrHostAddressKHR)
     ref = Ref{VkDeviceOrHostAddressKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -13000,17 +12932,14 @@ end
 
 const __U_VkDeviceOrHostAddressConstKHR = Union{VkDeviceAddress, Ptr{Cvoid}}
 
-function VkDeviceOrHostAddressConstKHR(deviceAddress::VkDeviceAddress)
+function VkDeviceOrHostAddressConstKHR(val::__U_VkDeviceOrHostAddressConstKHR)
     ref = Ref{VkDeviceOrHostAddressConstKHR}()
     ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.deviceAddress = deviceAddress
-    ref[]
-end
-
-function VkDeviceOrHostAddressConstKHR(hostAddress::Ptr{Cvoid})
-    ref = Ref{VkDeviceOrHostAddressConstKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkDeviceOrHostAddressConstKHR}, ref)
-    ptr.hostAddress = hostAddress
+    if val isa VkDeviceAddress
+        ptr.deviceAddress = val
+    elseif val isa Ptr{Cvoid}
+        ptr.hostAddress = val
+    end
     ref[]
 end
 
@@ -13071,24 +13000,16 @@ end
 
 const __U_VkAccelerationStructureGeometryDataKHR = Union{VkAccelerationStructureGeometryTrianglesDataKHR, VkAccelerationStructureGeometryAabbsDataKHR, VkAccelerationStructureGeometryInstancesDataKHR}
 
-function VkAccelerationStructureGeometryDataKHR(triangles::VkAccelerationStructureGeometryTrianglesDataKHR)
+function VkAccelerationStructureGeometryDataKHR(val::__U_VkAccelerationStructureGeometryDataKHR)
     ref = Ref{VkAccelerationStructureGeometryDataKHR}()
     ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.triangles = triangles
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(aabbs::VkAccelerationStructureGeometryAabbsDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.aabbs = aabbs
-    ref[]
-end
-
-function VkAccelerationStructureGeometryDataKHR(instances::VkAccelerationStructureGeometryInstancesDataKHR)
-    ref = Ref{VkAccelerationStructureGeometryDataKHR}()
-    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureGeometryDataKHR}, ref)
-    ptr.instances = instances
+    if val isa VkAccelerationStructureGeometryTrianglesDataKHR
+        ptr.triangles = val
+    elseif val isa VkAccelerationStructureGeometryAabbsDataKHR
+        ptr.aabbs = val
+    elseif val isa VkAccelerationStructureGeometryInstancesDataKHR
+        ptr.instances = val
+    end
     ref[]
 end
 


### PR DESCRIPTION
Regenerate wrapper with the new Clang.jl options `add_fptr_methods` and `add_record_constructors`.